### PR TITLE
fix(forms): fix bg colour on form fields

### DIFF
--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -10,7 +10,6 @@
 
   display: block;
   margin-bottom: var(--component-margin);
-  background-color: var(--color-white);
   line-height: var(--line-height-sm);
 
   &__prefix,
@@ -58,6 +57,7 @@
   &__inputs {
     display: inline-flex;
     align-items: center;
+    background-color: var(--color-white);
     border: solid var(--border-width) var(--border-color);
     border-radius: var(--border-radius-sm);
 

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -37,6 +37,7 @@
     display: inline-block;
     height: var(--toggle-outer-height);
     width: var(--toggle-outer-width);
+    background-color: var(--color-white);
     border-radius: 50%;
     border: var(--border-width) solid var(--border-color);
     margin: auto var(--space-sm) auto 0;

--- a/projects/canopy/src/lib/forms/select/select-field.component.scss
+++ b/projects/canopy/src/lib/forms/select/select-field.component.scss
@@ -4,7 +4,6 @@
 .lg-select-field {
   display: block;
   margin-bottom: var(--component-margin);
-  background-color: var(--color-white);
   line-height: var(--line-height-sm);
 }
 
@@ -13,9 +12,10 @@
 }
 
 .lg-select-field__inner {
-  position: relative;
   display: inline-block;
+  background-color: var(--color-white);
   max-width: 100%;
+  position: relative;
 
   &--block {
     width: 100%;

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -26,10 +26,11 @@
 }
 
 .lg-toggle__label > .lg-toggle__checkbox {
+  background-color: var(--color-white);
   border: var(--border-width) solid var(--toggle-border-color);
-  margin: var(--space-xxxs) var(--space-sm) auto 0;
-  font-size: 0.8rem;
   color: transparent;
+  font-size: 0.8rem;
+  margin: var(--space-xxxs) var(--space-sm) auto 0;
 
   &.lg-icon > svg {
     display: inline-block;


### PR DESCRIPTION
# Description

The `background-color` of the form fields was applied to the wrong elements. I've now moved it to the input tags.

Storybook link: (once netlify has deployed link provide a link to the component)
Screenshot:
![Screenshot 2020-12-02 at 15 43 34](https://user-images.githubusercontent.com/8397116/100896353-6ea60b80-34b6-11eb-9ecd-84bb34690462.png)
![Screenshot 2020-12-02 at 15 53 40](https://user-images.githubusercontent.com/8397116/100896540-a01ed700-34b6-11eb-83a9-b24fe409787b.png)
(Ignore the text colour against the background as i picked the first colour available in storybook)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
