### PR TITLE
fix(quick-link): fixed visited link colour

### DIFF
--- a/projects/canopy/src/lib/quick-action/quick-action.stories.ts
+++ b/projects/canopy/src/lib/quick-action/quick-action.stories.ts
@@ -78,9 +78,14 @@ export const link = () => ({
   `,
   props: {
     content: text('text', 'Send us a message', groupId),
-    link: text('link', '/mailbox', groupId),
+    link: text('link', 'https://google.com', groupId),
     target: select('target', ['_blank', '_self'], '_blank', groupId),
-    icon: select('icon', iconsArray.map(icon => icon.name), 'secure-messaging', groupId),
+    icon: select(
+      'icon',
+      iconsArray.map(icon => icon.name),
+      'secure-messaging',
+      groupId,
+    ),
   },
 });
 
@@ -93,6 +98,11 @@ export const button = () => ({
   `,
   props: {
     content: text('text', 'Load more', groupId),
-    icon: select('icon', iconsArray.map(icon => icon.name), 'repeat', groupId),
+    icon: select(
+      'icon',
+      iconsArray.map(icon => icon.name),
+      'repeat',
+      groupId,
+    ),
   },
 });

--- a/projects/canopy/src/styles/variables/components/_quick-action.scss
+++ b/projects/canopy/src/styles/variables/components/_quick-action.scss
@@ -4,7 +4,7 @@
   --quick-action-hover-color: var(--color-white);
   --quick-action-active-bg-color: var(--color-super-blue-dark);
   --quick-action-active-color: var(--color-white);
-  --quick-action-visited-color: var(--link-visited-color);
+  --quick-action-visited-color: var(--link-color);
   --quick-action-visited-hover-bg-color: var(--color-super-blue-dark);
   --quick-action-visited-hover-color: var(--color-white);
 }


### PR DESCRIPTION
A quick actions visited link colour should match its unvisited colour

This is the same fix as https://github.com/canopy-collective/canopy/pull/403

