### PR TITLE
docs: adds brand logo to storybook

### DIFF
--- a/.storybook/canopy-theme.js
+++ b/.storybook/canopy-theme.js
@@ -3,5 +3,6 @@ import { create } from '@storybook/theming/create';
 export default create({
   base: 'light',
   brandTitle: 'Canopy',
-  brandUrl: 'https://github.com/Legal-and-General/canopy'
+  brandUrl: 'https://github.com/Legal-and-General/canopy',
+  brandImage: 'legal-and-general-logo.png',
 });


### PR DESCRIPTION
# Description

Adds the logo to the storybook header, just to make it a bit more on brand. The image was already in the repo so just a case of linking to it.

![Screenshot 2020-11-03 at 16 51 30](https://user-images.githubusercontent.com/2196085/98015745-07346780-1df5-11eb-97cc-60c6dfa44f53.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
