### PR TITLE
docs(padding): adds missing directives to docs

### DIFF
--- a/projects/canopy/src/lib/spacing/padding/padding.notes.ts
+++ b/projects/canopy/src/lib/spacing/padding/padding.notes.ts
@@ -29,7 +29,7 @@ e.g. Apply an xxl padding to the bottom
 e.g. Apply an sm padding to the left and right
 
 ~~~html
-<lg-card lgPaddingLeft="sm" lgPaddingRight="sm">
+<lg-card lgPaddingHorizontal="sm">
   Your content
 </lg-card>
 ~~~
@@ -38,6 +38,14 @@ e.g. Apply an xl padding all round, but xxxl padding to the bottom
 
 ~~~html
 <lg-card lgPadding="xl" lgPaddingBottom="xxxl">
+  Your content
+</lg-card>
+~~~
+
+e.g. Apply an lg padding to the top and bottom
+
+~~~html
+<lg-card lgPaddingVertical="lg">
   Your content
 </lg-card>
 ~~~
@@ -53,6 +61,8 @@ The current available variants are 'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg'
 | \`\`lgPaddingRight\`\` | The padding variant applied to the right | string | null | No |
 | \`\`lgPaddingBottom\`\` | The padding variant applied to the bottom | string | null | No |
 | \`\`lgPaddingLeft\`\` | The padding variant applied to the left | string | null | No |
+| \`\`lgPaddingHorizontal\`\` | The padding variant applied to the left and the right | string | null | No |
+| \`\`lgPaddingVertical\`\` | The padding variant applied to the top and the bottom | string | null | No |
 
 
 ## Using only the SCSS files


### PR DESCRIPTION
Adds missing horizontal and vertical padding directives to docs

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
