### PR TITLE
ci(license-check): removes extra quote symbol

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,6 +32,6 @@ jobs:
       - name: install build dependencies
         run: npm --prefix ./dist/canopy install
       - name: license check build dependencies
-        run: npm run license-check:build'
+        run: npm run license-check:build
       - name: build:test-app
         run: npm run build:test-app


### PR DESCRIPTION
# Description

Removes the extra comma from the actions file which was causing the license check stage of the build to pass.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
