### PR TITLE
ci(next): add capability to release next branch

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
     tags-ignore:
       - '*'
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "branches": [ "master", {"name": "next", "prerelease": true} ],
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,6 +61,8 @@ Be particularly aware of any changes which may be deemed a breaking change. Refe
 
 The format for breaking changes is outlined on the [convention commit docs](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-with-description-and-breaking-change-in-body)
 
+Whenever introducing a breaking change consider using the `next` branch. Refer to the [next docs](./NEXT_BRANCH.md).
+
 ### Commit message examples
 
 Fix

--- a/docs/NEXT_BRANCH.md
+++ b/docs/NEXT_BRANCH.md
@@ -1,0 +1,12 @@
+# Pre-release `next` branch
+
+The `next` branch allows the library to be published with a pre-release version. This branch should only be used sporadically in case of a major breaking change, for example the upgrade to a major version of Angular.
+
+For additional information check the [semantic release docs](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#pre-release-branches).
+
+## The workflow
+1. Create a branch called `next` from the latest master
+2. Create the feature branch
+3. Once the work is complete merge the feature branch into `next`
+4. When happy with the pre-release, merge `next` into `master`
+5. Delete `next`


### PR DESCRIPTION
# Description

The `next` branch allows the library to be published with a pre-release version. 

## Requirements

Release major versions of the library without blocking other teams.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
