### PR TITLE
feat(segment): add segment component

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -393,6 +393,14 @@
               <lg-radio-button value="blue">Blue</lg-radio-button>
             </lg-radio-group>
 
+
+            <lg-segment-group formControlName="segment" value="top" stack="md">
+              Test segment
+              <lg-segment-button value="top">Top</lg-segment-button>
+              <lg-segment-button value="right">Right</lg-segment-button>
+              <lg-segment-button value="bottom">Bottom</lg-segment-button>
+            </lg-segment-group>
+
             <lg-filter-group formControlName="filter">
               Test filter group
               <lg-filter-button value="red">Red</lg-filter-button>

--- a/projects/canopy-test-app/src/app/app.component.ts
+++ b/projects/canopy-test-app/src/app/app.component.ts
@@ -57,6 +57,7 @@ export class AppComponent {
       filters: this.fb.control([]),
       checkbox: [''],
       switch: [''],
+      segment: [''],
       date: [''],
       sortCode: ['']
     });

--- a/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
@@ -1,0 +1,93 @@
+@import '../../../styles/mixins';
+
+.lg-radio-button--segment {
+  display: flex;
+  flex-grow: 1;
+  flex-basis: 0;
+  align-items: stretch;
+  padding: 0 var(--space-xxxs);
+  margin: var(--space-xxxs) 0;
+
+  + .lg-radio-button--segment {
+    border-left: var(--radio-segment-separator-border-width) solid
+      var(--radio-segment-separator-border-color);
+  }
+
+  .lg-radio-button__label {
+    display: flex;
+    padding: var(--space-xxxs) var(--space-sm);
+    border-radius: var(--border-radius-sm);
+    min-width: var(--radio-segment-label-min-width);
+    flex-grow: 1;
+    text-align: center;
+    align-items: center;
+    justify-content: center;
+
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+
+  .lg-radio-button__input {
+    &:checked + .lg-radio-button__label {
+      background-color: var(--radio-bg-color);
+      color: var(--radio-color);
+      transition: all var(--animation-duration) var(--animation-fn);
+    }
+
+    &:disabled:checked + .lg-radio-button__label {
+      background-color: var(--radio-disabled-color);
+      color: var(--radio-color);
+    }
+
+    &:disabled + .lg-radio-button__label {
+      color: var(--disabled-color);
+      cursor: not-allowed;
+    }
+
+    &:focus + .lg-radio-button__label {
+      @include lg-inner-focus-outline(var(--default-focus-color));
+    }
+
+    .lg-radio-button--error &:checked + .lg-radio-button__label {
+      background-color: var(--form-error-color);
+      color: var(--radio-color);
+    }
+  }
+
+  $stack-breakpoints: 'sm', 'md', 'lg' !default;
+
+  @each $stack-breakpoint in $stack-breakpoints {
+    &.lg-radio-button--stacked-#{$stack-breakpoint} {
+      @include lg-breakpoint($stack-breakpoint, 'max-width') {
+        display: flex;
+        flex-flow: column wrap;
+        margin: 0;
+      }
+
+      .lg-radio-button__label {
+        @include lg-breakpoint($stack-breakpoint, 'max-width') {
+          margin: calc(var(--space-xxxs) + var(--radio-segment-separator-border-width)) 0
+            var(--space-xxxs);
+        }
+      }
+
+      + .lg-radio-button--segment {
+        @include lg-breakpoint($stack-breakpoint, 'max-width') {
+          border-left: 0;
+        }
+
+        &::before {
+          @include lg-breakpoint($stack-breakpoint, 'max-width') {
+            content: '';
+            display: inline-block;
+            width: 100%;
+            height: var(--radio-segment-separator-border-width);
+            background-color: var(--radio-segment-separator-border-color);
+          }
+        }
+      }
+    }
+  }
+}

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -7,100 +7,75 @@
   &:last-of-type {
     margin-bottom: var(--space-xs);
   }
+}
 
-  .lg-radio-button__input {
-    @include lg-visually-hidden;
+.lg-radio-button__input {
+  @include lg-visually-hidden;
+}
+
+.lg-radio-button__label {
+  display: flex;
+  position: relative;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-sm);
+
+  .lg-radio-button__input:disabled + & {
+    color: var(--disabled-color);
   }
 
-  .lg-radio-button__label {
-    display: flex;
-    position: relative;
-    font-weight: var(--font-weight-regular);
-    line-height: var(--line-height-sm);
-  }
-
-  .lg-radio-button__input:disabled {
-    + .lg-radio-button__label {
-      color: var(--disabled-color);
-    }
-  }
-
-  &.lg-radio-button--error {
+  .lg-radio-button--error & {
     color: var(--form-error-color);
   }
+}
 
-  .lg-radio-button__label::before {
-    content: ' ';
-    left: 0;
-    top: 0;
-    bottom: 0;
-    display: inline-block;
-    height: var(--toggle-outer-height);
-    width: var(--toggle-outer-width);
-    background-color: var(--color-white);
-    border-radius: 50%;
-    border: var(--border-width) solid var(--border-color);
-    margin: auto var(--space-sm) auto 0;
+.lg-radio-button__label::before {
+  content: ' ';
+  left: 0;
+  top: 0;
+  bottom: 0;
+  display: inline-block;
+  height: var(--radio-outer-height);
+  width: var(--radio-outer-width);
+  background-color: var(--color-white);
+  border-radius: 50%;
+  border: var(--border-width) solid var(--radio-border-color);
+  margin: auto var(--space-sm) auto 0;
 
-    .lg-radio-button--error:hover &,
-    .lg-radio-button--error & {
-      border-color: var(--form-error-border-color);
-    }
+  .lg-radio-button__input:focus + & {
+    border-color: var(--border-focus-color);
+    @include lg-outer-focus-outline();
   }
 
-  &:hover {
-    .lg-radio-button__label::before {
-      border-color: var(--border-hover-color);
-    }
+  .lg-radio-button:disabled & {
+    border-color: var(--border-disabled-color);
   }
 
-  .lg-radio-button__input:focus {
-    + .lg-radio-button__label::before {
-      border-color: var(--border-focus-color);
-      @include lg-outer-focus-outline();
-    }
+  .lg-radio-button--error:hover &,
+  .lg-radio-button--error & {
+    border-color: var(--form-error-border-color);
+  }
+}
+
+.lg-radio-button__label::after {
+  content: ' ';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  margin: auto var(--space-xxxs);
+  height: var(--radio-inner-height);
+  width: var(--radio-inner-width);
+  border-radius: 50%;
+
+  .lg-radio-button__input:checked + & {
+    background-color: var(--radio-bg-color);
   }
 
-  &:disabled {
-    .lg-radio-button__label::before {
-      border-color: var(--border-disabled-color);
-    }
+  .lg-radio-button__input:disabled:checked + & {
+    background-color: var(--radio-disabled-color);
   }
 
-  &.lg-radio-button--error:hover,
-  &.lg-radio-button--error {
-    .lg-radio-button__label::before {
-      border-color: var(--form-error-border-color);
-    }
-
-    .lg-radio-button__input:checked {
-      + .lg-radio-button__label::after {
-        background-color: var(--form-error-border-color);
-      }
-    }
-  }
-
-  .lg-radio-button__label::after {
-    content: ' ';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    margin: auto var(--space-xxxs);
-    height: var(--toggle-inner-height);
-    width: var(--toggle-inner-width);
-    border-radius: 50%;
-  }
-
-  .lg-radio-button__input:checked {
-    + .lg-radio-button__label::after {
-      background-color: var(--toggle-bg-color);
-    }
-  }
-
-  .lg-radio-button__input:disabled:checked {
-    + .lg-radio-button__label::after {
-      background-color: var(--toggle-disabled-color);
-    }
+  .lg-radio-button--error .lg-radio-button__input:checked + & {
+    background-color: var(--form-error-border-color);
   }
 }

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
@@ -17,6 +17,7 @@ describe('LgRadioButtonComponent', () => {
     errorStateMatcherMock = mock(LgErrorStateMatcher);
     radioGroupMock = mock(LgRadioGroupComponent);
     when(radioGroupMock.name).thenReturn('color');
+    when(radioGroupMock.variant).thenReturn('segment');
 
     TestBed.configureTestingModule({
       declarations: [LgRadioButtonComponent],
@@ -40,6 +41,26 @@ describe('LgRadioButtonComponent', () => {
 
   it('sets its name from the radio group name', () => {
     expect(component.name).toBe('color');
+  });
+
+  describe('the variant', () => {
+    it('should be set based on the radio group variant', () => {
+      expect(component.variant).toBe('segment');
+    });
+
+    it('should set the correct class modifier', () => {
+      expect(fixture.debugElement.nativeElement.getAttribute('class')).toContain(
+        'lg-radio-button--segment',
+      );
+
+      when(radioGroupMock.variant).thenReturn('radio');
+      fixture = TestBed.createComponent(LgRadioButtonComponent);
+      component = fixture.componentInstance;
+
+      expect(fixture.debugElement.nativeElement.getAttribute('class')).not.toContain(
+        'lg-radio-button--segment',
+      );
+    });
   });
 
   // https://github.com/NagRock/ts-mockito/issues/120

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.ts
@@ -1,28 +1,32 @@
 import {
   Component,
+  ElementRef,
   Host,
   HostBinding,
   Input,
   OnInit,
   Optional,
+  Renderer2,
   Self,
   SkipSelf,
   ViewEncapsulation,
-  Renderer2,
-  ElementRef,
 } from '@angular/core';
 import { FormGroupDirective, NgControl } from '@angular/forms';
 
 import { LgErrorStateMatcher } from '../validation/error-state-matcher';
 import { LgRadioGroupComponent } from './radio-group.component';
-import { RadioVariant } from './radio.interface';
+import { RadioStackBreakpoint, RadioVariant } from './radio.interface';
 
 let nextUniqueId = 0;
 
 @Component({
-  selector: 'lg-radio-button, lg-filter-button',
+  selector: 'lg-radio-button, lg-filter-button, lg-segment-button',
   templateUrl: './radio-button.component.html',
-  styleUrls: ['./radio-button.component.scss', './radio-button--filter.component.scss'],
+  styleUrls: [
+    './radio-button.component.scss',
+    './radio-button--filter.component.scss',
+    './radio-button--segment.component.scss',
+  ],
   encapsulation: ViewEncapsulation.None,
 })
 export class LgRadioButtonComponent implements OnInit {
@@ -45,6 +49,21 @@ export class LgRadioButtonComponent implements OnInit {
   @Input() id = `lg-radio-button-${++nextUniqueId}`;
   @Input() name: string;
   @Input() value: string;
+
+  _stacked: RadioStackBreakpoint;
+  set stacked(stacked: RadioStackBreakpoint) {
+    this.renderer.removeClass(
+      this.hostElement.nativeElement,
+      `lg-radio-button--stacked-${this._stacked}`,
+    );
+    if (stacked) {
+      this.renderer.addClass(
+        this.hostElement.nativeElement,
+        `lg-radio-button--stacked-${stacked}`,
+      );
+    }
+    this._stacked = stacked;
+  }
 
   @Input()
   _disabled = false;

--- a/projects/canopy/src/lib/forms/radio/radio-group--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-group--segment.component.scss
@@ -1,0 +1,17 @@
+@import '../../../styles/mixins';
+
+.lg-radio-group__segment {
+  display: inline-flex;
+  border: var(--border-width) solid var(--radio-border-color);
+  border-radius: var(--border-radius-sm);
+}
+
+$stack-breakpoints: 'sm', 'md', 'lg' !default;
+
+@each $stack-breakpoint in $stack-breakpoints {
+  .lg-radio-group--stack-#{$stack-breakpoint} .lg-radio-group__segment {
+    @include lg-breakpoint($stack-breakpoint, 'max-width') {
+      display: block;
+    }
+  }
+}

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.html
@@ -3,7 +3,15 @@
     <ng-content></ng-content>
   </legend>
   <ng-content select="lg-hint"></ng-content>
-  <ng-content select="lg-radio-button, lg-filter-button"></ng-content>
+
+  <div *ngIf="variant === 'segment'; else generic" class="lg-radio-group__segment">
+    <ng-content select="lg-segment-button"></ng-content>
+  </div>
+
+  <ng-template #generic>
+    <ng-content select="lg-radio-button, lg-filter-button"></ng-content>
+  </ng-template>
+
   <ng-content select="lg-validation"></ng-content>
 </fieldset>
 <ng-content select="lg-hint"></ng-content>

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
@@ -90,6 +90,7 @@ describe('LgRadioGroupComponent', () => {
 
     fixture = TestBed.createComponent(TestRadioGroupComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
 
     groupDebugElement = fixture.debugElement.query(By.directive(LgRadioGroupComponent));
     groupInstance = groupDebugElement.injector.get<LgRadioGroupComponent>(
@@ -103,8 +104,6 @@ describe('LgRadioGroupComponent', () => {
     radioDebugElements = fixture.debugElement.queryAll(By.css('lg-radio-button'));
 
     radioInstances = radioDebugElements.map((debugEl) => debugEl.componentInstance);
-
-    fixture.detectChanges();
   }));
 
   it('sets all radio buttons to the same name', () => {
@@ -113,6 +112,16 @@ describe('LgRadioGroupComponent', () => {
     for (const radio of radioInstances) {
       expect(radio.name).toBe(name);
     }
+  });
+
+  it('adds a wrapper for the segment radio in the template', () => {
+    expect(fixture.debugElement.query(By.css('.lg-radio-group__segment'))).toBeNull();
+
+    groupInstance.variant = 'segment';
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css('.lg-radio-group__segment')).nativeElement,
+    ).toBeDefined();
   });
 
   it('sets the correct variant based on the selector', () => {
@@ -127,12 +136,12 @@ describe('LgRadioGroupComponent', () => {
 
   it('checks the selected radio button when a value is provided', () => {
     const blueOption: DebugElement = radioDebugElements.find(
-      (radioDebugElement) => radioDebugElement.componentInstance.value === 'blue',
+      (debugElement) => debugElement.componentInstance.value === 'blue',
     );
     blueOption.query(By.css('input')).triggerEventHandler('click', null);
     fixture.detectChanges();
     const checkedOption: DebugElement = radioDebugElements.find(
-      (radioDebugElement) => radioDebugElement.componentInstance.checked === true,
+      (debugElement) => debugElement.componentInstance.checked === true,
     );
     expect(checkedOption.componentInstance.value).toBe('blue');
   });
@@ -226,5 +235,23 @@ describe('LgRadioGroupComponent', () => {
     expect(groupDebugElement.nativeElement.className).not.toContain(
       'lg-radio-group--error',
     );
+  });
+
+  describe('stack', () => {
+    it('adds or removes a class based on its value', () => {
+      groupInstance.stack = 'sm';
+      fixture.detectChanges();
+
+      expect(groupDebugElement.nativeElement.className).toContain(
+        'lg-radio-group--stack-sm',
+      );
+
+      groupInstance.stack = undefined;
+      fixture.detectChanges();
+
+      expect(groupDebugElement.nativeElement.className).not.toContain(
+        'lg-radio-group--stack-sm',
+      );
+    });
   });
 });

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.ts
@@ -2,16 +2,17 @@ import {
   Component,
   ContentChild,
   ContentChildren,
+  ElementRef,
   forwardRef,
   Host,
   HostBinding,
   Input,
   Optional,
   QueryList,
+  Renderer2,
   Self,
   SkipSelf,
   ViewEncapsulation,
-  ElementRef,
 } from '@angular/core';
 import { ControlValueAccessor, FormGroupDirective, NgControl } from '@angular/forms';
 
@@ -20,14 +21,14 @@ import { LgHintComponent } from '../hint/hint.component';
 import { LgErrorStateMatcher } from '../validation/error-state-matcher';
 import { LgValidationComponent } from '../validation/validation.component';
 import { LgRadioButtonComponent } from './radio-button.component';
-import { RadioVariant } from './radio.interface';
+import { RadioStackBreakpoint, RadioVariant } from './radio.interface';
 
 let uniqueId = 0;
 
 @Component({
-  selector: 'lg-radio-group, lg-filter-group',
+  selector: 'lg-radio-group, lg-filter-group, lg-segment-group',
   templateUrl: './radio-group.component.html',
-  styleUrls: ['./radio-group.component.scss'],
+  styleUrls: ['./radio-group.component.scss', './radio-group--segment.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
 export class LgRadioGroupComponent implements ControlValueAccessor {
@@ -39,6 +40,33 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
   @Input() disabled = false;
   @Input() ariaDescribedBy: string;
   variant: RadioVariant;
+
+  _stack: RadioStackBreakpoint;
+  @Input()
+  set stack(stack: RadioStackBreakpoint) {
+    if (this._stack) {
+      this.renderer.removeClass(
+        this.hostElement.nativeElement,
+        `lg-radio-group--stack-${this.stack}`,
+      );
+    }
+    if (stack) {
+      this.renderer.addClass(
+        this.hostElement.nativeElement,
+        `lg-radio-group--stack-${stack}`,
+      );
+    }
+    this._stack = stack;
+
+    if (this.radios) {
+      this.radios.toArray().forEach((radio) => {
+        radio.stacked = this.stack;
+      });
+    }
+  }
+  get stack(): RadioStackBreakpoint {
+    return this._stack;
+  }
 
   @HostBinding('class.lg-radio-group') class = true;
   @HostBinding('class.lg-radio-group--inline') public get inlineClass() {
@@ -118,6 +146,7 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
     private controlContainer: FormGroupDirective,
     private domService: LgDomService,
     private hostElement: ElementRef,
+    private renderer: Renderer2,
   ) {
     this.variant = this.hostElement.nativeElement.tagName
       .split('-')[1]

--- a/projects/canopy/src/lib/forms/radio/radio.interface.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.interface.ts
@@ -1,1 +1,2 @@
-export type RadioVariant = 'radio' | 'filter';
+export type RadioVariant = 'radio' | 'filter' | 'segment';
+export type RadioStackBreakpoint = 'sm' | 'md' | 'lg';

--- a/projects/canopy/src/lib/forms/radio/radio.module.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 import { LgLabelModule } from '../label/label.module';
 import { LgRadioButtonComponent } from './radio-button.component';
@@ -6,7 +7,7 @@ import { LgRadioGroupComponent } from './radio-group.component';
 import { LgMarginModule } from '../../spacing/margin/margin.module';
 
 @NgModule({
-  imports: [LgLabelModule, LgMarginModule],
+  imports: [LgLabelModule, LgMarginModule, CommonModule],
   declarations: [LgRadioGroupComponent, LgRadioButtonComponent],
   exports: [LgRadioGroupComponent, LgRadioButtonComponent],
   entryComponents: [LgRadioGroupComponent, LgRadioButtonComponent],

--- a/projects/canopy/src/lib/forms/radio/radio.notes.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.notes.ts
@@ -17,13 +17,31 @@ Import the Radio Module into your application:
 and in your HTML:
 
 ~~~html
-<lg-${name.toLowerCase()}-group [inline]="true" formControlName="color">
+<lg-${name.toLowerCase()}-group ${
+  name === 'Radio' ? '[inline]="true"' : ''
+} formControlName="color">
   Colour
   <lg-hint>Please select a colour</lg-hint>
   <lg-${name.toLowerCase()}-button value="red">Red</lg-${name.toLowerCase()}-button>
   <lg-${name.toLowerCase()}-button value="yellow">Yellow</lg-${name.toLowerCase()}-button>
 </lg-${name.toLowerCase()}-group>
 ~~~
+\
+${
+  name === 'Segment' &&
+  `### Displaying the buttons at different breakpoints
+
+Radios are displayed inline, unless given a \`RadioStackBreakpoint\`, which tells them at which breakpoint should they appear stacked on top of each other:
+
+~~~html
+<lg-segment-group [stack]="sm" formControlName="color">
+  Colour
+  <lg-segment-button value="red">Red</lg-segment-button>
+  <lg-segment-button value="yellow">Yellow</lg-segment-button>
+</lg-segment-group>
+~~~
+    `
+}
 
 ## Inputs
 
@@ -33,7 +51,13 @@ and in your HTML:
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\${nextUniqueId++}' | No |
 | \`\`name\`\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\${nextUniqueId++}' | No |
 | \`\`value\`\` | Set the default checked radio button, must match the value of the radio button | string | null | No |
-| \`\`inline\`\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |
+${
+  name === 'Radio'
+    ? `| \`\`inline\`\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`
+    : name === 'Segment'
+    ? `| \`\`stack\`\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`
+    : ''
+}
 
 ### LgRadioButtonComponent
 | Name | Description | Type | Default | Required |
@@ -52,16 +76,58 @@ Generate the markup as show in the example below.
 | Class | Description |
 |------|-------------|
 | \`\`lg-radio-group\`\` | Adds styles to the wrapping element |
-| \`\`lg-radio-group--inline\`\` | Displays the radio buttons inline, rather than stacked |
+${
+  name === 'Segment'
+    ? `| \`\`lg-radio-group--stack-sm\`\` | Stacks the radio buttons at the small breakpoint |
+      | \`\`lg-radio-group--stack-md\`\` | Stacks the radio buttons at the medium breakpoint |
+      | \`\`lg-radio-group--stack-lg\`\` | Stacks the radio buttons at the large breakpoint |`
+    : name === 'Radio'
+    ? `| \`\`lg-radio-group--inline\`\` | Displays the radio buttons inline, rather than stacked |`
+    : ''
+}
 
 ### Radio button
 | Class | Description |
 |------|-------------|
-| \`\`lg-radio-button--filter\`\` | Adds filter variant styles to the radio button element |
 | \`\`lg-radio-button__input\`\` | Adds styles to the radio button input element |
 | \`\`lg-radio-button__label\`\` | Adds styles to the radio label element |
+${
+  name === 'Segment'
+    ? `| \`\`lg-radio-button--segment\`\` | Adds segment variant styles to the radio button element |
+      | \`\`lg-radio-button--stack-sm\`\` | Adds styles to the radio button at small breakpoint |
+      | \`\`lg-radio-button--stack-md\`\` | Adds styles to the radio button at medium breakpoint |
+      | \`\`lg-radio-button--stack-lg\`\` | Adds styles to the radio button at large breakpoint |`
+    : name === 'Filter'
+    ? `| \`\`lg-radio-button--filter\`\` | Adds filter variant styles to the radio button element |
+      | \`\`lg-radio-button--filter\`\` | Adds filter variant styles to the radio button element |`
+    : ''
+}
+
 
 ### Examples:
+${
+  name === 'Segment'
+    ? `
+~~~html
+<div class="lg-radio-group">
+  <fieldset>
+    <legend class="lg-label">Color</legend>
+    <div class="lg-radio--segment">
+      <div class="lg-radio-button lg-radio-button--segment">
+        <label class="lg-radio-button__label" for="red">Red</label>
+        <input class="lg-radio-button__input" id="red" name="color" value="red" checked="true">
+      </div>
+      <div class="lg-radio-button lg-radio-button--segment">
+        <label class="lg-radio-button__label" for="red">Blue</label>
+        <input class="lg-radio-button__input" id="red" name="color" value="blue">
+      </div>
+    </div>
+  </fieldset>
+</div>
+~~~
+`
+    : name === 'Filter'
+    ? `
 ~~~html
 <div class="lg-radio-group">
   <label class="lg-input__label" for="color">Color</label>
@@ -75,4 +141,23 @@ Generate the markup as show in the example below.
   </div>
 </div>
 ~~~
+`
+    : `
+~~~html
+<div class="lg-radio-group">
+  <fieldset>
+    <legend class="lg-label">Color</legend>
+    <div class="lg-radio-button">
+      <label class="lg-radio-button__label" for="red">Red</label>
+      <input class="lg-radio-button__input" id="red" name="color" value="red" checked="true">
+    </div>
+    <div class="lg-radio-button">
+      <label class="lg-radio-button__label" for="red">Blue</label>
+      <input class="lg-radio-button__input" id="red" name="color" value="blue">
+    </div>
+  </fieldset>
+</div>
+~~~
+`
+}
 `;

--- a/projects/canopy/src/lib/forms/radio/segment.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/segment.stories.ts
@@ -1,0 +1,88 @@
+import { ReactiveFormsModule, FormGroup, FormBuilder } from '@angular/forms';
+import { Component, Input, EventEmitter, Output } from '@angular/core';
+
+import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
+import { moduleMetadata } from '@storybook/angular';
+import { action } from '@storybook/addon-actions';
+
+import { notes } from './radio.notes';
+import { LgRadioModule } from './radio.module';
+import { RadioStackBreakpoint } from './radio.interface';
+
+@Component({
+  selector: 'lg-reactive-form-segment',
+  template: `
+    <form [formGroup]="form">
+      <lg-segment-group formControlName="color" [stack]="stack">
+        {{ label }} {{ itemsInSegment }}
+        <lg-segment-button value="red">Red</lg-segment-button>
+        <lg-segment-button value="yellow">{{ secondButtonLabel }}</lg-segment-button>
+        <lg-segment-button value="green">Green</lg-segment-button>
+        <lg-segment-button value="blue">Blue</lg-segment-button>
+      </lg-segment-group>
+    </form>
+  `,
+})
+class ReactiveFormSegmentComponent {
+  @Input() label: string;
+  @Input() secondButtonLabel: string;
+  @Input() stack: RadioStackBreakpoint;
+  @Input()
+  set disabled(isDisabled: boolean) {
+    if (isDisabled === true) {
+      this.form.controls.color.disable();
+    } else {
+      this.form.controls.color.enable();
+    }
+  }
+  get disabled(): boolean {
+    return this.form.controls.color.disabled;
+  }
+
+  @Output() segmentChange: EventEmitter<void> = new EventEmitter();
+
+  form: FormGroup;
+
+  constructor(public fb: FormBuilder) {
+    this.form = this.fb.group({ color: null });
+    this.form.valueChanges.subscribe((val) => this.segmentChange.emit(val));
+  }
+}
+
+export default {
+  title: 'Components/Form/Segment',
+  parameters: {
+    decorators: [
+      withKnobs,
+      moduleMetadata({
+        declarations: [ReactiveFormSegmentComponent],
+        imports: [ReactiveFormsModule, LgRadioModule],
+      }),
+    ],
+    'in-dsm': {
+      id: '5ed64569a269db443068121a',
+    },
+    notes: {
+      markdown: notes('Segment'),
+    },
+  },
+};
+
+export const standard = () => ({
+  template: `
+    <lg-reactive-form-segment
+    [stack]="stack === 'false' ? false : stack"
+    [disabled]="disabled"
+    [label]="label"
+    [secondButtonLabel]="secondButtonLabel"
+    (segmentChange)="segmentChange($event)">
+  </lg-reactive-form-segment>
+  `,
+  props: {
+    label: text('label', 'Select a color'),
+    secondButtonLabel: text('secondButtonLabel', 'Yellow'),
+    segmentChange: action('segmentChange'),
+    disabled: boolean('disabled', false),
+    stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),
+  },
+});

--- a/projects/canopy/src/lib/forms/toggle/index.ts
+++ b/projects/canopy/src/lib/forms/toggle/index.ts
@@ -1,3 +1,4 @@
 export * from './toggle.interface';
 export * from './toggle.component';
 export * from './toggle.module';
+export * from './toggle.interface';

--- a/projects/canopy/src/styles/form.scss
+++ b/projects/canopy/src/styles/form.scss
@@ -1,5 +1,5 @@
 @import '../lib/forms/toggle/toggle.component';
-@import '../lib/forms/input/input-field.component.scss';
-@import '../lib/forms/select/select-field.component.scss';
-@import '../lib/forms/radio/radio-button.component.scss';
-@import '../lib/forms/radio/radio-group.component.scss';
+@import '../lib/forms/input/input-field.component';
+@import '../lib/forms/select/select-field.component';
+@import '../lib/forms/radio/radio-button.component';
+@import '../lib/forms/radio/radio-group.component';

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -4,6 +4,7 @@
 @import 'variables/components/breadcrumb';
 @import 'variables/components/button/main';
 @import 'variables/components/card';
+@import 'variables/components/radio';
 @import 'variables/components/data-point';
 @import 'variables/components/details';
 @import 'variables/components/filter-button';

--- a/projects/canopy/src/styles/variables/components/_radio.scss
+++ b/projects/canopy/src/styles/variables/components/_radio.scss
@@ -1,0 +1,15 @@
+:root {
+  --radio-bg-color: var(--color-super-blue);
+  --radio-color: var(--color-white);
+  --radio-border-color: var(--border-color);
+  --radio-disabled-color: var(--color-taupe-grey);
+
+  --radio-inner-height: 0.5rem;
+  --radio-inner-width: var(--radio-inner-height);
+  --radio-outer-height: 1rem;
+  --radio-outer-width: var(--radio-outer-height);
+
+  --radio-segment-separator-border-width: var(--border-width);
+  --radio-segment-separator-border-color: var(--color-platinum);
+  --radio-segment-label-min-width: calc(6 * var(--space-unit));
+}


### PR DESCRIPTION
# Description

This PR implements the segment component. The way the segment stack is controlled by the `stack` input which by default is set to be falsey.

## Requirements

The segment component should be either inline at all breakpoints or stack whenever needed (sm, md, lg breakpoint).
It takes the full width of the container element.

Storybook link: https://deploy-preview-86--legal-and-general-canopy.netlify.app/
Design link: https://legalandgeneral.invisionapp.com/share/NSZDSDYUWFE#/screens/416751156_Segment
Screenshots:

![Screenshot 2020-11-27 at 17 39 02](https://user-images.githubusercontent.com/8397116/100474990-d553af80-30d9-11eb-898c-e72156888df9.png)
![Screenshot 2020-11-27 at 17 39 21](https://user-images.githubusercontent.com/8397116/100474994-d8e73680-30d9-11eb-85fd-f837313df74a.png)
![Screenshot 2020-11-27 at 17 39 43](https://user-images.githubusercontent.com/8397116/100474998-db499080-30d9-11eb-8024-3a378d7a004a.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
- [x] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
