### PR TITLE
feat(table): add configurable showLabel property

### DIFF
--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.html
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.html
@@ -1,9 +1,17 @@
-<span #label aria-hidden="true" class="lg-table-cell__label">{{ columnLabel }}</span>
+<span
+  #label
+  [ngClass]="{
+    'lg-visually-hidden': !showLabel
+  }"
+  aria-hidden="true"
+  class="lg-table-cell__label"
+  >{{ columnLabel }}
+</span>
 <div
   #content
-  class="lg-table-cell__content"
   [ngClass]="{
-    'lg-table-cell__content--align-end': align === alignOptions.End
+    'lg-table-cell__content--align-end': align === alignOptions.End,
+    'lg-table-cell__content': showLabel
   }"
 >
   <ng-content></ng-content>

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.spec.ts
@@ -70,14 +70,52 @@ describe('LgTableCellComponent', () => {
     });
   });
 
+  describe('when showLabel is set to true', () => {
+    beforeEach(() => {
+      component.showLabel = true;
+      fixture.detectChanges();
+    });
+
+    it('should not set the lg-visually-hidden class', () => {
+      const labelElement = debugElement.query(By.css('.lg-table-cell__label'));
+      expect(labelElement.nativeElement.getAttribute('class')).not.toContain(
+        'lg-visually-hidden',
+      );
+    });
+
+    it('should set the content class', () => {
+      const contentElement = debugElement.query(By.css('.lg-table-cell__content'));
+      expect(contentElement.nativeElement).toBeDefined();
+    });
+  });
+
+  describe('when showLabel is set to false', () => {
+    beforeEach(() => {
+      component.showLabel = false;
+      fixture.detectChanges();
+    });
+
+    it('should set the lg-visually-hidden class', () => {
+      const labelElement = debugElement.query(By.css('.lg-table-cell__label'));
+      expect(labelElement.nativeElement.getAttribute('class')).toContain(
+        'lg-visually-hidden',
+      );
+    });
+
+    it('should not set the content class', () => {
+      const contentElement = debugElement.query(By.css('.lg-table-cell__content'));
+      expect(contentElement).toBe(null);
+    });
+  });
+
   describe('when there is a expandable detail', () => {
     beforeEach(() => {
-      fixture = MockRender(`
+      fixture = (MockRender(`
         <td lg-table-cell>
           <lg-table-expanded-detail>
           </lg-table-expanded-detail>
         </td>
-      `);
+      `) as unknown) as ComponentFixture<LgTableCellComponent>;
     });
 
     it('should set the expanding detail class', () => {

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.ts
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.ts
@@ -91,7 +91,19 @@ export class LgTableCellComponent {
     return this._align;
   }
 
+  set showLabel(showLabel: boolean) {
+    this._showLabel = showLabel;
+
+    this.cd.detectChanges();
+  }
+
+  get showLabel() {
+    return this._showLabel;
+  }
+
   private _align: AlignmentOptions = AlignmentOptions.Start;
+
+  private _showLabel = true;
 
   private _columnLabel = '';
 

--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.ts
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.ts
@@ -25,6 +25,7 @@ export class LgTableHeadCellComponent {
   }
 
   @Input() align: AlignmentOptions = AlignmentOptions.Start;
+  @Input() showLabel = true;
 
   constructor(public element: ElementRef) {}
 }

--- a/projects/canopy/src/lib/table/table.interface.ts
+++ b/projects/canopy/src/lib/table/table.interface.ts
@@ -6,4 +6,5 @@ export enum AlignmentOptions {
 export interface TableColumn {
   label: string;
   align: AlignmentOptions;
+  showLabel: boolean;
 }

--- a/projects/canopy/src/lib/table/table.notes.ts
+++ b/projects/canopy/src/lib/table/table.notes.ts
@@ -93,6 +93,7 @@ A component that acts as a standard table header cell.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`align\`\` | Alignment option for the header and its respective column | \`\`start\`\`, \`\`end\`\` | n/a | No |
+| \`\`showLabel\`\` | Whether to show label for this header in each row on mobile | boolean | true | No |
 
 ### LgTableRowComponent
 A component that acts as a standard table row.

--- a/projects/canopy/src/lib/table/table.stories.ts
+++ b/projects/canopy/src/lib/table/table.stories.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Component, Input } from '@angular/core';
 
-import { object, select, withKnobs } from '@storybook/addon-knobs';
+import { boolean, object, select, withKnobs } from '@storybook/addon-knobs';
 import { moduleMetadata } from '@storybook/angular';
 
 import { AlignmentOptions } from './table.interface';
@@ -22,7 +22,7 @@ interface TableStoryItem {
           <th scope="col" lg-table-head-cell>
             <span class="lg-visually-hidden">Toggle</span>
           </th>
-          <th lg-table-head-cell>Author</th>
+          <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
           <th lg-table-head-cell>Book</th>
           <th lg-table-head-cell [align]="alignPublishColumn">Published</th>
         </tr>
@@ -59,6 +59,7 @@ export class StoryTableDetailComponent {
   @Input() books: Array<TableStoryItem> = [];
 
   @Input() alignPublishColumn: AlignmentOptions;
+  @Input() showAuthorLabel: boolean;
 
   @Input() expandedRows: Array<number> = [];
 
@@ -108,7 +109,7 @@ export const standard = () => ({
     <table lg-table>
       <thead lg-table-head>
         <tr lg-table-row>
-          <th lg-table-head-cell>Author</th>
+          <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
           <th lg-table-head-cell [align]="alignTitleColumn">Title</th>
           <th lg-table-head-cell [align]="alignPublishColumn">Published</th>
         </tr>
@@ -125,7 +126,7 @@ export const standard = () => ({
   `,
 
   props: {
-    books: object('Books', getDefultTableContent(), 'lg-table'),
+    books: object('Books', getDefaultTableContent(), 'lg-table'),
     alignTitleColumn: select(
       'Align Title column',
       [AlignmentOptions.End, AlignmentOptions.Start],
@@ -136,24 +137,26 @@ export const standard = () => ({
       [AlignmentOptions.End, AlignmentOptions.Start],
       AlignmentOptions.End,
     ),
+    showAuthorLabel: boolean('Display author label on mobile', false, 'lg-table'),
   },
 });
 
 export const detail = () => ({
-  template: `<story-table-detail [books]="books" [alignPublishColumn]="alignPublishColumn"></story-table-detail>`,
+  template: `<story-table-detail [books]="books" [alignPublishColumn]="alignPublishColumn" [showAuthorLabel]="showAuthorLabel"></story-table-detail>`,
 
   props: {
-    books: object('Books', getDefultTableContent(), 'lg-table'),
+    books: object('Books', getDefaultTableContent(), 'lg-table'),
     alignPublishColumn: select(
       'Published column alignment',
       [AlignmentOptions.Start, AlignmentOptions.End],
       AlignmentOptions.End,
       'lg-table',
     ),
+    showAuthorLabel: boolean('Display author label on mobile', false, 'lg-table'),
   },
 });
 
-function getDefultTableContent(): Array<TableStoryItem> {
+function getDefaultTableContent(): Array<TableStoryItem> {
   return [
     {
       author: 'Orhan Pamuk',

--- a/projects/canopy/src/lib/table/table/table.component.spec.ts
+++ b/projects/canopy/src/lib/table/table/table.component.spec.ts
@@ -170,6 +170,70 @@ describe('TableComponent', () => {
     });
   });
 
+  describe('showLabel setting', () => {
+    describe('when showLabel is true', () => {
+      beforeEach(() => {
+        fixture = MockRender(getShowLabelMockRender(), {
+          showLabel: true,
+        });
+        debugElement = fixture.debugElement;
+        tableDebugElement = debugElement.query(By.directive(LgTableComponent));
+        fixture.detectChanges();
+      });
+
+      it('should add the lg-table-cell__content class to the table cell', () => {
+        const [titleCell] = tableDebugElement.queryAll(
+          By.directive(LgTableCellComponent),
+        );
+
+        expect(titleCell.query(By.css('.lg-table-cell__content'))).toBeDefined();
+      });
+
+      it('should not add the lg-visually-hidden class to the label', () => {
+        const [titleCell] = tableDebugElement.queryAll(
+          By.directive(LgTableCellComponent),
+        );
+
+        expect(
+          titleCell
+            .query(By.css('.lg-table-cell__label'))
+            .nativeElement.getAttribute('class'),
+        ).not.toContain('lg-visually-hidden');
+      });
+    });
+
+    describe('when showLabel is false', () => {
+      beforeEach(() => {
+        fixture = MockRender(getShowLabelMockRender(), {
+          showLabel: false,
+        });
+        debugElement = fixture.debugElement;
+        tableDebugElement = debugElement.query(By.directive(LgTableComponent));
+        fixture.detectChanges();
+      });
+
+      it('should not add the lg-table-cell__content class to the table cell', () => {
+        const [titleCell] = tableDebugElement.queryAll(
+          By.directive(LgTableCellComponent),
+        );
+
+        expect(titleCell.query(By.css('.lg-table-cell__content'))).toBe(null);
+      });
+
+      it('should add the lg-visually-hidden class to the label', () => {
+        const [titleCell] = tableDebugElement.queryAll(
+          By.directive(LgTableCellComponent),
+        );
+
+        expect(
+          titleCell
+            .query(By.css('.lg-table-cell__label'))
+            .nativeElement.getAttribute('class'),
+        ).toContain('lg-visually-hidden');
+      });
+    });
+  });
+
   describe('when there is an expanded detail', () => {
     let headerRow: DebugElement;
     let bodyRow: DebugElement;
@@ -264,6 +328,23 @@ describe('TableComponent', () => {
       expect(clickSpy).toHaveBeenCalledWith(0);
     });
   });
+
+  function getShowLabelMockRender() {
+    return `
+    <table lg-table>
+      <thead lg-table-head>
+        <tr lg-table-row>
+          <th lg-table-head-cell [showLabel]="showLabel">Title</th>
+        </tr>
+      </thead>
+
+      <tbody lg-table-body>
+        <tr lg-table-row>
+          <td lg-table-cell>Accelerate: The Science of Lean Software and Devops</td>
+        </tr>
+      </tbody>
+    </table>`;
+  }
 
   function getAlignmentMockRender() {
     return `

--- a/projects/canopy/src/lib/table/table/table.component.ts
+++ b/projects/canopy/src/lib/table/table/table.component.ts
@@ -63,6 +63,7 @@ export class LgTableComponent implements AfterContentChecked {
       this.columns.set(cellIndex, {
         align: cell.align,
         label: cell.element.nativeElement.innerHTML,
+        showLabel: cell.showLabel,
       });
     });
   }
@@ -83,8 +84,11 @@ export class LgTableComponent implements AfterContentChecked {
         row.bodyCells
           .filter((cell) => !cell.expandableDetail)
           .forEach((cell, cellIndex) => {
-            cell.align = this.columns.get(cellIndex).align;
-            cell.label.nativeElement.innerHTML = this.columns.get(cellIndex).label;
+            const { align, showLabel, label } = this.columns.get(cellIndex);
+
+            cell.align = align;
+            cell.showLabel = showLabel;
+            cell.label.nativeElement.innerHTML = label;
             cell.tableId = this.id;
           });
 


### PR DESCRIPTION
# Description

Adds the ability to configure whether the contents of a `table-head-cell` are displayed in each row on mobile. This is useful for the project I'm working on where the first column's value is long and self explanatory.

The default value for `showLabel` is true, but if set to false, the label is visually hidden; so it is still available to screen readers but not on screen.

## Requirements

The story has a new knob for toggling the label on the Author column of the example table.

1. Set viewport in Story to mobile.
2. Set `Display author label on mobile` to false
3. Observe that label for *Author* does not appear in each row
4. Set `Display author label on mobile` to true
5. Observe that label for *Author* appears in each row

Storybook link:

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story