### PR TITLE
Typography changes

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -22,10 +22,15 @@
   outline: var(--link-focus-outline) solid $bg-color;
 }
 
-@mixin lg-font-size($size) {
+@mixin lg-font-size($size, $modifier: null) {
   font-size: var(--text-fs-#{$size}-size);
   line-height: var(--text-fs-#{$size}-line-height);
-  font-weight: var(--text-fs-#{$size}-weight);
+
+  @if $modifier {
+    font-weight: var(--text-fs-#{$size}-weight--#{$modifier});
+  } @else {
+    font-weight: var(--text-fs-#{$size}-weight);
+  }
 }
 
 @mixin lg-visually-hidden {

--- a/projects/canopy/src/styles/typography.notes.ts
+++ b/projects/canopy/src/styles/typography.notes.ts
@@ -11,18 +11,35 @@ In addition to the native styling the following utility classes are exposed.
 
 ~~~html
 .lg-font-size-7
+.lg-font-size-7--strong
+
 .lg-font-size-6
+.lg-font-size-6--strong
+
 .lg-font-size-5
+.lg-font-size-5--strong
+
 .lg-font-size-4
+.lg-font-size-4--strong
+
 .lg-font-size-3
+.lg-font-size-3--strong
+
 .lg-font-size-2
+.lg-font-size-2--strong
+
 .lg-font-size-1
+.lg-font-size-1--strong
+
 .lg-font-size-0-8
+
 .lg-font-size-0-6
 ~~~
 
 \`.lg-font-size-1\` is the base font size that is used to style native elements like p and span, as the numbers increase so
-does the font size up to the largest \`.lg-font-size-7.\` There are two additional styles which are smaller \`.lg-font-size-0-8\`
+does the font size up to the largest \`.lg-font-size-7.\` Each of the primary font styles also have a \`--strong\` modifier.
+
+There are two additional styles which are smaller \`.lg-font-size-0-8\`
 and \`.lg-font-size-0-6\`. The utility classes are particularly useful for when you want to decouple the semantics and styling,
 for example making an h1 look like an h3.
 

--- a/projects/canopy/src/styles/typography.scss
+++ b/projects/canopy/src/styles/typography.scss
@@ -114,8 +114,16 @@ h6,
   @include lg-font-size('7');
 }
 
+.lg-font-size-7--strong {
+  @include lg-font-size('7', 'strong');
+}
+
 .lg-font-size-6 {
   @include lg-font-size('6');
+}
+
+.lg-font-size-6--strong {
+  @include lg-font-size('6', 'strong');
 }
 
 h1,
@@ -123,9 +131,17 @@ h1,
   @include lg-font-size('5');
 }
 
+.lg-font-size-5--strong {
+  @include lg-font-size('5', 'strong');
+}
+
 h2,
 .lg-font-size-4 {
   @include lg-font-size('4');
+}
+
+.lg-font-size-4--strong {
+  @include lg-font-size('4', 'strong');
 }
 
 h3,
@@ -133,14 +149,26 @@ h3,
   @include lg-font-size('3');
 }
 
+.lg-font-size-3--strong {
+  @include lg-font-size('3', 'strong');
+}
+
 h4,
 .lg-font-size-2 {
   @include lg-font-size('2');
 }
 
+.lg-font-size-2--strong {
+  @include lg-font-size('2', 'strong');
+}
+
 h5,
 .lg-font-size-1 {
   @include lg-font-size('1');
+}
+
+.lg-font-size-1--strong {
+  @include lg-font-size('1', 'strong');
 }
 
 h6,

--- a/projects/canopy/src/styles/typography.stories.ts
+++ b/projects/canopy/src/styles/typography.stories.ts
@@ -74,38 +74,48 @@ stories.add(
   'Page',
   () => ({
     template: `
-      <h1 class="h1">Albert Camus</h1>
+      <h1 class="h1">Accusantium doloremque laudantium</h1>
       <p>
-        The Plague is a famous allegorical novel by Albert Camus, who's known
-        for his existential works. The book was published in 1947 and is
-        considered one of the most important works by Camus.
+        Accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+        suscipit laboriosam. Accusantium doloremque laudantium, totam rem aperiam,
+        eaque ipsa quae ab illo.
       </p>
       <ul>
-        <li>A Happy Death (La Mort heureuse)</li>
-        <li>The Stranger (L'Étranger, often translated as The Outsider.)</li>
-        <li>The Plague (La Peste)</li>
-        <li>The Fall (La Chute)</li>
+        <li>Ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis.</li>
+        <li>Do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+        <li>Laboris nisi ut aliquip ex ea commodo consequat.</li>
       </ul>
+
+      <h2>Qui officia deserunt mollit anim id est laborum.</h2>
       <p>
-        The truth is that everyone is bored, and devotes himself to cultivating
-        habits. <b>Our citizens work hard</b>, but solely with the object of
-        getting rich. Their chief interest is commerce, and their chief aim in
-        life is, as they call it, 'doing business.
+        Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
+        adipisci velit. Et harum quidem rerum facilis est et expedita distinctio.
+        Animi, id est laborum et dolorum fuga. Itaque earum rerum hic tenetur a
+        sapiente delectus.
       </p>
+
       <p>
-        You must picture the consternation of our
-        <a href="https://en.wikipedia.org/wiki/Oran">little town</a> hitherto
-        so tranquil, and now, out of the blue, shaken to its core, like a quite
-        healthy man who all of a sudden feels his temperature shoot up and the
-        blood seething like wildfire in his veins.
+        Laboris nisi ut aliquip ex ea commodo consequat. Architecto beatae vitae
+        dicta sunt explicabo. Fugiat quo voluptas nulla pariatur? Cupiditate non
+        provident, similique sunt in culpa qui officia deserunt mollitia.
       </p>
+
+      <h3>Inventore veritatis</h3>
       <p>
-        <small>They fancied themselves free, and no one will ever be free so
-        long as there are pestilences.</small>
+        Facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.
+        <a href="https://en.wikipedia.org/wiki/Oran">Oran hitherto.</a> Excepteur
+        sint occaecat cupidatat non proident, sunt in culpa. Fugiat quo voluptas
+        nulla pariatur? Duis aute irure dolor in reprehenderit in voluptate velit.
       </p>
-      <p class="fs-0-6">
-        The Plague (French: La Peste) is a novel by Albert Camus, published in
-        1947
+
+      <h4>Inventore veritatis</h4>
+      <p class="lg-font-size-0-8">
+        Totam rem aperiam. Inventore veritatis et quasi architecto beatae
+        vitae dicta sunt explicabo.
+      </p>
+      <p class="lg-font-size-0-6">
+        Et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
       </p>
   `,
   }),

--- a/projects/canopy/src/styles/typography.stories.ts
+++ b/projects/canopy/src/styles/typography.stories.ts
@@ -14,23 +14,51 @@ stories.add(
     },
     template: `
     <p class="lg-font-size-7">{{lgFontSize7}}</p>
+    <p class="lg-font-size-7--strong">{{lgFontSize7Strong}}</p>
+
     <p class="lg-font-size-6">{{lgFontSize6}}</p>
+    <p class="lg-font-size-6--strong">{{lgFontSize6Strong}}</p>
+
     <p class="lg-font-size-5">{{lgFontSize5}}</p>
+    <p class="lg-font-size-5--strong">{{lgFontSize5Strong}}</p>
+
     <p class="lg-font-size-4">{{lgFontSize4}}</p>
+    <p class="lg-font-size-4--strong">{{lgFontSize4Strong}}</p>
+
     <p class="lg-font-size-3">{{lgFontSize3}}</p>
+    <p class="lg-font-size-3--strong">{{lgFontSize3Strong}}</p>
+
     <p class="lg-font-size-2">{{lgFontSize2}}</p>
+    <p class="lg-font-size-2--strong">{{lgFontSize2Strong}}</p>
+
     <p class="lg-font-size-1">{{lgFontSize1}}</p>
+    <p class="lg-font-size-1--strong">{{lgFontSize1Strong}}</p>
+
     <p class="lg-font-size-0-8">{{lgFontSize08}}</p>
     <p class="lg-font-size-0-6">{{lgFontSize06}}</p>
     `,
     props: {
       lgFontSize7: text('font size 7', '.lg-font-size-7'),
+      lgFontSize7Strong: text('font size 7 strong', '.lg-font-size-7--strong'),
+
       lgFontSize6: text('font size 6', '.lg-font-size-6'),
+      lgFontSize6Strong: text('font size 6 strong', '.lg-font-size-6--strong'),
+
       lgFontSize5: text('font size 5', '.lg-font-size-5'),
+      lgFontSize5Strong: text('font size 5 strong', '.lg-font-size-5--strong'),
+
       lgFontSize4: text('font size 4', '.lg-font-size-4'),
+      lgFontSize4Strong: text('font size 4 strong', '.lg-font-size-4--strong'),
+
       lgFontSize3: text('font size 3', '.lg-font-size-3'),
+      lgFontSize3Strong: text('font size 3 strong', '.lg-font-size-3--strong'),
+
       lgFontSize2: text('font size 2', '.lg-font-size-2'),
+      lgFontSize2Strong: text('font size 2 strong', '.lg-font-size-2--strong'),
+
       lgFontSize1: text('font size 1', '.lg-font-size-1'),
+      lgFontSize1Strong: text('font size 1 strong', '.lg-font-size-1--strong'),
+
       lgFontSize08: text('font size 08', '.lg-font-size-0-8'),
       lgFontSize06: text('font size 06', '.lg-font-size-0-6'),
     },

--- a/projects/canopy/src/styles/variables/_typography.scss
+++ b/projects/canopy/src/styles/variables/_typography.scss
@@ -27,12 +27,12 @@
     var(--text-base-size) - (var(--text-scale-ratio) * 3 / 4)
   ); // 13px
 
-  --text-fs-7-line-height: 1.1;
-  --text-fs-6-line-height: 1.1;
-  --text-fs-5-line-height: 1.1;
-  --text-fs-4-line-height: 1.1;
-  --text-fs-3-line-height: 1.2;
-  --text-fs-2-line-height: 1.3;
+  --text-fs-7-line-height: 1.4;
+  --text-fs-6-line-height: 1.4;
+  --text-fs-5-line-height: 1.4;
+  --text-fs-4-line-height: 1.4;
+  --text-fs-3-line-height: 1.4;
+  --text-fs-2-line-height: 1.4;
   --text-fs-1-line-height: 1.5;
   --text-fs--8-line-height: 1.7;
   --text-fs--6-line-height: 1.25;

--- a/projects/canopy/src/styles/variables/_typography.scss
+++ b/projects/canopy/src/styles/variables/_typography.scss
@@ -15,28 +15,14 @@
   --font-weight-bold: 500;
 
   /* font size variables */
-  --text-fs-7-size: calc(
-    var(--text-base-size) + (9 * var(--text-scale-ratio))
-  ); // 52px
-  --text-fs-6-size: calc(
-    var(--text-base-size) + (7 * var(--text-scale-ratio))
-  ); // 44px
-  --text-fs-5-size: calc(
-    var(--text-base-size) + (5 * var(--text-scale-ratio))
-  ); // 36px
-  --text-fs-4-size: calc(
-    var(--text-base-size) + (3 * var(--text-scale-ratio))
-  ); // 28px
-  --text-fs-3-size: calc(
-    var(--text-base-size) + (2 * var(--text-scale-ratio))
-  ); // 24px
-  --text-fs-2-size: calc(
-    var(--text-base-size) + var(--text-scale-ratio)
-  ); // 20px
+  --text-fs-7-size: calc(var(--text-base-size) + (9 * var(--text-scale-ratio))); // 52px
+  --text-fs-6-size: calc(var(--text-base-size) + (7 * var(--text-scale-ratio))); // 44px
+  --text-fs-5-size: calc(var(--text-base-size) + (5 * var(--text-scale-ratio))); // 36px
+  --text-fs-4-size: calc(var(--text-base-size) + (3 * var(--text-scale-ratio))); // 28px
+  --text-fs-3-size: calc(var(--text-base-size) + (2 * var(--text-scale-ratio))); // 24px
+  --text-fs-2-size: calc(var(--text-base-size) + var(--text-scale-ratio)); // 20px
   --text-fs-1-size: var(--text-base-size); // 16px
-  --text-fs--8-size: calc(
-    var(--text-base-size) - (var(--text-scale-ratio) / 2)
-  ); // 14px
+  --text-fs--8-size: calc(var(--text-base-size) - (var(--text-scale-ratio) / 2)); // 14px
   --text-fs--6-size: calc(
     var(--text-base-size) - (var(--text-scale-ratio) * 3 / 4)
   ); // 13px
@@ -52,27 +38,36 @@
   --text-fs--6-line-height: 1.25;
 
   --text-fs-7-weight: var(--font-weight-light);
+  --text-fs-7-weight--strong: var(--font-weight-regular);
+
   --text-fs-6-weight: var(--font-weight-light);
+  --text-fs-6-weight--strong: var(--font-weight-regular);
+
   --text-fs-5-weight: var(--font-weight-light);
+  --text-fs-5-weight--strong: var(--font-weight-regular);
+
   --text-fs-4-weight: var(--font-weight-light);
+  --text-fs-4-weight--strong: var(--font-weight-regular);
+
   --text-fs-3-weight: var(--font-weight-light);
-  --text-fs-2-weight: var(--font-weight-regular);
+  --text-fs-3-weight--strong: var(--font-weight-regular);
+
+  --text-fs-2-weight: var(--font-weight-light);
+  --text-fs-2-weight--strong: var(--font-weight-regular);
+
   --text-fs-1-weight: var(--font-weight-regular);
+  --text-fs-1-weight--strong: var(--font-weight-bold);
+
   --text-fs--8-weight: var(--font-weight-regular);
+  --text-fs--8-weight--strong: var(--font-weight-bold);
+
   --text-fs--6-weight: var(--font-weight-regular);
+  --text-fs--6-weight--strong: var(--font-weight-bold);
 
   @include lg-breakpoint('md') {
-    --text-fs-7-size: calc(
-      var(--text-base-size) + (10 * var(--text-scale-ratio))
-    );
-    --text-fs-6-size: calc(
-      var(--text-base-size) + (8 * var(--text-scale-ratio))
-    );
-    --text-fs-5-size: calc(
-      var(--text-base-size) + (6 * var(--text-scale-ratio))
-    );
-    --text-fs-4-size: calc(
-      var(--text-base-size) + (4 * var(--text-scale-ratio))
-    );
+    --text-fs-7-size: calc(var(--text-base-size) + (10 * var(--text-scale-ratio)));
+    --text-fs-6-size: calc(var(--text-base-size) + (8 * var(--text-scale-ratio)));
+    --text-fs-5-size: calc(var(--text-base-size) + (6 * var(--text-scale-ratio)));
+    --text-fs-4-size: calc(var(--text-base-size) + (4 * var(--text-scale-ratio)));
   }
 }


### PR DESCRIPTION
# Description

Font style classes now have the addition of a `--strong` modifier. Not currently used in any components but added to allow more flexible typography within applications.

Minor line height modifications to match designs.

Co-authored with @alexcanning.


## Requirements

Storybook link: (once netlify has deployed link provide a link to the component)

![Screenshot 2020-10-02 at 16 26 18](https://user-images.githubusercontent.com/2196085/94941529-e662b480-04cc-11eb-9cb4-fa912e887508.png)

![Screenshot 2020-10-02 at 16 26 30](https://user-images.githubusercontent.com/2196085/94941541-eb276880-04cc-11eb-90f8-885b407b45bd.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
