### PR TITLE
ci(codeowners): updates CODEOWNERS to use team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # Default owners for everything in the repo
-*       @thatguynamedandy @elenagarrone @owensgit @aaronbery
+*       @Legal-and-General/canopy-core-contributors


### PR DESCRIPTION
# Description

Using the team name should reduce steps to keep in sync as we add more people.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
