### PR TITLE
fix(toggle): remove empty describedby attribute when value is null

### DIFF
--- a/projects/canopy/src/lib/forms/toggle/toggle.component.html
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.html
@@ -1,6 +1,6 @@
 <input
   (click)="onCheck()"
-  [attr.aria-describedby]="ariaDescribedBy"
+  [attr.aria-describedby]="ariaDescribedBy || null"
   [attr.checked]="checked || null"
   [attr.disabled]="disabled || null"
   [attr.id]="id"

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
@@ -229,6 +229,14 @@ describe('LgToggleComponent', () => {
     );
   });
 
+  it('unlinks the error from the fieldset with the correct aria attributes when valid', () => {
+    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
+      false,
+    );
+    fixture.detectChanges();
+    expect(inputDebugElement.nativeElement.hasAttribute('aria-describedBy')).toBe(false);
+  });
+
   it('adds the error class if the form field is invalid', () => {
     when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
     fixture.detectChanges();


### PR DESCRIPTION
Removes the empty aria-describedby attribute from the input element when it is null.

Fixes #56 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
