### PR TITLE
fix(checkbox): fix the checkbox icon colour

### DIFF
--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -29,7 +29,7 @@
   border: var(--border-width) solid var(--toggle-border-color);
   margin: var(--space-xxxs) var(--space-sm) auto 0;
   font-size: 0.8rem;
-  color: var(--toggle-checkbox-color);
+  color: transparent;
 
   &.lg-icon > svg {
     display: inline-block;


### PR DESCRIPTION
# Description

The checkbox icon colour was set to be white when unchecked causing issues
when a background is present.

Storybook link: https://deploy-preview-92--legal-and-general-canopy.netlify.app/
Screenshot: 
![Screenshot 2020-11-30 at 16 45 21](https://user-images.githubusercontent.com/8397116/100638692-396db200-332c-11eb-940a-0914a103ffb5.png)
 
# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
