### PR TITLE
refactor(filter-buttons): amend filter buttons style and public-api

### DIFF
--- a/projects/canopy/src/lib/forms/index.ts
+++ b/projects/canopy/src/lib/forms/index.ts
@@ -1,3 +1,4 @@
+export * from './checkbox-group/index';
 export * from './date/index';
 export * from './forms.module';
 export * from './hint/index';

--- a/projects/canopy/src/lib/forms/radio/radio-button--filter.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--filter.component.scss
@@ -14,12 +14,12 @@
 
   .lg-radio-button__label {
     display: inline-block;
-    max-height: var(--space-lg);
     border: solid var(--border-width) var(--filter-btn-bg-color-active);
     border-radius: var(--space-md);
     padding: var(--space-xxxs) var(--space-sm);
     background: transparent;
     font-size: var(--text-fs--8-size);
+    line-height: var(--filter-btn-line-height);
     margin-bottom: var(--space-xs);
     transition: all var(--animation-duration) var(--animation-fn);
     cursor: pointer;

--- a/projects/canopy/src/styles/variables/components/_filter-button.scss
+++ b/projects/canopy/src/styles/variables/components/_filter-button.scss
@@ -8,4 +8,6 @@
 
   --filter-btn-text-color-selected: var(--color-white);
   --filter-btn-text-color-disabled: var(--color-taupe-grey);
+
+  --filter-btn-line-height: 1.6;
 }


### PR DESCRIPTION
# Description

Amend filter buttons style by getting rid of 'max-height' because it's not necessary and using 'line-height' instead, and add
checkbox-group to forms index.ts.

# Requirements
Storybook link: [https://deploy-preview-50--legal-and-general-canopy.netlify.app/?path=/story/components-filter-buttons--select-one](https://deploy-preview-50--legal-and-general-canopy.netlify.app/?path=/story/components-filter-buttons--select-one)
Design link: [https://legalandgeneral.invisionapp.com/share/2SZ192MTHZY#/432421864_Filter_Buttons](https://legalandgeneral.invisionapp.com/share/2SZ192MTHZY#/432421864_Filter_Buttons)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
