### PR TITLE
fix(breadcrumb): prevent expression changed errors

### DIFF
--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component.ts
@@ -4,6 +4,7 @@ import {
   HostBinding,
   Renderer2,
   ViewEncapsulation,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 
 import { BreadcrumbVariant } from '../breadcrumb-item/breadcrumb-item.interface';
@@ -13,6 +14,7 @@ import { BreadcrumbVariant } from '../breadcrumb-item/breadcrumb-item.interface'
   templateUrl: './breadcrumb-item-ellipsis.component.html',
   styleUrls: ['./breadcrumb-item-ellipsis.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LgBreadcrumbItemEllipsisComponent {
   @HostBinding('class.lg-breadcrumb-item-ellipsis') class = true;

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
@@ -1,18 +1,25 @@
-<span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showBackChevron">
-  <lg-icon
-    [name]="'caret-left'"
-    class="lg-breadcrumb-item__icon lg-breadcrumb-item__icon-backward"
-  ></lg-icon>
-</span>
+<div
+  class="lg-breadcrumb-item__container"
+  [ngClass]="{
+    'lg-breadcrumb-item__container--visible-sm': isSmScreenFeaturedItem
+  }"
+>
+  <span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showBackChevron">
+    <lg-icon
+      [name]="'caret-left'"
+      class="lg-breadcrumb-item__icon lg-breadcrumb-item__icon-backward"
+    ></lg-icon>
+  </span>
 
-<span class="lg-breadcrumb-item__content">
-  <span class="lg-visually-hidden">{{ index + 1 }}.</span>
-  <ng-content></ng-content>
-</span>
+  <span class="lg-breadcrumb-item__content">
+    <span class="lg-visually-hidden">{{ index + 1 }}.</span>
+    <ng-content></ng-content>
+  </span>
 
-<span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showForwardChevron">
-  <lg-icon
-    [name]="'caret-right'"
-    class="lg-breadcrumb-item__icon lg-breadcrumb-item__icon-forward"
-  ></lg-icon>
-</span>
+  <span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showForwardChevron">
+    <lg-icon
+      [name]="'caret-right'"
+      class="lg-breadcrumb-item__icon lg-breadcrumb-item__icon-forward"
+    ></lg-icon>
+  </span>
+</div>

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
@@ -1,12 +1,19 @@
 @import '../../../styles/mixins';
 
 .lg-breadcrumb-item {
-  display: none;
   align-items: center;
-  margin-right: var(--space-xxs);
 
-  @include lg-breakpoint('md') {
-    display: flex;
+  &__container {
+    display: none;
+    margin-right: var(--space-xxs);
+
+    @include lg-breakpoint('md') {
+      display: flex;
+    }
+
+    &--visible-sm {
+      display: flex;
+    }
   }
 
   .lg-icon {
@@ -19,10 +26,6 @@
     .lg-icon {
       margin-right: var(--space-xxs);
     }
-  }
-
-  &--sm-screen-visible-item {
-    display: flex;
   }
 
   &--hide-icons {

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
@@ -1,5 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
 import { MockComponent } from 'ng-mocks';
 
@@ -77,9 +78,12 @@ describe('LgBreadcrumbItemComponent', () => {
       fixture.detectChanges();
     });
 
-    it(`the class should contain 'lg-breadcrumb-item--sm-screen-visible-item'`, () => {
-      expect(breadcrumbItemEl.getAttribute('class')).toContain(
-        'lg-breadcrumb-item--sm-screen-visible-item',
+    it(`the class should contain small screen visibility class`, () => {
+      const containerEL = fixture.debugElement.query(
+        By.css('.lg-breadcrumb-item__container'),
+      );
+      expect(containerEL.nativeElement.getAttribute('class')).toContain(
+        'lg-breadcrumb-item__container--visible-sm',
       );
     });
   });

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
@@ -4,6 +4,8 @@ import {
   HostBinding,
   Renderer2,
   ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
 } from '@angular/core';
 
 import * as iconSet from '../../icon/icons.interface';
@@ -14,14 +16,10 @@ import { BreadcrumbVariant } from './breadcrumb-item.interface';
   templateUrl: './breadcrumb-item.component.html',
   styleUrls: ['./breadcrumb-item.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LgBreadcrumbItemComponent {
   @HostBinding('class.lg-breadcrumb-item') class = true;
-
-  @HostBinding('class.lg-breadcrumb-item--sm-screen-visible-item')
-  get smScreenFeaturedItemControl() {
-    return this.isSmScreenFeaturedItem;
-  }
 
   @HostBinding('class.lg-breadcrumb-item--hide-icons')
   get iconControl() {
@@ -34,11 +32,15 @@ export class LgBreadcrumbItemComponent {
 
   index: number;
 
-  isSmScreenFeaturedItem = false;
+  set isSmScreenFeaturedItem(isSmScreenFeaturedItem: boolean) {
+    this._isSmScreenFeaturedItem = isSmScreenFeaturedItem;
 
-  showBackChevron = false;
+    this.cd.detectChanges();
+  }
 
-  showForwardChevron = false;
+  get isSmScreenFeaturedItem() {
+    return this._isSmScreenFeaturedItem;
+  }
 
   set variant(variant: BreadcrumbVariant) {
     if (this._variant) {
@@ -58,7 +60,37 @@ export class LgBreadcrumbItemComponent {
     return this._variant;
   }
 
+  set showBackChevron(showBackChevron: boolean) {
+    this._showBackChevron = showBackChevron;
+
+    this.cd.detectChanges();
+  }
+
+  get showBackChevron() {
+    return this._showBackChevron;
+  }
+
+  set showForwardChevron(showForwardChevron: boolean) {
+    this._showForwardChevron = showForwardChevron;
+
+    this.cd.detectChanges();
+  }
+
+  get showForwardChevron() {
+    return this._showForwardChevron;
+  }
+
   private _variant: BreadcrumbVariant;
 
-  constructor(private renderer: Renderer2, private hostElement: ElementRef) {}
+  private _showBackChevron = false;
+
+  private _showForwardChevron = false;
+
+  private _isSmScreenFeaturedItem = false;
+
+  constructor(
+    private renderer: Renderer2,
+    private hostElement: ElementRef,
+    private cd: ChangeDetectorRef,
+  ) {}
 }

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterContentInit,
   Component,
   ContentChildren,
   forwardRef,
@@ -7,6 +6,8 @@ import {
   Input,
   QueryList,
   ViewEncapsulation,
+  AfterContentChecked,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 
 import { LgBreadcrumbItemEllipsisComponent } from './breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component';
@@ -18,22 +19,29 @@ import { BreadcrumbVariant } from './breadcrumb-item/breadcrumb-item.interface';
   templateUrl: './breadcrumb.component.html',
   styleUrls: ['./breadcrumb.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgBreadcrumbComponent implements AfterContentInit {
+export class LgBreadcrumbComponent implements AfterContentChecked {
   @HostBinding('class.lg-breadcrumb') class = true;
 
   @HostBinding('attr.aria-label') attr = 'breadcrumb';
 
   @HostBinding('attr.role') role = 'navigation';
 
-  @ContentChildren(forwardRef(() => LgBreadcrumbItemComponent), {
-    descendants: true,
-  })
+  @ContentChildren(
+    forwardRef(() => LgBreadcrumbItemComponent),
+    {
+      descendants: true,
+    },
+  )
   crumbs: QueryList<LgBreadcrumbItemComponent>;
 
-  @ContentChildren(forwardRef(() => LgBreadcrumbItemEllipsisComponent), {
-    descendants: true,
-  })
+  @ContentChildren(
+    forwardRef(() => LgBreadcrumbItemEllipsisComponent),
+    {
+      descendants: true,
+    },
+  )
   ellipsis: QueryList<LgBreadcrumbItemEllipsisComponent>;
 
   @Input() set variant(variant: BreadcrumbVariant) {
@@ -52,7 +60,7 @@ export class LgBreadcrumbComponent implements AfterContentInit {
 
   private contentHasInit = false;
 
-  ngAfterContentInit() {
+  ngAfterContentChecked() {
     this.setVariantOnChildren();
     this.setCrumbProperties();
 

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
@@ -60,21 +60,31 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
 |------|-------------|
 | \`\`lg-breadcrumb\`\` | Adds the default styles to the breadcrumbs
 | \`\`lg-breadcrumb-item\`\` | Adds the default styles to the breadcrumb items
+| \`\`lg-breadcrumb-item__container\`\` | Adds the default styles to the breadcrumb items container
+| \`\`lg-breadcrumb-item__container--visible-sm\`\` | Adds the default styles to set a breadcrumb item to be visible on small screens
+| \`\`lg-breadcrumb-item__icon-wrapper\`\` | Adds the default styles to set a breadcrumb item icon wrapper
+| \`\`lg-breadcrumb-item__icon\`\` | Adds the default styles to set a breadcrumb item icon
+| \`\`lg-breadcrumb-item__icon-backward\`\` | Adds the default styles to set a breadcrumb item backward icon
+| \`\`lg-breadcrumb-item__icon-forward\`\` | Adds the default styles to set a breadcrumb item forward icon
 
 ### Examples:
 ~~~html
 <div class="lg-breadcrumb" aria-label="breadcrumb" role="navigation">
   <div class="lg-breadcrumb-item--dark lg-breadcrumb-item">
-    <span class="lg-breadcrumb-item__content">
-      <span class="lg-visually-hidden">1.</span>
-      <a href="#" aria-current="page">Home</a>
-    </span>
+    <div class="lg-breadcrumb-item__container lg-breadcrumb-item__container--visible-sm">
+      <span class="lg-breadcrumb-item__content">
+        <span class="lg-visually-hidden">1.</span>
+        <a href="#" aria-current="page">Home</a>
+      </span>
+    </div>
   </div>
     <div class="lg-breadcrumb-item--dark lg-breadcrumb-item">
-      <span class="lg-breadcrumb-item__content">
-        <span class="lg-visually-hidden">2.</span>
-        <a href="#" aria-current="page">Product</a>
-      </span>
+      <div class="lg-breadcrumb-item__container">
+        <span class="lg-breadcrumb-item__content">
+          <span class="lg-visually-hidden">2.</span>
+          <a href="#" aria-current="page">Product</a>
+        </span>
+      </div>
   </div>
 </div>
 ~~~

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
@@ -1,3 +1,5 @@
+import { Component, OnInit, Input } from '@angular/core';
+
 import { select, withKnobs } from '@storybook/addon-knobs';
 import { moduleMetadata } from '@storybook/angular';
 
@@ -6,12 +8,55 @@ import { BreadcrumbVariant } from './breadcrumb-item/breadcrumb-item.interface';
 import { LgBreadcrumbModule } from './breadcrumb.module';
 import { notes } from './breadcrumb.notes';
 
+interface Breadcrumb {
+  text: string;
+}
+
+@Component({
+  selector: 'async-breadcrumb-story',
+  template: `
+    <lg-breadcrumb [variant]="variant">
+      <lg-breadcrumb-item *ngFor="let crumb of crumbs; index as i">
+        <a href="#" [attr.aria-current]="isCurrentAttribute(i)">
+          <lg-icon *ngIf="!i" [name]="'home'"></lg-icon>
+          {{ crumb.text }}
+        </a>
+      </lg-breadcrumb-item>
+    </lg-breadcrumb>
+  `,
+})
+export class AsyncBreadcrumbStoryComponent implements OnInit {
+  @Input() variant: BreadcrumbVariant;
+
+  crumbs: Array<Breadcrumb> = [];
+
+  currentPageIndex = this.crumbs.length - 1;
+
+  isCurrentAttribute(index: number) {
+    return this.currentPageIndex === index ? 'page' : null;
+  }
+
+  ngOnInit() {
+    const mockAsyncDelay = 500;
+
+    setTimeout(() => {
+      this.crumbs = [
+        { text: 'Home' },
+        { text: 'Home Insurance' },
+        { text: 'Change direct debit' },
+      ];
+    }, mockAsyncDelay);
+  }
+}
+
 export default {
   title: 'Components/Breadcrumb',
+  excludeStories: ['AsyncBreadcrumbStoryComponent'],
   parameters: {
     decorators: [
       withKnobs,
       moduleMetadata({
+        declarations: [AsyncBreadcrumbStoryComponent],
         imports: [LgIconModule, LgBreadcrumbModule],
       }),
     ],
@@ -64,6 +109,17 @@ export const threeItems = () => ({
       </lg-breadcrumb-item>
     </lg-breadcrumb>
   `,
+  props: {
+    variant: select(
+      'Variant',
+      [BreadcrumbVariant.light, BreadcrumbVariant.dark],
+      BreadcrumbVariant.dark,
+    ),
+  },
+});
+
+export const asynchronousLoading = () => ({
+  template: `<async-breadcrumb-story [variant]="variant"></async-breadcrumb-story>`,
   props: {
     variant: select(
       'Variant',


### PR DESCRIPTION
# Description

Fix to prevent the 'ExpressionChangedAfterItHasBeenCheckedError' error from appearing when running in development mode. This includes abandoning the use of HostBinding to set the class for controlling which items which are visible on small devices. This follows the need to interrogate the breadcrumb items AfterContentChecked rather than on AfterContentInit to allow for changes to the breadcrumb data, for instance during the asynchronous fetching of data.

Fixes #8 

Requirements
Create a story using a breadcrumb generated by a ngFor loop with a setTimeout used to simulate an async operation

Storybook link: (once netlify has deployed link provide a link to the component)
# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
