### PR TITLE
fix(breadcrumb): hide icons expression changed

### DIFF
--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
@@ -1,7 +1,8 @@
 <div
   class="lg-breadcrumb-item__container"
   [ngClass]="{
-    'lg-breadcrumb-item__container--visible-sm': isSmScreenFeaturedItem
+    'lg-breadcrumb-item__container--visible-sm': isSmScreenFeaturedItem,
+    'lg-breadcrumb-item__container--hide-icons': hideIcons
   }"
 >
   <span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showBackChevron">

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
@@ -16,6 +16,16 @@
     }
   }
 
+  &__container--hide-icons {
+    .lg-breadcrumb-item__content .lg-icon {
+      display: none;
+
+      @include lg-breakpoint('md') {
+        display: inline;
+      }
+    }
+  }
+
   .lg-icon {
     @include lg-breakpoint('md') {
       display: inline;
@@ -25,16 +35,6 @@
   &__content {
     .lg-icon {
       margin-right: var(--space-xxs);
-    }
-  }
-
-  &--hide-icons {
-    .lg-breadcrumb-item__content .lg-icon {
-      display: none;
-
-      @include lg-breakpoint('md') {
-        display: inline;
-      }
     }
   }
 

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
@@ -94,9 +94,12 @@ describe('LgBreadcrumbItemComponent', () => {
       fixture.detectChanges();
     });
 
-    it(`the class should contain 'lg-breadcrumb-item--hide-icons'`, () => {
-      expect(breadcrumbItemEl.getAttribute('class')).toContain(
-        'lg-breadcrumb-item--hide-icons',
+    it('the class should contain hide-icons class', () => {
+      const containerEL = fixture.debugElement.query(
+        By.css('.lg-breadcrumb-item__container'),
+      );
+      expect(containerEL.nativeElement.getAttribute('class')).toContain(
+        'lg-breadcrumb-item__container--hide-icons',
       );
     });
   });

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
@@ -21,16 +21,19 @@ import { BreadcrumbVariant } from './breadcrumb-item.interface';
 export class LgBreadcrumbItemComponent {
   @HostBinding('class.lg-breadcrumb-item') class = true;
 
-  @HostBinding('class.lg-breadcrumb-item--hide-icons')
-  get iconControl() {
-    return this.hideIcons;
-  }
-
-  hideIcons = false;
-
   icons = iconSet;
 
   index: number;
+
+  set hideIcons(hideIcons: boolean) {
+    this._hideIcons = hideIcons;
+
+    this.cd.detectChanges();
+  }
+
+  get hideIcons() {
+    return this._hideIcons;
+  }
 
   set isSmScreenFeaturedItem(isSmScreenFeaturedItem: boolean) {
     this._isSmScreenFeaturedItem = isSmScreenFeaturedItem;
@@ -87,6 +90,8 @@ export class LgBreadcrumbItemComponent {
   private _showForwardChevron = false;
 
   private _isSmScreenFeaturedItem = false;
+
+  private _hideIcons = false;
 
   constructor(
     private renderer: Renderer2,

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
@@ -61,6 +61,7 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
 | \`\`lg-breadcrumb\`\` | Adds the default styles to the breadcrumbs
 | \`\`lg-breadcrumb-item\`\` | Adds the default styles to the breadcrumb items
 | \`\`lg-breadcrumb-item__container\`\` | Adds the default styles to the breadcrumb items container
+| \`\`lg-breadcrumb-item__container--hide-icons\`\` | Adds the default styles to hide icons (excluding forward and backward icons)
 | \`\`lg-breadcrumb-item__container--visible-sm\`\` | Adds the default styles to set a breadcrumb item to be visible on small screens
 | \`\`lg-breadcrumb-item__icon-wrapper\`\` | Adds the default styles to set a breadcrumb item icon wrapper
 | \`\`lg-breadcrumb-item__icon\`\` | Adds the default styles to set a breadcrumb item icon


### PR DESCRIPTION
# Description

Consuming apps are getting ExpressionChangedAfterItHasBeenCheck errors from dynamic HostBindings which sets the class. In hindsight we should have been consistent for this component and just removed all dynamic Hostbindings which set classes. Slightly unnerving is the inability for storybook to replicate the errors consuming applications are getting even with our Async story.

Fixes: Similar issue to #3 however this is not replicable in storybook but has been evident in consuming apps. The same approach has been taken though which is removing the dynamic HostBinding which triggers the ExpressionChangedAfterItHasBeenCheck errors. 

Storybook link: https://deploy-preview-9--legal-and-general-canopy.netlify.app/?path=/story/components-breadcrumb--asynchronous-loading

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
