### PR TITLE
fix(input): match height with designs

### DIFF
--- a/projects/canopy/src/lib/forms/input/input.scss
+++ b/projects/canopy/src/lib/forms/input/input.scss
@@ -4,8 +4,8 @@
   display: block;
   border: solid var(--border-width) var(--border-color);
   border-radius: var(--border-radius-sm);
-  line-height: var(--line-height-sm);
-  padding: var(--space-xs) var(--space-sm);
+  line-height: var(--input-line-height);
+  padding: var(--input-vertical-padding) var(--space-sm);
   outline: 0;
   max-width: 100%;
 
@@ -22,9 +22,7 @@
   &:focus {
     border-left-width: var(--keyline-width);
     border-color: var(--border-focus-color);
-    padding-left: calc(
-      var(--space-sm) - var(--keyline-width) + var(--border-width)
-    );
+    padding-left: calc(var(--space-sm) - var(--keyline-width) + var(--border-width));
 
     @include lg-outer-focus-outline();
   }

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -1,15 +1,11 @@
 @import '../../../styles/mixins';
 
-:root {
-  --select-icon-width: 0.875rem;
-}
-
 .lg-select {
   border: solid var(--border-width) var(--border-color);
   border-radius: var(--border-radius-sm);
-  padding: calc(var(--space-xs) - var(--border-width))
-    calc(var(--select-icon-width) + (2 * var(--space-sm)))
-    calc(var(--space-xs) - var(--border-width)) var(--space-sm);
+  padding: var(--select-vertical-padding)
+    calc(var(--select-icon-width) + (2 * var(--space-sm))) var(--select-vertical-padding)
+    var(--space-sm);
   line-height: var(--line-height-sm);
   background-color: var(--color-white);
   outline: 0;
@@ -23,9 +19,7 @@
   &:focus {
     border-left-width: var(--keyline-width);
     border-color: var(--border-focus-color);
-    padding-left: calc(
-      var(--space-sm) - var(--keyline-width) + var(--border-width)
-    );
+    padding-left: calc(var(--space-sm) - var(--keyline-width) + var(--border-width));
     @include lg-outer-focus-outline();
   }
 

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -10,9 +10,11 @@
 @import 'variables/components/footer';
 @import 'variables/components/header';
 @import 'variables/components/hero';
+@import 'variables/components/input';
 @import 'variables/components/page';
 @import 'variables/components/brand-icon';
 @import 'variables/components/quick-action';
+@import 'variables/components/select';
 @import 'variables/components/spinner';
 @import 'variables/components/tabs';
 @import 'variables/components/table';

--- a/projects/canopy/src/styles/variables/_main.scss
+++ b/projects/canopy/src/styles/variables/_main.scss
@@ -43,6 +43,8 @@
 
   --keyline-width: 0.1875rem;
 
+  --form-field-vertical-padding: 0.5625rem; // 9px
+
   /* Separator */
   --separator-color: var(--color-platinum);
 }

--- a/projects/canopy/src/styles/variables/components/_input.scss
+++ b/projects/canopy/src/styles/variables/components/_input.scss
@@ -1,0 +1,4 @@
+:root {
+  --input-line-height: 1.5;
+  --input-vertical-padding: var(--form-field-vertical-padding);
+}

--- a/projects/canopy/src/styles/variables/components/_select.scss
+++ b/projects/canopy/src/styles/variables/components/_select.scss
@@ -1,0 +1,4 @@
+:root {
+  --select-icon-width: 0.875rem;
+  --select-vertical-padding: var(--form-field-vertical-padding);
+}

--- a/projects/canopy/src/styles/variables/components/button/_button.scss
+++ b/projects/canopy/src/styles/variables/components/button/_button.scss
@@ -5,7 +5,7 @@
   --btn-disabled-border-color: var(--disabled-color);
   --btn-disabled-color: var(--color-taupe-grey);
 
-  --btn-vertical-padding: 0.5625rem; // 9px
+  --btn-vertical-padding: var(--form-field-vertical-padding); // 9px
   --btn-horizontal-padding: 1.1875rem; // 19px
   --btn-icon-text-padding: 0.625rem; // 2px
   --btn-icon-edge-padding: 0.125rem; // 10px


### PR DESCRIPTION
# Description

Fixes an issue where inputs were set at the wrong height (50px) instead of the height specified in the designs (44px).

Fixes #43

## Requirements

Storybook link: https://deploy-preview-45--legal-and-general-canopy.netlify.app/
Design link: https://legalandgeneral.invisionapp.com/d/main#/console/19910472/416751159/inspect
Screenshot:
![Screenshot 2020-10-23 at 15 42 09](https://user-images.githubusercontent.com/1943532/97017881-5b626080-1546-11eb-8f72-8972165f1c6b.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
