### PR TITLE
Brand icon remove duplicate variable

### DIFF
--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
@@ -50,15 +50,14 @@ export class LgBrandIconComponent {
   @Input()
   set name(name: Name) {
     if (this.svgElement) {
-      this.elementRef.nativeElement.removeChild(this.svgElement);
+      this.hostElement.nativeElement.removeChild(this.svgElement);
     }
     const svgData = this.setSVGAttributes(this.iconRegistry.getBrandIcon(name));
     this.svgElement = this.svgElementFromString(svgData);
-    this.elementRef.nativeElement.appendChild(this.svgElement);
+    this.hostElement.nativeElement.appendChild(this.svgElement);
   }
 
   constructor(
-    private elementRef: ElementRef,
     private iconRegistry: LgBrandIconRegistry,
     @Inject(DOCUMENT) private document: any,
     private renderer: Renderer2,

--- a/projects/canopy/src/lib/icon/icon.component.ts
+++ b/projects/canopy/src/lib/icon/icon.component.ts
@@ -31,16 +31,16 @@ export class LgIconComponent {
   @Input()
   set name(name: Name) {
     if (this.svgIcon) {
-      this.elementRef.nativeElement.removeChild(this.svgIcon);
+      this.hostElement.nativeElement.removeChild(this.svgIcon);
     }
 
     const svgData = this.setSVGAttributes(this.iconRegistry.getIcon(name));
     this.svgIcon = this.svgElementFromString(svgData);
-    this.elementRef.nativeElement.appendChild(this.svgIcon);
+    this.hostElement.nativeElement.appendChild(this.svgIcon);
   }
 
   constructor(
-    private elementRef: ElementRef,
+    private hostElement: ElementRef,
     private iconRegistry: LgIconRegistry,
     @Inject(DOCUMENT) private document: any,
   ) {}


### PR DESCRIPTION
# Description

Just a minor refactor.

The BrandIcon had a duplicate injected `ElementRef`, I removed one.

I also aligned the injected `ElementRef` variable to be called `hostElement`, this aligns with the majority of other components. I think it is a more descriptive name as there could be multiple elementRefs and hostElement gives a bit more context as to what element it is.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
