### PR TITLE
docs(input): fixes markdown formatting

### DIFF
--- a/projects/canopy/src/lib/forms/input/input.notes.ts
+++ b/projects/canopy/src/lib/forms/input/input.notes.ts
@@ -31,7 +31,8 @@ The \`lgSuffix\` directive needs to be added to the button to place it in the co
 Only small size buttons should be placed in the input field. 
 There is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.
 
-Button suffix
+#### Button suffix
+
 ~~~html
 <lg-input-field>
   Name
@@ -42,7 +43,8 @@ Button suffix
 </lg-input-field>
 ~~~
 
-Icon Button suffix with add-on class
+#### Icon Button suffix with add-on class
+
 ~~~html
 <lg-input-field>
   Name
@@ -57,7 +59,8 @@ Icon Button suffix with add-on class
 
 Prefix and suffix text can be added to input fields using the \`lgSuffix\` and \`lgPrefix\` directive.
 
-Text prefix
+#### Text prefix
+
 ~~~html
 <lg-input-field>
   Name
@@ -66,7 +69,8 @@ Text prefix
 </lg-input-field>
 ~~~
 
-Text suffix
+#### Text suffix
+
 ~~~html
 <lg-input-field>
   Name


### PR DESCRIPTION
# Description

Apologies I had a few markdown formatting issues in the notes.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
