### PR TITLE
docs(margin): add missing docs for margin directives

### DIFF
--- a/projects/canopy/src/lib/spacing/margin/margin.notes.ts
+++ b/projects/canopy/src/lib/spacing/margin/margin.notes.ts
@@ -42,6 +42,22 @@ e.g. Apply an xl margin all round, but xxxl margin to the bottom
 </lg-card>
 ~~~
 
+e.g. Apply an lg margin to both the left and the right
+
+~~~html
+<lg-card lgMarginHorizontal="lg">
+  Your content
+</lg-card>
+~~~
+
+e.g. Apply an lg margin to both the top and the bottom
+
+~~~html
+<lg-card lgMarginVertical="lg">
+  Your content
+</lg-card>
+~~~
+
 ## Inputs
 
 The current available variants are 'none', xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'.
@@ -53,6 +69,8 @@ The current available variants are 'none', xxxs', 'xxs', 'xs', 'sm', 'md', 'lg',
 | \`\`lgMarginRight\`\` | The margin variant applied to the right | string | null | No |
 | \`\`lgMarginBottom\`\` | The margin variant applied to the bottom | string | null | No |
 | \`\`lgMarginLeft\`\` | The margin variant applied to the left | string | null | No |
+| \`\`lgMarginHorizontal\`\` | The margin variant applied to the left and the right | string | null | No |
+| \`\`lgMarginVertical\`\` | The margin variant applied to the top and the bottom | string | null | No |
 
 
 ## Using only the SCSS files


### PR DESCRIPTION
Adds missing docs for the missing horizontal and vertical margin directives

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
