### PR TITLE
refactor(stories): convert CSS stories to CSF format

### DIFF
--- a/projects/canopy/src/styles/color.stories.ts
+++ b/projects/canopy/src/styles/color.stories.ts
@@ -8,12 +8,10 @@ import {
   ViewChildren,
 } from '@angular/core';
 
-import { storiesOf } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
 import convert from 'color-convert';
 
 import { notes } from './color.notes';
-
-const stories = storiesOf('Colors', module);
 
 interface Color {
   name: string;
@@ -166,13 +164,22 @@ class TintSwatchComponent implements AfterViewInit {
   }
 }
 
-stories.add(
-  'Colors',
-  () => ({
-    moduleMetadata: {
-      declarations: [SwatchComponent, TintSwatchComponent],
+export default {
+  title: 'Colours',
+  parameters: {
+    decorators: [
+      moduleMetadata({
+        declarations: [SwatchComponent, TintSwatchComponent],
+      }),
+    ],
+    notes: {
+      markdown: notes,
     },
-    template: `
+  },
+};
+
+export const colours = () => ({
+  template: `
     <h2>Shades</h2>
 
     <div>
@@ -236,10 +243,4 @@ stories.add(
       </div>
     </div>
   `,
-  }),
-  {
-    notes: {
-      markdown: notes,
-    },
-  },
-);
+});

--- a/projects/canopy/src/styles/grid.stories.ts
+++ b/projects/canopy/src/styles/grid.stories.ts
@@ -1,14 +1,16 @@
-import { storiesOf } from '@storybook/angular';
-
 import { notes } from './grid.notes';
 
-const stories = storiesOf('Grid', module);
+export default {
+  title: 'Grid',
+  parameters: {
+    notes: {
+      markdown: notes,
+    },
+  },
+};
 
-stories.add(
-  'Grid',
-  () => {
-    return {
-      template: `
+export const grid = () => ({
+  template: `
     <div>
       <div class="lg-container">
         <div class="lg-row">
@@ -222,8 +224,8 @@ stories.add(
       </div>
     </div>
     `,
-      styles: [
-        `
+  styles: [
+    `
         .box {
           background-color: var(--color-super-blue);
           margin-bottom: var(--space-md);
@@ -254,12 +256,5 @@ stories.add(
           margin-bottom: var(--text-bottom-margin)
         }
       `,
-      ],
-    };
-  },
-  {
-    notes: {
-      markdown: notes,
-    },
-  },
-);
+  ],
+});

--- a/projects/canopy/src/styles/mixins.stories.ts
+++ b/projects/canopy/src/styles/mixins.stories.ts
@@ -1,15 +1,14 @@
-import { storiesOf } from '@storybook/angular';
-
 import { notes } from './mixins.notes';
 
-const stories = storiesOf('Mixins', module);
-
-stories.add(
-  'Mixins',
-  () => ({
-    template: ``,
-  }),
-  {
-    notes: { markdown: notes },
+export default {
+  title: 'Mixins',
+  parameters: {
+    notes: {
+      markdown: notes,
+    },
   },
-);
+};
+
+export const mixins = () => ({
+  template: ``,
+});

--- a/projects/canopy/src/styles/spacing.stories.ts
+++ b/projects/canopy/src/styles/spacing.stories.ts
@@ -1,15 +1,14 @@
-import { storiesOf } from '@storybook/angular';
-
 import { notes } from './spacing.notes';
 
-const stories = storiesOf('Spacing', module);
-
-stories.add(
-  'Spacing',
-  () => ({
-    template: ``,
-  }),
-  {
-    notes: { markdown: notes },
+export default {
+  title: 'Spacing',
+  parameters: {
+    notes: {
+      markdown: notes,
+    },
   },
-);
+};
+
+export const spacing = () => ({
+  template: ``,
+});

--- a/projects/canopy/src/styles/typography.stories.ts
+++ b/projects/canopy/src/styles/typography.stories.ts
@@ -1,18 +1,25 @@
 import { text, withKnobs } from '@storybook/addon-knobs';
-import { storiesOf } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
 
 import { CanopyModule } from '../lib/canopy.module';
 import { notes } from './typography.notes';
 
-const stories = storiesOf('Typography', module).addDecorator(withKnobs);
-
-stories.add(
-  'Headings',
-  () => ({
-    moduleMetadata: {
-      imports: [CanopyModule],
+export default {
+  title: 'Typography',
+  parameters: {
+    decorators: [
+      moduleMetadata({
+        imports: [CanopyModule],
+      }),
+    ],
+    notes: {
+      markdown: notes,
     },
-    template: `
+  },
+};
+
+export const headings = () => ({
+  template: `
     <p class="lg-font-size-7">{{lgFontSize7}}</p>
     <p class="lg-font-size-7--strong">{{lgFontSize7Strong}}</p>
 
@@ -36,92 +43,81 @@ stories.add(
 
     <p class="lg-font-size-0-8">{{lgFontSize08}}</p>
     <p class="lg-font-size-0-6">{{lgFontSize06}}</p>
-    `,
-    props: {
-      lgFontSize7: text('font size 7', '.lg-font-size-7'),
-      lgFontSize7Strong: text('font size 7 strong', '.lg-font-size-7--strong'),
-
-      lgFontSize6: text('font size 6', '.lg-font-size-6'),
-      lgFontSize6Strong: text('font size 6 strong', '.lg-font-size-6--strong'),
-
-      lgFontSize5: text('font size 5', '.lg-font-size-5'),
-      lgFontSize5Strong: text('font size 5 strong', '.lg-font-size-5--strong'),
-
-      lgFontSize4: text('font size 4', '.lg-font-size-4'),
-      lgFontSize4Strong: text('font size 4 strong', '.lg-font-size-4--strong'),
-
-      lgFontSize3: text('font size 3', '.lg-font-size-3'),
-      lgFontSize3Strong: text('font size 3 strong', '.lg-font-size-3--strong'),
-
-      lgFontSize2: text('font size 2', '.lg-font-size-2'),
-      lgFontSize2Strong: text('font size 2 strong', '.lg-font-size-2--strong'),
-
-      lgFontSize1: text('font size 1', '.lg-font-size-1'),
-      lgFontSize1Strong: text('font size 1 strong', '.lg-font-size-1--strong'),
-
-      lgFontSize08: text('font size 08', '.lg-font-size-0-8'),
-      lgFontSize06: text('font size 06', '.lg-font-size-0-6'),
-    },
-  }),
-  {
-    notes: {
-      markdown: notes,
-    },
-  },
-);
-
-stories.add(
-  'Page',
-  () => ({
-    template: `
-      <h1 class="h1">Accusantium doloremque laudantium</h1>
-      <p>
-        Accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-        illo. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
-        suscipit laboriosam. Accusantium doloremque laudantium, totam rem aperiam,
-        eaque ipsa quae ab illo.
-      </p>
-      <ul>
-        <li>Ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis.</li>
-        <li>Do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
-        <li>Laboris nisi ut aliquip ex ea commodo consequat.</li>
-      </ul>
-
-      <h2>Qui officia deserunt mollit anim id est laborum.</h2>
-      <p>
-        Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
-        adipisci velit. Et harum quidem rerum facilis est et expedita distinctio.
-        Animi, id est laborum et dolorum fuga. Itaque earum rerum hic tenetur a
-        sapiente delectus.
-      </p>
-
-      <p>
-        Laboris nisi ut aliquip ex ea commodo consequat. Architecto beatae vitae
-        dicta sunt explicabo. Fugiat quo voluptas nulla pariatur? Cupiditate non
-        provident, similique sunt in culpa qui officia deserunt mollitia.
-      </p>
-
-      <h3>Inventore veritatis</h3>
-      <p>
-        Facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.
-        <a href="https://en.wikipedia.org/wiki/Oran">Oran hitherto.</a> Excepteur
-        sint occaecat cupidatat non proident, sunt in culpa. Fugiat quo voluptas
-        nulla pariatur? Duis aute irure dolor in reprehenderit in voluptate velit.
-      </p>
-
-      <h4>Inventore veritatis</h4>
-      <p class="lg-font-size-0-8">
-        Totam rem aperiam. Inventore veritatis et quasi architecto beatae
-        vitae dicta sunt explicabo.
-      </p>
-      <p class="lg-font-size-0-6">
-        Et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
-      </p>
   `,
-  }),
-  {
-    notes: {
-      markdown: notes,
-    },
+  props: {
+    lgFontSize7: text('font size 7', '.lg-font-size-7'),
+    lgFontSize7Strong: text('font size 7 strong', '.lg-font-size-7--strong'),
+
+    lgFontSize6: text('font size 6', '.lg-font-size-6'),
+    lgFontSize6Strong: text('font size 6 strong', '.lg-font-size-6--strong'),
+
+    lgFontSize5: text('font size 5', '.lg-font-size-5'),
+    lgFontSize5Strong: text('font size 5 strong', '.lg-font-size-5--strong'),
+
+    lgFontSize4: text('font size 4', '.lg-font-size-4'),
+    lgFontSize4Strong: text('font size 4 strong', '.lg-font-size-4--strong'),
+
+    lgFontSize3: text('font size 3', '.lg-font-size-3'),
+    lgFontSize3Strong: text('font size 3 strong', '.lg-font-size-3--strong'),
+
+    lgFontSize2: text('font size 2', '.lg-font-size-2'),
+    lgFontSize2Strong: text('font size 2 strong', '.lg-font-size-2--strong'),
+
+    lgFontSize1: text('font size 1', '.lg-font-size-1'),
+    lgFontSize1Strong: text('font size 1 strong', '.lg-font-size-1--strong'),
+
+    lgFontSize08: text('font size 08', '.lg-font-size-0-8'),
+    lgFontSize06: text('font size 06', '.lg-font-size-0-6'),
   },
-);
+  parameters: {
+    decorators: [withKnobs],
+  },
+});
+
+export const page = () => ({
+  template: `
+    <h1 class="h1">Accusantium doloremque laudantium</h1>
+    <p>
+      Accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+      illo. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+      suscipit laboriosam. Accusantium doloremque laudantium, totam rem aperiam,
+      eaque ipsa quae ab illo.
+    </p>
+    <ul>
+      <li>Ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis.</li>
+      <li>Do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+      <li>Laboris nisi ut aliquip ex ea commodo consequat.</li>
+    </ul>
+
+    <h2>Qui officia deserunt mollit anim id est laborum.</h2>
+    <p>
+      Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
+      adipisci velit. Et harum quidem rerum facilis est et expedita distinctio.
+      Animi, id est laborum et dolorum fuga. Itaque earum rerum hic tenetur a
+      sapiente delectus.
+    </p>
+
+    <p>
+      Laboris nisi ut aliquip ex ea commodo consequat. Architecto beatae vitae
+      dicta sunt explicabo. Fugiat quo voluptas nulla pariatur? Cupiditate non
+      provident, similique sunt in culpa qui officia deserunt mollitia.
+    </p>
+
+    <h3>Inventore veritatis</h3>
+    <p>
+      Facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.
+      <a href="https://en.wikipedia.org/wiki/Oran">Oran hitherto.</a> Excepteur
+      sint occaecat cupidatat non proident, sunt in culpa. Fugiat quo voluptas
+      nulla pariatur? Duis aute irure dolor in reprehenderit in voluptate velit.
+    </p>
+
+    <h4>Inventore veritatis</h4>
+    <p class="lg-font-size-0-8">
+      Totam rem aperiam. Inventore veritatis et quasi architecto beatae
+      vitae dicta sunt explicabo.
+    </p>
+    <p class="lg-font-size-0-6">
+      Et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
+    </p>
+  `,
+});

--- a/projects/canopy/src/styles/utils.stories.ts
+++ b/projects/canopy/src/styles/utils.stories.ts
@@ -1,15 +1,12 @@
-import { storiesOf } from '@storybook/angular';
-
 import { notes } from './utils.notes';
 
-const stories = storiesOf('Utils', module);
-
-stories.add(
-  'Utils',
-  () => ({
-    template: ``,
-  }),
-  {
+export default {
+  title: 'Utils',
+  parameters: {
     notes: { markdown: notes },
   },
-);
+};
+
+export const utils = () => ({
+  template: ``,
+});


### PR DESCRIPTION
# Description

As recommended by Storybook, this changes some stories into the CSF story format.

Note that it only changes the CSS based stories found in the styles directory.

There are a few more stories that need converting, but require a little more thought, e.g. Pipes, Directives.

Partly addresses #65 

## Requirements

There should be no changes to the functionality in Storybook, as this is more of a future proofing change.

Storybook link: https://deploy-preview-67--legal-and-general-canopy.netlify.app/

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
