### PR TITLE
feat(card): add form journey card type

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -89,237 +89,285 @@
     <div lgRow>
       <div lgCol="12" lgColLg="9" lgColMdOffset="0">
         <lg-card lgPaddingTop="none">
-          <lg-tabs [headingLevel]="2" label="Annuities">
-            <lg-tab-item>
-              <lg-tab-item-heading>Tab 1</lg-tab-item-heading>
-              <lg-tab-item-content>
-                <div class="lg-tabs__content-section">
-                  <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere
-                    nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna
-                    felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend
-                    mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus
-                    efficitur, elementum mauris in, porta nisl. Praesent porttitor
-                    accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo.
-                    Aenean magna lacus, iaculis at velit non, congue commodo dui.
-                    Pellentesque tempus elementum tempor.
-                  </p>
-                </div>
-              </lg-tab-item-content>
-            </lg-tab-item>
-            <lg-tab-item>
-              <lg-tab-item-heading>Tab 2</lg-tab-item-heading>
-              <lg-tab-item-content>
-                <div class="lg-tabs__content-section">
-                  <p>
-                    Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus
-                    eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis
-                    orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus.
-                    Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque
-                    ante, eget tempus dui. Fusce semper ex eu lorem pellentesque
-                    tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis
-                    luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis
-                    feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce
-                    facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero
-                    laoreet hendrerit at quis magna.
-                  </p>
-                </div>
-              </lg-tab-item-content>
-            </lg-tab-item>
-            <lg-tab-item>
-              <lg-tab-item-heading>Tab 3</lg-tab-item-heading>
-              <lg-tab-item-content>
-                <div class="lg-tabs__content-section">
-                  <p>
-                    Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna.
-                    Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit
-                    egestas pellentesque a quis nunc. Praesent commodo risus in metus
-                    tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit
-                    pellentesque a. Proin et varius ante, nec venenatis nulla.
-                    Pellentesque pharetra risus lorem, et congue ligula interdum volutpat.
-                    Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum.
-                    Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante
-                    id, ullamcorper tristique libero. Praesent imperdiet, orci in
-                    tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus
-                    sed lacus. Suspendisse ut tortor dui.
-                  </p>
-                </div>
-              </lg-tab-item-content>
-            </lg-tab-item>
-            <lg-tab-item>
-              <lg-tab-item-heading>Tab 4</lg-tab-item-heading>
-              <lg-tab-item-content>
-                <div class="lg-tabs__content-section">
-                  <p>
-                    Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et
-                    efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et
-                    lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec.
-                    Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo.
-                    Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis
-                    augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend
-                    magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor
-                    sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu
-                    ante ornare sollicitudin in et est.
-                  </p>
-                </div>
-              </lg-tab-item-content>
-            </lg-tab-item>
-          </lg-tabs>
+          <lg-card-content>
+            <lg-tabs [headingLevel]="2" label="Annuities">
+              <lg-tab-item>
+                <lg-tab-item-heading>Tab 1</lg-tab-item-heading>
+                <lg-tab-item-content>
+                  <div class="lg-tabs__content-section">
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere
+                      nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna
+                      felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend
+                      mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus
+                      efficitur, elementum mauris in, porta nisl. Praesent porttitor
+                      accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo.
+                      Aenean magna lacus, iaculis at velit non, congue commodo dui.
+                      Pellentesque tempus elementum tempor.
+                    </p>
+                  </div>
+                </lg-tab-item-content>
+              </lg-tab-item>
+              <lg-tab-item>
+                <lg-tab-item-heading>Tab 2</lg-tab-item-heading>
+                <lg-tab-item-content>
+                  <div class="lg-tabs__content-section">
+                    <p>
+                      Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus
+                      eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis
+                      orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus.
+                      Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque
+                      ante, eget tempus dui. Fusce semper ex eu lorem pellentesque
+                      tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis
+                      luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis
+                      feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce
+                      facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero
+                      laoreet hendrerit at quis magna.
+                    </p>
+                  </div>
+                </lg-tab-item-content>
+              </lg-tab-item>
+              <lg-tab-item>
+                <lg-tab-item-heading>Tab 3</lg-tab-item-heading>
+                <lg-tab-item-content>
+                  <div class="lg-tabs__content-section">
+                    <p>
+                      Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna.
+                      Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit
+                      egestas pellentesque a quis nunc. Praesent commodo risus in metus
+                      tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit
+                      pellentesque a. Proin et varius ante, nec venenatis nulla.
+                      Pellentesque pharetra risus lorem, et congue ligula interdum volutpat.
+                      Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum.
+                      Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante
+                      id, ullamcorper tristique libero. Praesent imperdiet, orci in
+                      tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus
+                      sed lacus. Suspendisse ut tortor dui.
+                    </p>
+                  </div>
+                </lg-tab-item-content>
+              </lg-tab-item>
+              <lg-tab-item>
+                <lg-tab-item-heading>Tab 4</lg-tab-item-heading>
+                <lg-tab-item-content>
+                  <div class="lg-tabs__content-section">
+                    <p>
+                      Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et
+                      efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et
+                      lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec.
+                      Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo.
+                      Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis
+                      augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend
+                      magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor
+                      sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu
+                      ante ornare sollicitudin in et est.
+                    </p>
+                  </div>
+                </lg-tab-item-content>
+              </lg-tab-item>
+            </lg-tabs>
 
-          <lg-tab-nav-bar label="Test nav tabs">
-            <a
-              id="nav-tab-{{ i }}"
-              *ngFor="let tab of tabs; index as i"
-              [routerLink]="[tab.path]"
-              [isActive]="selectedTabIndex === i"
-              (click)="handleTabClick($event, i)"
-              lgTabNavBarLink
-              >{{ tab.label }}</a
-            >
-          </lg-tab-nav-bar>
-
-          <lg-tab-nav-content [selectedTabId]="'nav-tab-' + selectedTabIndex">
-            <router-outlet></router-outlet>
-          </lg-tab-nav-content>
-
-          <lg-accordion [headingLevel]="3">
-            <lg-accordion-item>
-              <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-                tempor incididunt ut labore et dolore magna aliqua.
-              </p>
-            </lg-accordion-item>
-            <lg-accordion-item>
-              <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>
-              <p>
-                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-                aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-                voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-              </p>
-              <button lg-button lgMarginTop="sm" variant="solid-primary">
-                Test primary button
-              </button>
-            </lg-accordion-item>
-          </lg-accordion>
-
-          <lg-alert variant="info">
-            <lg-heading level="4">Test heading</lg-heading>
-            Information alert
-          </lg-alert>
-
-          <lg-alert variant="warning"> Warning alert </lg-alert>
-
-          <lg-alert variant="success"> Success alert </lg-alert>
-
-          <lg-alert variant="error" lgMarginBottom="xxxl"> Error alert </lg-alert>
-
-          <lg-alert variant="generic">
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-              <li>Item 4</li>
-            </ul>
-          </lg-alert>
-
-          <lg-card>
-            <lg-card-header>
-              <lg-card-title headingLevel="4"> Test card title </lg-card-title>
-            </lg-card-header>
-            <lg-card-content> Test card content </lg-card-content>
-          </lg-card>
-
-          <lg-card>
-            <lg-card-header>
-              <lg-card-title headingLevel="4">
-                <a href="#">Product card title</a>
-              </lg-card-title>
-              <lg-card-subtitle> Payroll Reference Number P23456 </lg-card-subtitle>
-              <lg-card-principle-data-point>
-                <lg-card-principle-data-point-label>
-                  Last payment (after tax and deductions)
-                </lg-card-principle-data-point-label>
-                <lg-card-principle-data-point-value>
-                  <span><span class="lg-font-size-3">£</span>230.20</span>
-                </lg-card-principle-data-point-value>
-                <lg-card-principle-data-point-date>
-                  as of 01 Jan 2020
-                </lg-card-principle-data-point-date>
-              </lg-card-principle-data-point>
-            </lg-card-header>
-          </lg-card>
-
-          <button lg-button variant="solid-primary">Solid primary button</button>
-          <br />
-
-          <button lg-button variant="solid-secondary">Solid secondary button</button>
-          <br />
-
-          <button lg-button variant="outline-primary">Outline primary button</button>
-          <br />
-
-          <button lg-button variant="outline-secondary">Outline secondary button</button>
-          <br />
-
-          <button lg-button variant="solid-primary" [loading]="true">
-            Loading button
-          </button>
-          <br />
-
-          <button lg-button variant="solid-secondary">
-            Button with icon
-            <lg-icon name="add"></lg-icon>
-          </button>
-          <br />
-
-          <button lg-button variant="outline-primary" iconPosition="left">
-            Button with left aligned icon
-            <lg-icon name="arrow-down"></lg-icon>
-          </button>
-          <br />
-
-          <button lg-button variant="solid-primary" [iconButton]="true">
-            Icon Button
-            <lg-icon name="close"></lg-icon>
-          </button>
-          <br />
-
-          <button lg-button variant="solid-primary" size="sm">
-            Small button
-          </button>
-          <br />
-
-          <button lg-button variant="solid-primary" size="sm" [loading]="true">
-            Small button
-          </button>
-          <br />
-
-          <lg-separator></lg-separator>
-
-          <form [formGroup]="form" (ngSubmit)="onSubmit(form)">
-            <lg-input-field>
-              Text input
-              <lg-hint>Enter some text</lg-hint>
-              <input lgInput formControlName="text" />
-            </lg-input-field>
-
-
-            <lg-input-field>
-              Text input with icon
-              <input lgInput formControlName="textSearch" />
-              <button
-                lg-button
-                lgSuffix
-                size="sm"
-                [iconButton]="true"
+            <lg-tab-nav-bar label="Test nav tabs">
+              <a
+                id="nav-tab-{{ i }}"
+                *ngFor="let tab of tabs; index as i"
+                [routerLink]="[tab.path]"
+                [isActive]="selectedTabIndex === i"
+                (click)="handleTabClick($event, i)"
+                lgTabNavBarLink
+                >{{ tab.label }}</a
               >
-                Search
-                <lg-icon name="search"></lg-icon>
-              </button>
-            </lg-input-field>
+            </lg-tab-nav-bar>
 
-            <lg-input-field>
+            <lg-tab-nav-content [selectedTabId]="'nav-tab-' + selectedTabIndex">
+              <router-outlet></router-outlet>
+            </lg-tab-nav-content>
+
+            <lg-accordion [headingLevel]="3">
+              <lg-accordion-item>
+                <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>
+                <p>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+                  tempor incididunt ut labore et dolore magna aliqua.
+                </p>
+              </lg-accordion-item>
+              <lg-accordion-item>
+                <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>
+                <p>
+                  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                  aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+                  voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                </p>
+                <button lg-button lgMarginTop="sm" variant="solid-primary">
+                  Test primary button
+                </button>
+              </lg-accordion-item>
+            </lg-accordion>
+
+            <lg-alert variant="info">
+              <lg-heading level="4">Test heading</lg-heading>
+              Information alert
+            </lg-alert>
+
+            <lg-alert variant="warning"> Warning alert </lg-alert>
+
+            <lg-alert variant="success"> Success alert </lg-alert>
+
+            <lg-alert variant="error" lgMarginBottom="xxxl"> Error alert </lg-alert>
+
+            <lg-alert variant="generic">
+              <ul>
+                <li>Item 1</li>
+                <li>Item 2</li>
+                <li>Item 3</li>
+                <li>Item 4</li>
+              </ul>
+            </lg-alert>
+
+            <lg-card>
+              <lg-card-header>
+                <lg-card-title headingLevel="4"> Test card title </lg-card-title>
+              </lg-card-header>
+              <lg-card-content> Test card content </lg-card-content>
+            </lg-card>
+
+            <lg-card>
+              <lg-card-header>
+                <lg-card-title headingLevel="4">
+                  <a href="#">Product card title</a>
+                </lg-card-title>
+                <lg-card-subtitle> Payroll Reference Number P23456 </lg-card-subtitle>
+                <lg-card-principle-data-point>
+                  <lg-card-principle-data-point-label>
+                    Last payment (after tax and deductions)
+                  </lg-card-principle-data-point-label>
+                  <lg-card-principle-data-point-value>
+                    <span><span class="lg-font-size-3">£</span>230.20</span>
+                  </lg-card-principle-data-point-value>
+                  <lg-card-principle-data-point-date>
+                    as of 01 Jan 2020
+                  </lg-card-principle-data-point-date>
+                </lg-card-principle-data-point>
+              </lg-card-header>
+            </lg-card>
+
+            <div lgContainer>
+              <div lgRow>
+                <div lgCol="12" lgColLg="8" lgColLgOffset="2" lgColMd="10" lgColMdOffset="1">
+                  <lg-card lgPadding="none">
+                    <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
+                      <lg-breadcrumb lgMarginBottom="none">
+                        <lg-breadcrumb-item>
+                          <a href="#">
+                            <lg-icon [name]="'chevron-left'"></lg-icon>
+                            Back
+                          </a>
+                        </lg-breadcrumb-item>
+                      </lg-breadcrumb>
+                    </lg-card-header>
+                    <lg-card-content>
+                      <div lgContainer>
+                        <div lgRow>
+                          <div lgCol="12" lgColMd="10" lgColMdOffset="1">
+                            <lg-card-title headingLevel="4">
+                              Form Journey Card
+                            </lg-card-title>
+                            <lg-separator></lg-separator>
+                            <p>Form Journey card content</p>
+                            <lg-input-field>
+                              Account number
+                              <lg-hint>Must contain 8 digits</lg-hint>
+                              <input lgInput size="8"/>
+                            </lg-input-field>
+                          </div>
+                        </div>
+                      </div>
+                    </lg-card-content>
+                    <lg-card-footer>
+                      <div lgContainer>
+                        <div lgRow>
+                          <div lgCol="12" lgColMd="10" lgColMdOffset="1">
+                            <button lg-button type="button" variant="outline-primary" lgMarginRight="sm">Back</button>
+                            <button lg-button type="submit" variant="solid-primary">Confirm</button>
+                          </div>
+                        </div>
+                      </div>
+                    </lg-card-footer>
+                  </lg-card>
+                </div>
+              </div>
+            </div>
+
+            <button lg-button variant="solid-primary">Solid primary button</button>
+            <br />
+
+            <button lg-button variant="solid-secondary">Solid secondary button</button>
+            <br />
+
+            <button lg-button variant="outline-primary">Outline primary button</button>
+            <br />
+
+            <button lg-button variant="outline-secondary">Outline secondary button</button>
+            <br />
+
+            <button lg-button variant="solid-primary" [loading]="true">
+              Loading button
+            </button>
+            <br />
+
+            <button lg-button variant="solid-secondary">
+              Button with icon
+              <lg-icon name="add"></lg-icon>
+            </button>
+            <br />
+
+            <button lg-button variant="outline-primary" iconPosition="left">
+              Button with left aligned icon
+              <lg-icon name="arrow-down"></lg-icon>
+            </button>
+            <br />
+
+            <button lg-button variant="solid-primary" [iconButton]="true">
+              Icon Button
+              <lg-icon name="close"></lg-icon>
+            </button>
+            <br />
+
+            <button lg-button variant="solid-primary" size="sm">
+              Small button
+            </button>
+            <br />
+
+            <button lg-button variant="solid-primary" size="sm" [loading]="true">
+              Small button
+            </button>
+            <br />
+
+            <lg-separator></lg-separator>
+
+            <form [formGroup]="form" (ngSubmit)="onSubmit(form)">
+              <lg-input-field>
+                Text input
+                <lg-hint>Enter some text</lg-hint>
+                <input lgInput formControlName="text" />
+              </lg-input-field>
+
+
+              <lg-input-field>
+                Text input with icon
+                <input lgInput formControlName="textSearch" />
+                <button
+                  lg-button
+                  lgSuffix
+                  size="sm"
+                  [iconButton]="true"
+                >
+                  Search
+                  <lg-icon name="search"></lg-icon>
+                </button>
+              </lg-input-field>
+
+              <lg-input-field>
                 Text input with add-on icon
                 <input lgInput formControlName="textSearch" />
                 <button
@@ -338,146 +386,147 @@
                   size="sm"
                   [iconButton]="true"
                 >
-                Search
-                <lg-icon name="search"></lg-icon>
-              </button>
+                  Search
+                  <lg-icon name="search"></lg-icon>
+                </button>
               </lg-input-field>
 
-            <lg-input-field>
-              Text input with prefix
-              <input lgInput formControlName="textPound" />
-              <span lgPrefix>£</span>
-            </lg-input-field>
+              <lg-input-field>
+                Text input with prefix
+                <input lgInput formControlName="textPound" />
+                <span lgPrefix>£</span>
+              </lg-input-field>
 
-            <lg-input-field>
-              Text input with suffix
-              <input lgInput formControlName="textPercent" />
-              <span lgSuffix>%</span>
-            </lg-input-field>
+              <lg-input-field>
+                Text input with suffix
+                <input lgInput formControlName="textPercent" />
+                <span lgSuffix>%</span>
+              </lg-input-field>
 
-            <lg-select-field>
-              Select input
-              <lg-hint>Pick an option</lg-hint>
-              <select lgSelect formControlName="select">
-                <option value="blue">Blue</option>
-                <option value="yellow">Yellow</option>
-                <option value="green">Green</option>
-                <option value="red">Red</option>
-              </select>
-            </lg-select-field>
+              <lg-select-field>
+                Select input
+                <lg-hint>Pick an option</lg-hint>
+                <select lgSelect formControlName="select">
+                  <option value="blue">Blue</option>
+                  <option value="yellow">Yellow</option>
+                  <option value="green">Green</option>
+                  <option value="red">Red</option>
+                </select>
+              </lg-select-field>
 
-            <lg-date-field formControlName="date">
-              Date of birth
-              <lg-hint>e.g. 05 12 1980</lg-hint>
-            </lg-date-field>
+              <lg-date-field formControlName="date">
+                Date of birth
+                <lg-hint>e.g. 05 12 1980</lg-hint>
+              </lg-date-field>
 
-            <lg-checkbox-group formControlName="colors">
-              Test checkbox group
-              <lg-hint>This is a standard checkbox group</lg-hint>
-              <lg-toggle value="red">Red</lg-toggle>
-              <lg-toggle value="yellow">Yellow</lg-toggle>
-              <lg-toggle value="green">Green</lg-toggle>
-              <lg-toggle value="blue">Blue</lg-toggle>
-            </lg-checkbox-group>
+              <lg-checkbox-group formControlName="colors">
+                Test checkbox group
+                <lg-hint>This is a standard checkbox group</lg-hint>
+                <lg-toggle value="red">Red</lg-toggle>
+                <lg-toggle value="yellow">Yellow</lg-toggle>
+                <lg-toggle value="green">Green</lg-toggle>
+                <lg-toggle value="blue">Blue</lg-toggle>
+              </lg-checkbox-group>
 
-            <lg-toggle formControlName="checkbox"> Test checkbox </lg-toggle>
+              <lg-toggle formControlName="checkbox"> Test checkbox </lg-toggle>
 
-            <lg-toggle variant="switch" formControlName="switch">Test switch</lg-toggle>
+              <lg-toggle variant="switch" formControlName="switch">Test switch</lg-toggle>
 
-            <lg-radio-group formControlName="radio">
-              Test radio group
-              <lg-hint>Pick an option</lg-hint>
-              <lg-radio-button value="red">Red</lg-radio-button>
-              <lg-radio-button value="yellow">Yellow</lg-radio-button>
-              <lg-radio-button value="green">Green</lg-radio-button>
-              <lg-radio-button value="blue">Blue</lg-radio-button>
-            </lg-radio-group>
+              <lg-radio-group formControlName="radio">
+                Test radio group
+                <lg-hint>Pick an option</lg-hint>
+                <lg-radio-button value="red">Red</lg-radio-button>
+                <lg-radio-button value="yellow">Yellow</lg-radio-button>
+                <lg-radio-button value="green">Green</lg-radio-button>
+                <lg-radio-button value="blue">Blue</lg-radio-button>
+              </lg-radio-group>
 
 
-            <lg-segment-group formControlName="segment" value="top" stack="md">
-              Test segment
-              <lg-segment-button value="top">Top</lg-segment-button>
-              <lg-segment-button value="right">Right</lg-segment-button>
-              <lg-segment-button value="bottom">Bottom</lg-segment-button>
-            </lg-segment-group>
+              <lg-segment-group formControlName="segment" value="top" stack="md">
+                Test segment
+                <lg-segment-button value="top">Top</lg-segment-button>
+                <lg-segment-button value="right">Right</lg-segment-button>
+                <lg-segment-button value="bottom">Bottom</lg-segment-button>
+              </lg-segment-group>
 
-            <lg-filter-group formControlName="filter">
-              Test filter group
-              <lg-filter-button value="red">Red</lg-filter-button>
-              <lg-filter-button value="yellow">Yellow</lg-filter-button>
-              <lg-filter-button value="green">Green</lg-filter-button>
-              <lg-filter-button value="blue">Blue</lg-filter-button>
-            </lg-filter-group>
+              <lg-filter-group formControlName="filter">
+                Test filter group
+                <lg-filter-button value="red">Red</lg-filter-button>
+                <lg-filter-button value="yellow">Yellow</lg-filter-button>
+                <lg-filter-button value="green">Green</lg-filter-button>
+                <lg-filter-button value="blue">Blue</lg-filter-button>
+              </lg-filter-group>
 
-            <lg-filter-multiple-group formControlName="filters">
-              Test filter group, multiple selection
-              <lg-filter-checkbox value="red">Red</lg-filter-checkbox>
-              <lg-filter-checkbox value="yellow">Yellow</lg-filter-checkbox>
-              <lg-filter-checkbox value="green">Green</lg-filter-checkbox>
-              <lg-filter-checkbox value="blue">Blue</lg-filter-checkbox>
-            </lg-filter-multiple-group>
+              <lg-filter-multiple-group formControlName="filters">
+                Test filter group, multiple selection
+                <lg-filter-checkbox value="red">Red</lg-filter-checkbox>
+                <lg-filter-checkbox value="yellow">Yellow</lg-filter-checkbox>
+                <lg-filter-checkbox value="green">Green</lg-filter-checkbox>
+                <lg-filter-checkbox value="blue">Blue</lg-filter-checkbox>
+              </lg-filter-multiple-group>
 
-            <lg-sort-code formControlName="sortCode">
-              Sort Code
-              <lg-hint>Must be 6 digits long</lg-hint>
-            </lg-sort-code>
+              <lg-sort-code formControlName="sortCode">
+                Sort Code
+                <lg-hint>Must be 6 digits long</lg-hint>
+              </lg-sort-code>
 
-            <button lg-button type="submit" variant="solid-primary">Submit</button>
-          </form>
+              <button lg-button type="submit" variant="solid-primary">Submit</button>
+            </form>
 
-          <lg-separator></lg-separator>
+            <lg-separator></lg-separator>
 
-          <lg-spinner variant="dark"></lg-spinner>
+            <lg-spinner variant="dark"></lg-spinner>
 
-          <lg-spinner
-            variant="color"
-            text="Medium Spinner"
-            lgMarginTop="xxl"
-          ></lg-spinner>
+            <lg-spinner
+              variant="color"
+              text="Medium Spinner"
+              lgMarginTop="xxl"
+            ></lg-spinner>
 
-          <lg-spinner
-            variant="color"
-            text="Small spinner"
-            lgMarginTop="xxl"
-            size="sm"
-          ></lg-spinner>
+            <lg-spinner
+              variant="color"
+              text="Small spinner"
+              lgMarginTop="xxl"
+              size="sm"
+            ></lg-spinner>
 
-          <table lg-table>
-            <thead lg-table-head>
-              <tr lg-table-row>
-                <th scope="col" lg-table-head-cell>
-                  <span class="lg-visually-hidden">Toggle</span>
-                </th>
-                <th lg-table-head-cell>Author</th>
-                <th lg-table-head-cell>Book</th>
-                <th lg-table-head-cell align="end">Published</th>
-              </tr>
-            </thead>
-
-            <tbody lg-table-body>
-              <ng-container *ngFor="let item of expandedTableRowData; index as i">
+            <table lg-table>
+              <thead lg-table-head>
                 <tr lg-table-row>
-                  <td lg-table-cell>
-                    <lg-table-row-toggle
-                      (click)="toggleTableRow(i)"
-                      [isActive]="expandedTableRow === i"
-                    >
-                    </lg-table-row-toggle>
-                  </td>
-                  <td lg-table-cell>{{ item.author }}</td>
-                  <td lg-table-cell>{{ item.title }}</td>
-                  <td lg-table-cell>{{ item.published }}</td>
+                  <th scope="col" lg-table-head-cell>
+                    <span class="lg-visually-hidden">Toggle</span>
+                  </th>
+                  <th lg-table-head-cell>Author</th>
+                  <th lg-table-head-cell>Book</th>
+                  <th lg-table-head-cell align="end">Published</th>
                 </tr>
-                <tr lg-table-row [isHidden]="expandedTableRow !== i">
-                  <td lg-table-cell colspan="4">
-                    <lg-table-expanded-detail>
-                      This is the details section for {{ item.title }}
-                    </lg-table-expanded-detail>
-                  </td>
-                </tr>
-              </ng-container>
-            </tbody>
-          </table>
+              </thead>
+
+              <tbody lg-table-body>
+                <ng-container *ngFor="let item of expandedTableRowData; index as i">
+                  <tr lg-table-row>
+                    <td lg-table-cell>
+                      <lg-table-row-toggle
+                        (click)="toggleTableRow(i)"
+                        [isActive]="expandedTableRow === i"
+                      >
+                      </lg-table-row-toggle>
+                    </td>
+                    <td lg-table-cell>{{ item.author }}</td>
+                    <td lg-table-cell>{{ item.title }}</td>
+                    <td lg-table-cell>{{ item.published }}</td>
+                  </tr>
+                  <tr lg-table-row [isHidden]="expandedTableRow !== i">
+                    <td lg-table-cell colspan="4">
+                      <lg-table-expanded-detail>
+                        This is the details section for {{ item.title }}
+                      </lg-table-expanded-detail>
+                    </td>
+                  </tr>
+                </ng-container>
+              </tbody>
+            </table>
+          </lg-card-content>
         </lg-card>
       </div>
       <div lgCol="12" lgColLg="3" lgColMdOffset="0">

--- a/projects/canopy-test-app/src/app/app.component.ts
+++ b/projects/canopy-test-app/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
   lgIconArrowDown,
   lgIconClose,
   lgIconSearch,
+  lgIconChevronLeft,
 } from 'projects/canopy/src/lib/icon';
 
 @Component({
@@ -44,6 +45,7 @@ export class AppComponent {
       lgIconArrowDown,
       lgIconClose,
       lgIconSearch,
+      lgIconChevronLeft,
     ]);
     this.form = this.fb.group({
       text: [''],

--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.html
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.scss
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.scss
@@ -1,0 +1,7 @@
+@import '../../../styles/mixins.scss';
+
+.lg-card-footer {
+  display: block;
+  border-top: solid var(--border-width) var(--card-title-border-color);
+  padding-top: var(--space-lg);
+}

--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.spec.ts
@@ -1,19 +1,19 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { LgCardHeaderComponent } from './card-header.component';
+import { LgCardFooterComponent } from './card-footer.component';
 
-describe('LgCardHeaderComponent', () => {
-  let component: LgCardHeaderComponent;
-  let fixture: ComponentFixture<LgCardHeaderComponent>;
+describe('LgCardFooterComponent', () => {
+  let component: LgCardFooterComponent;
+  let fixture: ComponentFixture<LgCardFooterComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [LgCardHeaderComponent],
+      declarations: [LgCardFooterComponent],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(LgCardHeaderComponent);
+    fixture = TestBed.createComponent(LgCardFooterComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -23,6 +23,6 @@ describe('LgCardHeaderComponent', () => {
   });
 
   it('should contain the default class', () => {
-    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-card-header');
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-card-footer');
   });
 });

--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.ts
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.ts
@@ -6,12 +6,12 @@ import {
 } from '@angular/core';
 
 @Component({
-  selector: 'lg-card-header',
-  templateUrl: './card-header.component.html',
-  styleUrls: ['./card-header.component.scss'],
+  selector: 'lg-card-footer',
+  templateUrl: './card-footer.component.html',
+  styleUrls: ['./card-footer.component.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgCardHeaderComponent {
-  @HostBinding('class.lg-card-header') class = true;
+export class LgCardFooterComponent {
+  @HostBinding('class.lg-card-footer') class = true;
 }

--- a/projects/canopy/src/lib/card/card-header/card-header.component.html
+++ b/projects/canopy/src/lib/card/card-header/card-header.component.html
@@ -1,6 +1,3 @@
 <div class="lg-card-header__title">
   <ng-content></ng-content>
 </div>
-<div class="lg-card-header__data">
-  <ng-content select="lg-card-principle-data-point"></ng-content>
-</div>

--- a/projects/canopy/src/lib/card/card-header/card-header.component.scss
+++ b/projects/canopy/src/lib/card/card-header/card-header.component.scss
@@ -4,15 +4,12 @@
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+  border-bottom: solid var(--border-width) var(--card-title-border-color);
+  padding-bottom: var(--space-lg);
+  margin-bottom: var(--space-lg);
 
   @include lg-breakpoint('md') {
     flex-direction: row;
-  }
-
-  &--with-content {
-    border-bottom: solid var(--border-width) var(--card-title-border-color);
-    padding-bottom: var(--space-lg);
-    margin-bottom: var(--space-lg);
   }
 }
 
@@ -20,12 +17,5 @@
   @include lg-breakpoint('md') {
     flex: 1 1 0;
     margin-right: var(--space-lg);
-  }
-}
-
-.lg-card-header__data {
-  @include lg-breakpoint('md') {
-    text-align: right;
-    flex: 0 0 auto;
   }
 }

--- a/projects/canopy/src/lib/card/card-principle-data-point/card-principle-data-point.component.scss
+++ b/projects/canopy/src/lib/card/card-principle-data-point/card-principle-data-point.component.scss
@@ -6,5 +6,6 @@
   @include lg-breakpoint('md') {
     display: flex;
     flex-direction: column;
+    text-align: right;
   }
 }

--- a/projects/canopy/src/lib/card/card.component.html
+++ b/projects/canopy/src/lib/card/card.component.html
@@ -1,1 +1,3 @@
-<ng-content></ng-content>
+<ng-content select="lg-card-header"></ng-content>
+<ng-content select="lg-card-content"></ng-content>
+<ng-content select="lg-card-footer"></ng-content>

--- a/projects/canopy/src/lib/card/card.component.spec.ts
+++ b/projects/canopy/src/lib/card/card.component.spec.ts
@@ -1,11 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
 import { MockComponent, MockRender } from 'ng-mocks';
 
 import { LgCardContentComponent } from './card-content/card-content.component';
 import { LgCardHeaderComponent } from './card-header/card-header.component';
 import { LgCardComponent } from './card.component';
+import { LgCardFooterComponent } from './card-footer/card-footer.component';
 
 describe('LgCardComponent', () => {
   let component: LgCardComponent;
@@ -19,18 +21,16 @@ describe('LgCardComponent', () => {
         LgCardComponent,
         MockComponent(LgCardHeaderComponent),
         MockComponent(LgCardContentComponent),
+        MockComponent(LgCardFooterComponent),
       ],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = MockRender(`
-      <lg-card>
-      </lg-card>
-    `);
+    fixture = TestBed.createComponent(LgCardComponent);
     debugElement = fixture.debugElement;
     component = fixture.componentInstance;
-    el = debugElement.children[0].nativeElement;
+    el = debugElement.nativeElement;
     fixture.detectChanges();
   });
 
@@ -42,24 +42,24 @@ describe('LgCardComponent', () => {
     expect(el.getAttribute('class')).toContain('lg-card');
   });
 
-  describe('when there is lg-card-header', () => {
+  describe('when there is only lg-card-content', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-card>
-         <lg-card-header>Title</lg-card-header>
+         <lg-card-content>Content</lg-card-content>
         </lg-card>
       `);
 
-      component = localFixture.debugElement.children[0].componentInstance;
+      debugElement = localFixture.debugElement;
+      el = debugElement.children[0].nativeElement;
+      component = debugElement.children[0].componentInstance;
       localFixture.detectChanges();
     });
 
-    it('should expect first element to render', () => {
-      expect(component.lgCardHeaderComponent).toBeDefined();
-    });
-
-    it('should expect second element not to render', () => {
-      expect(component.lgCardContentComponent).toBeUndefined();
+    it('should expect card content to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardContentComponent)),
+      ).toBeDefined();
     });
   });
 
@@ -67,25 +67,90 @@ describe('LgCardComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-card>
-         <lg-card-header>Title</lg-card-header>
-         <lg-card-content>Card content</lg-card-content>
+         <lg-card-header>Top</lg-card-header>
+         <lg-card-content>Content</lg-card-content>
         </lg-card>
       `);
 
-      component = localFixture.debugElement.children[0].componentInstance;
+      debugElement = localFixture.debugElement;
+      el = debugElement.children[0].nativeElement;
+      component = debugElement.children[0].componentInstance;
       localFixture.detectChanges();
     });
 
-    it('should expect first element to render', () => {
-      expect(component.lgCardHeaderComponent).toBeDefined();
+    it('should expect card header to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardHeaderComponent)),
+      ).toBeDefined();
     });
 
-    it('should expect second element to render', () => {
-      expect(component.lgCardContentComponent).toBeDefined();
+    it('should expect card content to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardContentComponent)),
+      ).toBeDefined();
+    });
+  });
+
+  describe('when there is lg-card-content and lg-card-footer', () => {
+    beforeEach(() => {
+      const localFixture = MockRender(`
+        <lg-card>
+         <lg-card-content>Content</lg-card-content>
+         <lg-card-footer>Footer</lg-card-footer>
+        </lg-card>
+      `);
+
+      debugElement = localFixture.debugElement;
+      el = debugElement.children[0].nativeElement;
+      component = debugElement.children[0].componentInstance;
+      localFixture.detectChanges();
     });
 
-    it('should set show border to true', () => {
-      expect(component.lgCardHeaderComponent.hasContent).toBe(true);
+    it('should expect card content to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardContentComponent)),
+      ).toBeDefined();
+    });
+
+    it('should expect card footer to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardFooterComponent)),
+      ).toBeDefined();
+    });
+  });
+
+  describe('when there is lg-card-header, lg-card-content and lg-card-footer', () => {
+    beforeEach(() => {
+      const localFixture = MockRender(`
+        <lg-card>
+         <lg-card-header>Top</lg-card-header>
+         <lg-card-content>Content</lg-card-content>
+         <lg-card-footer>Footer</lg-card-footer>
+        </lg-card>
+      `);
+
+      debugElement = localFixture.debugElement;
+      el = debugElement.children[0].nativeElement;
+      component = debugElement.children[0].componentInstance;
+      localFixture.detectChanges();
+    });
+
+    it('should expect card header to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardHeaderComponent)),
+      ).toBeDefined();
+    });
+
+    it('should expect card content to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardContentComponent)),
+      ).toBeDefined();
+    });
+
+    it('should expect card footer to render', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgCardFooterComponent)),
+      ).toBeDefined();
     });
   });
 });

--- a/projects/canopy/src/lib/card/card.component.ts
+++ b/projects/canopy/src/lib/card/card.component.ts
@@ -1,14 +1,4 @@
-import {
-  AfterContentInit,
-  Component,
-  ContentChild,
-  HostBinding,
-  QueryList,
-  ViewEncapsulation,
-} from '@angular/core';
-
-import { LgCardContentComponent } from './card-content/card-content.component';
-import { LgCardHeaderComponent } from './card-header/card-header.component';
+import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'lg-card',
@@ -16,20 +6,6 @@ import { LgCardHeaderComponent } from './card-header/card-header.component';
   styleUrls: ['./card.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class LgCardComponent implements AfterContentInit {
+export class LgCardComponent {
   @HostBinding('class.lg-card') class = true;
-
-  @ContentChild(LgCardHeaderComponent)
-  lgCardHeaderComponent: LgCardHeaderComponent;
-
-  @ContentChild(LgCardContentComponent)
-  lgCardContentComponent: LgCardContentComponent;
-
-  cardContent: QueryList<LgCardContentComponent>;
-
-  ngAfterContentInit() {
-    if (this.lgCardHeaderComponent && this.lgCardContentComponent) {
-      this.lgCardHeaderComponent.hasContent = true;
-    }
-  }
 }

--- a/projects/canopy/src/lib/card/card.module.ts
+++ b/projects/canopy/src/lib/card/card.module.ts
@@ -13,11 +13,13 @@ import { LgCardTitleComponent } from './card-title/card-title.component';
 import { LgCardComponent } from './card.component';
 
 import { LgHeadingModule } from '../heading/heading.module';
+import { LgCardFooterComponent } from './card-footer/card-footer.component';
 
 const components = [
   LgCardComponent,
   LgCardHeaderComponent,
   LgCardTitleComponent,
+  LgCardFooterComponent,
   LgCardSubtitleComponent,
   LgCardPrincipleDataPointComponent,
   LgCardPrincipleDataPointLabelComponent,

--- a/projects/canopy/src/lib/card/card.notes.ts
+++ b/projects/canopy/src/lib/card/card.notes.ts
@@ -30,26 +30,84 @@ or for a Product card:
 
 ~~~html
 <lg-card>
-  <lg-card-header>
-    <lg-card-title headingLevel="3">
-      Card Title
-    </lg-card-title>
-    <lg-card-subtitle>
-      Payroll Reference Number P23456
-    </lg-card-subtitle>
-    <lg-card-principle-data-point>
-      <lg-card-principle-data-point-label>
-        Last payment (after tax and deductions)
-      </lg-card-principle-data-point-label>
-      <lg-card-principle-data-point-value>
-        <span><span class="lg-font-size-3">£</span>230.20</span>
-      </lg-card-principle-data-point-value>
-      <lg-card-principle-data-point-date>
-        as of 01 Jan 2020
-      </lg-card-principle-data-point-date>
-    </lg-card-principle-data-point>
-  </lg-card-header>
+  <lg-card-content>
+    <div lgRow>
+      <div lgCol="12" lgColMd="6">
+        <lg-card-title headingLevel="4">
+          <a href="#">{{title}}</a>.
+        </lg-card-title>
+        <lg-card-subtitle>
+          Payroll Reference Number P23456
+        </lg-card-subtitle>
+      </div>
+      <lg-card-principle-data-point lgCol="12" lgColMd="6">
+        <lg-card-principle-data-point-label>
+          Last payment (after tax and deductions)
+        </lg-card-principle-data-point-label>
+        <lg-card-principle-data-point-value>
+          <span><span class="lg-font-size-3">£</span>230.20</span>
+        </lg-card-principle-data-point-value>
+        <lg-card-principle-data-point-date>
+          as of 01 Jan 2020
+        </lg-card-principle-data-point-date>
+      </lg-card-principle-data-point>
+    </div>
+  </lg-card-content>
 </lg-card>
+~~~
+
+or for a Form Journey card:
+
+~~~html
+<div lgContainer>
+  <div lgRow>
+    <div lgCol="12" lgColLg="6" lgColLgOffset="3" lgColMd="10" lgColMdOffset="1">
+      <lg-card lgPadding="none">
+        <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
+          <lg-breadcrumb lgMarginBottom="none">
+            <lg-breadcrumb-item>
+              <a href="#">
+                <lg-icon [name]="'chevron-left'"></lg-icon>
+                Back
+              </a>
+            </lg-breadcrumb-item>
+          </lg-breadcrumb>
+        </lg-card-header>
+        <lg-card-content>
+          <div lgContainer>
+            <div lgRow>
+              <div lgCol="12" lgColMd="10" lgColMdOffset="1">
+                <lg-card-title headingLevel="4">
+                {{ title }}
+                </lg-card-title>
+                <lg-separator aria-hidden="true"></lg-separator>
+                <p>{{cardContent}}</p>
+                <lg-reactive-form
+                  (formSubmit)="formSubmit($event)"
+                  (inputChange)="inputChange($event)"
+                  [disabled]="disabled"
+                  [hint]="hint"
+                  [label]="label"
+                ></lg-reactive-form>
+              </div>
+            </div>
+          </div>
+        </lg-card-content>
+        <lg-card-footer>
+          <div lgContainer>
+            <div lgRow>
+              <div lgCol="12" lgColMd="10" lgColMdOffset="1">
+                <button lg-button type="button" variant="outline-primary" lgMarginRight="sm">Back</button>
+                <button lg-button type="submit" variant="solid-primary">Confirm</button>
+                <p *ngIf="policy" lgPaddingBottom="md">{{ policy }}</p>
+              </div>
+            </div>
+          </div>
+        </lg-card-footer>
+      </lg-card>
+    </div>
+  </div>
+</div>
 ~~~
 
 ### Inputs
@@ -61,10 +119,10 @@ Content projection slots
 | \`\`<default>\`\` | The main body content of the card
 
 ### LgCardHeaderComponent
-This is the primary layout section of the card component, it is used to contain the title, subtitle and principle value.
+This is the primary layout section of the card component, it is used to contain breadcrumbs or other similar content.
 
 ### LgCardTitleComponent
-This is where the main title should be provided. It should be located inside the card header.
+This is where the main title should be provided. It should be located inside the card content.
 
 ### Inputs
 
@@ -73,10 +131,10 @@ This is where the main title should be provided. It should be located inside the
 | \`\`headingLevel\`\` | The level of the card heading: \`\`1\`\`, \`\`2\`\`, \`\`3\`\`, \`\`4\`\`, \`\`5\`\`, \`\`6\`\` | number | n/a | Yes |
 
 ### LgCardSubtitleComponent
-If the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card header.
+If the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.
 
 ### LgCardPrincipleDataPoint
-Sometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card header which will controls it's layout
+Sometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card content which will control it's layout
 
 ### LgCardPrincipleDataPointValue
 This is where the value for the data point should be projected. It should be located inside the card principle data point
@@ -88,7 +146,10 @@ This is where the label for the data point should be projected. A data point sho
 This is where the date for the data point should be projected. It should be located inside the card principle data point
 
 ### LgCardContent
-This is the secondary layout section of the card component, it is used to contain secondary information.
+This is the secondary layout section of the card component, it is used to contain the cards main content.
+
+### LgCardFooter
+This is the footer layout section of the card component, it is used to contain call to action buttons as well as messages or hints.
 
 ### Using only the SCSS files
 Generate the markup as show in the example below, no current modifiers.
@@ -96,6 +157,8 @@ Generate the markup as show in the example below, no current modifiers.
 | Class | Description |
 |------|-------------|
 | \`\`lg-card\`\` | Adds styles to the outer card element |
+| \`\`lg-card-header\`\` | Adds styles to the header element |
+| \`\`lg-card-footer\`\` | Adds styles to the footer element |
 | \`\`lg-card-title\`\` | Adds styles to the outer card element |
 | \`\`lg-card-subtitle\`\` | Adds styles to the outer card element |
 | \`\`lg-card-principle-data-point\`\` | Adds styles to the outer principle-data-point element |
@@ -112,6 +175,9 @@ Generate the markup as show in the example below, no current modifiers.
     <div class="lg-card-content">
         Your content
     </div>
+    <div class="lg-card-footer">
+        Your footer
+    </div>
 </div>
 ~~~
 
@@ -121,15 +187,15 @@ When the content of a card is set in a nested grid you will need to suppress the
 
 ~~~html
 <lg-card lgPaddingHorizontal="none">
-  <div lgContainer>
-    <div lgRow>
-      <div lgCol="12" lgColMd="10" lgColMdOffset="1">
-        <lg-card-content>
+  <lg-card-content>
+    <div lgContainer>
+      <div lgRow>
+        <div lgCol="12" lgColMd="10" lgColMdOffset="1">
           Your content
-        </lg-card-content>
+        </div>
       </div>
     </div>
-  </div>
+  </lg-card-content>
 </lg-card>
 ~~~
 `;

--- a/projects/canopy/src/lib/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/card.stories.ts
@@ -1,11 +1,78 @@
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
+
+import { text, withKnobs, boolean } from '@storybook/addon-knobs';
 import { moduleMetadata } from '@storybook/angular';
+import { action } from '@storybook/addon-actions';
 
 import { LgCardModule } from '../card/card.module';
 import { LgGridModule } from '../grid/grid.module';
-
 import { LgPaddingModule } from '../spacing/padding/padding.module';
 import { notes } from './card.notes';
+import { LgMarginModule } from '../spacing/margin/margin.module';
+import { LgBreadcrumbModule } from '../breadcrumb/breadcrumb.module';
+import { LgIconModule } from '../icon/icon.module';
+import { LgButtonModule } from '../button/button.module';
+import { LgInputModule } from '../forms/input/input.module';
+import { LgLabelModule } from '../forms/label/label.module';
+import { LgHintModule } from '../forms/hint/hint.module';
+import { LgSeparatorModule } from '../separator/separator.module';
+import { iconsArray } from '../icon/icons.stories';
+import { LgIconRegistry } from '../icon/icon.registry';
+
+@Component({
+  selector: 'card-with-icons',
+  template: ` <ng-content></ng-content> `,
+})
+class CardWithIconsComponent {
+  icons = iconsArray;
+  constructor(private registry: LgIconRegistry) {
+    this.registry.registerIcons(this.icons);
+  }
+}
+
+@Component({
+  selector: 'lg-reactive-form',
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit(form)">
+      <lg-input-field [block]="block">
+        {{ label }}
+        <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
+        <input lgInput formControlName="accountNumber" size="8" />
+      </lg-input-field>
+    </form>
+  `,
+})
+class ReactiveFormComponent {
+  @Input()
+  set disabled(disabled: boolean) {
+    if (disabled === true) {
+      this.form.controls.accountNumber.disable();
+    } else {
+      this.form.controls.accountNumber.enable();
+    }
+  }
+  get disabled(): boolean {
+    return this.form.controls.accountNumber.disabled;
+  }
+
+  @Input() hint: string;
+  @Input() label: string;
+
+  @Output() inputChange: EventEmitter<void> = new EventEmitter();
+  @Output() formSubmit: EventEmitter<void> = new EventEmitter();
+
+  form: FormGroup;
+
+  constructor(public fb: FormBuilder) {
+    this.form = this.fb.group({ accountNumber: { value: '', disabled: false } });
+    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));
+  }
+
+  onSubmit(event): void {
+    this.formSubmit.emit(event);
+  }
+}
 
 export default {
   title: 'Components/Card',
@@ -13,7 +80,21 @@ export default {
     decorators: [
       withKnobs,
       moduleMetadata({
-        imports: [LgCardModule, LgGridModule, LgPaddingModule],
+        declarations: [ReactiveFormComponent, CardWithIconsComponent],
+        imports: [
+          ReactiveFormsModule,
+          LgInputModule,
+          LgLabelModule,
+          LgHintModule,
+          LgCardModule,
+          LgBreadcrumbModule,
+          LgIconModule,
+          LgButtonModule,
+          LgGridModule,
+          LgPaddingModule,
+          LgMarginModule,
+          LgSeparatorModule,
+        ],
       }),
     ],
     'in-dsm': {
@@ -53,15 +134,15 @@ export const standard = () => ({
 export const nestedGrid = () => ({
   template: `
   <lg-card lgPaddingHorizontal="none">
-    <div lgContainer>
-      <div lgRow>
-        <div lgCol="12" lgColMd="10" lgColMdOffset="1">
-          <lg-card-content>
+    <lg-card-content>
+      <div lgContainer>
+        <div lgRow>
+          <div lgCol="12" lgColMd="10" lgColMdOffset="1">
             {{cardContent}}
-          </lg-card-content>
+          </div>
         </div>
       </div>
-    </div>
+    </lg-card-content>
   </lg-card>
   `,
   props: {
@@ -78,28 +159,103 @@ export const nestedGrid = () => ({
 export const product = () => ({
   template: `
     <lg-card>
-      <lg-card-header>
-        <lg-card-title headingLevel="4">
-          <a href="#">{{title}}</a>.
-        </lg-card-title>
-        <lg-card-subtitle>
-          Payroll Reference Number P23456
-        </lg-card-subtitle>
-        <lg-card-principle-data-point>
-          <lg-card-principle-data-point-label>
-            Last payment (after tax and deductions)
-          </lg-card-principle-data-point-label>
-          <lg-card-principle-data-point-value>
-            <span><span class="lg-font-size-3">£</span>230.20</span>
-          </lg-card-principle-data-point-value>
-          <lg-card-principle-data-point-date>
-            as of 01 Jan 2020
-          </lg-card-principle-data-point-date>
-        </lg-card-principle-data-point>
-      </lg-card-header>
+      <lg-card-content>
+        <div lgRow>
+          <div lgCol="12" lgColMd="6">
+            <lg-card-title headingLevel="4">
+              <a href="#">{{title}}</a>.
+            </lg-card-title>
+            <lg-card-subtitle>
+              Payroll Reference Number P23456
+            </lg-card-subtitle>
+          </div>
+          <lg-card-principle-data-point lgCol="12" lgColMd="6">
+            <lg-card-principle-data-point-label>
+              Last payment (after tax and deductions)
+            </lg-card-principle-data-point-label>
+            <lg-card-principle-data-point-value>
+              <span><span class="lg-font-size-3">£</span>230.20</span>
+            </lg-card-principle-data-point-value>
+            <lg-card-principle-data-point-date>
+              as of 01 Jan 2020
+            </lg-card-principle-data-point-date>
+          </lg-card-principle-data-point>
+        </div>
+      </lg-card-content>
     </lg-card>
   `,
   props: {
     title: text('title', 'Standard Lifetime Annuity Joint Life Full'),
+  },
+});
+
+export const formJourney = () => ({
+  template: `
+    <div lgContainer>
+      <div lgRow>
+        <div lgCol="12" lgColLg="6" lgColLgOffset="3" lgColMd="10" lgColMdOffset="1">
+          <card-with-icons>
+            <lg-card lgPadding="none">
+              <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
+                <lg-breadcrumb lgMarginBottom="none">
+                  <lg-breadcrumb-item>
+                    <a href="#">
+                      <lg-icon [name]="'chevron-left'"></lg-icon>
+                      Back
+                    </a>
+                  </lg-breadcrumb-item>
+                </lg-breadcrumb>
+              </lg-card-header>
+              <lg-card-content>
+                <div lgContainer>
+                  <div lgRow>
+                    <div lgCol="12" lgColMd="10" lgColMdOffset="1">
+                      <lg-card-title headingLevel="4">
+                      {{ title }}
+                      </lg-card-title>
+                      <lg-separator aria-hidden="true"></lg-separator>
+                      <p>{{cardContent}}</p>
+                      <lg-reactive-form
+                        (formSubmit)="formSubmit($event)"
+                        (inputChange)="inputChange($event)"
+                        [disabled]="disabled"
+                        [hint]="hint"
+                        [label]="label"
+                      ></lg-reactive-form>
+                    </div>
+                  </div>
+                </div>
+              </lg-card-content>
+              <lg-card-footer>
+                <div lgContainer>
+                  <div lgRow>
+                    <div lgCol="12" lgColMd="10" lgColMdOffset="1">
+                      <button lg-button type="button" variant="outline-primary" lgMarginRight="sm">Back</button>
+                      <button lg-button type="submit" variant="solid-primary">Confirm</button>
+                      <p *ngIf="policy" lgPaddingBottom="md">{{ policy }}</p>
+                    </div>
+                  </div>
+                </div>
+              </lg-card-footer>
+            </lg-card>
+          </card-with-icons>
+        </div>
+      </div>
+    </div>
+  `,
+  props: {
+    title: text('title', 'New bank details'),
+    cardContent: text(
+      'cardContent',
+      `Any changes today are unlikely to be processed in time for your next payment, due no later January.`,
+    ),
+    disabled: boolean('disabled', false),
+    hint: text('hint', 'Must be 8 digits long'),
+    policy: text(
+      'policy',
+      'By completing this form you are confirming you have consent to share these details with us. See our privacy policy.',
+    ),
+    label: text('label', 'Account Number'),
+    inputChange: action('inputChange'),
   },
 });

--- a/projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts
+++ b/projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts
@@ -37,10 +37,10 @@ stories
         ],
       },
       template: `
-  <lg-card *lgFeatureToggle="'firstFeature'">Feature 1 showing</lg-card>
-  <lg-card *lgFeatureToggle="'secondFeature'">Feature 2 not showing</lg-card>
-  <lg-card *lgFeatureToggle="'thirdFeature'">Feature 3 showing</lg-card>
-  <lg-card *lgFeatureToggle="'fourthFeature'">Feature 4 not showing</lg-card>
+  <lg-card *lgFeatureToggle="'firstFeature'"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>
+  <lg-card *lgFeatureToggle="'secondFeature'"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>
+  <lg-card *lgFeatureToggle="'thirdFeature'"><lg-card-content>Feature 3 showing</lg-card-content></lg-card>
+  <lg-card *lgFeatureToggle="'fourthFeature'"><lg-card-content>Feature 4 not showing</lg-card-content></lg-card>
   `,
     }),
     {

--- a/projects/canopy/src/lib/grid/grid.stories.ts
+++ b/projects/canopy/src/lib/grid/grid.stories.ts
@@ -36,7 +36,9 @@ stories
                 [lgColLgOffset]="firstColLgOffset"
               >
               <lg-card lgMarginHorizontal="none">
-                ${firstColGroupId}
+                <lg-card-content>
+                  ${firstColGroupId}
+                </lg-card-content>
               </lg-card>
             </div>
             <div
@@ -48,7 +50,9 @@ stories
                 [lgColLgOffset]="secondColLgOffset"
               >
               <lg-card lgMarginHorizontal="none">
-              ${secondColGroupId}
+                <lg-card-content>
+                  ${secondColGroupId}
+                </lg-card-content>
               </lg-card>
             </div>
             <div
@@ -60,7 +64,9 @@ stories
                 [lgColLgOffset]="thirdColLgOffset"
               >
               <lg-card lgMarginHorizontal="none">
-                ${thirdColGroupId}
+                <lg-card-content>
+                  ${thirdColGroupId}
+                </lg-card-content>
               </lg-card>
             </div>
           </div>

--- a/projects/canopy/src/lib/hero/hero.stories.ts
+++ b/projects/canopy/src/lib/hero/hero.stories.ts
@@ -10,7 +10,8 @@ const bodyHTML = `
     <div lgRow>
       <div lgCol="12">
         <lg-card>
-          <p>
+          <lg-card-content>
+            <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Fusce iaculis nunc vel pulvinar molestie. Quisque porta
             interdum ligula, in pellentesque purus ultrices sed.
@@ -21,7 +22,8 @@ const bodyHTML = `
             at mattis efficitur. Nunc tempor auctor enim, in hendrerit
             neque blandit sit amet. Donec efficitur mauris ut molestie
             lobortis. Integer nec consectetur odio, ut aliquam tortor.
-          </p>
+            </p>
+          </lg-card-content>
         </lg-card>
       </div>
     </div>

--- a/projects/canopy/src/lib/page/page.notes.ts
+++ b/projects/canopy/src/lib/page/page.notes.ts
@@ -28,8 +28,8 @@ and in your HTML:
           lgColLg="6"
           lgColLgOffset="3"
         >
-        <lg-card lgMarginHorizontal="none">{{card1Content}}</lg-card>
-        <lg-card lgMarginHorizontal="none">{{card2Content}}</lg-card>
+        <lg-card lgMarginHorizontal="none"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>
+        <lg-card lgMarginHorizontal="none"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>
       </div>
     </div>
   </div>

--- a/projects/canopy/src/lib/page/page.stories.ts
+++ b/projects/canopy/src/lib/page/page.stories.ts
@@ -95,8 +95,8 @@ export const oneColumn = () => ({
               lgColMdOffset="2"
               lgColLg="6"
               lgColLgOffset="3">
-            <lg-card lgMarginHorizontal="none">{{card1Content}}</lg-card>
-            <lg-card lgMarginHorizontal="none">{{card2Content}}</lg-card>
+            <lg-card lgMarginHorizontal="none"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>
+            <lg-card lgMarginHorizontal="none"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>
           </div>
         </div>
       </div>
@@ -114,13 +114,15 @@ export const twoColumn = () => ({
         <div lgRow>
           <div lgCol="12" lgColMd="8" lgColLg="5" lgColLgOffset="2">
             <lg-card lgMarginHorizontal="none">
-              {{card1Content}}
-              {{card3Content}}
+              <lg-card-content>
+                {{card1Content}}
+                {{card3Content}}
+              </lg-card-content>
             </lg-card>
           </div>
           <div lgCol="12" lgColMd="4" lgColLg="3">
-            <lg-card lgMarginHorizontal="none">{{card2Content}}</lg-card>
-            <lg-card lgMarginHorizontal="none">{{card3Content}}</lg-card>
+            <lg-card lgMarginHorizontal="none"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>
+            <lg-card lgMarginHorizontal="none"><lg-card-content>{{card3Content}}</lg-card-content></lg-card>
           </div>
         </div>
       </div>
@@ -138,9 +140,11 @@ export const fullWidth = () => ({
         <div lgRow>
           <div lgCol="12">
             <lg-card lgMarginHorizontal="none">
-              {{card1Content}} <br /><br />
-              {{card2Content}} <br /><br />
-              {{card3Content}}
+              <lg-card-content>
+                {{card1Content}} <br /><br />
+                {{card2Content}} <br /><br />
+                {{card3Content}}
+              </lg-card-content>
             </lg-card>
           </div>
         </div>
@@ -166,9 +170,11 @@ export const fullWidthWithHero = () => ({
         <div lgRow>
           <div lgCol="12">
             <lg-card lgMarginHorizontal="none">
-              {{card1Content}} <br /><br />
-              {{card2Content}} <br /><br />
-              {{card3Content}}
+              <lg-card-content>
+                {{card1Content}} <br /><br />
+                {{card2Content}} <br /><br />
+                {{card3Content}}
+              </lg-card-content>
             </lg-card>
           </div>
         </div>

--- a/projects/canopy/src/lib/spacing/margin/margin.notes.ts
+++ b/projects/canopy/src/lib/spacing/margin/margin.notes.ts
@@ -22,7 +22,9 @@ e.g. Apply an xxl margin to the bottom
 
 ~~~html
 <lg-card lgMarginBottom="xxl">
-  Your content
+  <lg-card-content>
+    Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 
@@ -30,7 +32,9 @@ e.g. Apply an sm margin to the left and right
 
 ~~~html
 <lg-card lgMarginLeft="sm" lgMarginRight="sm">
-  Your content
+  <lg-card-content>
+    Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 
@@ -46,7 +50,9 @@ e.g. Apply an lg margin to both the left and the right
 
 ~~~html
 <lg-card lgMarginHorizontal="lg">
+  <lg-card-content>
   Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 
@@ -54,7 +60,9 @@ e.g. Apply an lg margin to both the top and the bottom
 
 ~~~html
 <lg-card lgMarginVertical="lg">
+  <lg-card-content>
   Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 

--- a/projects/canopy/src/lib/spacing/margin/margin.stories.ts
+++ b/projects/canopy/src/lib/spacing/margin/margin.stories.ts
@@ -39,9 +39,11 @@ stories
           [lgMarginRight]="marginRight !== 'undefined' ? marginRight : null"
           [lgMarginBottom]="marginBottom !== 'undefined' ? marginBottom : null"
           [lgMarginLeft]="marginLeft !== 'undefined' ? marginLeft : null">
-            Card with directive applied
+            <lg-card-content>
+              Card with directive applied
+            </lg-card-content>
         </lg-card>
-        <lg-card>Card without directive applied</lg-card>
+        <lg-card><lg-card-content>Card without directive applied</lg-card-content></lg-card>
       `,
       props: {
         margin: select('margin', spaces, 'md'),

--- a/projects/canopy/src/lib/spacing/padding/padding.notes.ts
+++ b/projects/canopy/src/lib/spacing/padding/padding.notes.ts
@@ -22,7 +22,9 @@ e.g. Apply an xxl padding to the bottom
 
 ~~~html
 <lg-card lgPaddingBottom="xxl">
-  Your content
+  <lg-card-content>
+    Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 
@@ -30,7 +32,9 @@ e.g. Apply an sm padding to the left and right
 
 ~~~html
 <lg-card lgPaddingHorizontal="sm">
-  Your content
+  <lg-card-content>
+    Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 
@@ -38,7 +42,9 @@ e.g. Apply an xl padding all round, but xxxl padding to the bottom
 
 ~~~html
 <lg-card lgPadding="xl" lgPaddingBottom="xxxl">
-  Your content
+  <lg-card-content>
+    Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 
@@ -46,7 +52,9 @@ e.g. Apply an lg padding to the top and bottom
 
 ~~~html
 <lg-card lgPaddingVertical="lg">
-  Your content
+  <lg-card-content>
+    Your content
+  </lg-card-content>
 </lg-card>
 ~~~
 

--- a/projects/canopy/src/lib/spacing/padding/padding.stories.ts
+++ b/projects/canopy/src/lib/spacing/padding/padding.stories.ts
@@ -39,9 +39,11 @@ stories
           [lgPaddingRight]="paddingRight !== 'undefined' ? paddingRight : null"
           [lgPaddingBottom]="paddingBottom !== 'undefined' ? paddingBottom : null"
           [lgPaddingLeft]="paddingLeft !== 'undefined' ? paddingLeft : null">
-            Card with directive applied
+            <lg-card-content>
+              Card with directive applied
+            </lg-card-content>
         </lg-card>
-        <lg-card>Card without directive applied</lg-card>
+        <lg-card><lg-card-content>Card without directive applied</lg-card-content></lg-card>
       `,
       props: {
         padding: select('padding', spaces, 'md'),


### PR DESCRIPTION
# Description

Adds the 'form-journey' card type to the already existing cards.

FYI: The desktop version will be slightly different from the design version as we opted to use the existing grid for page positioning and card width.
The product card was changed to use card-content instead of card-header, and the card-header suffered minor modifications.
All the other cards examples look exactly the same and did not suffer design modifications.

## Requirements

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: [https://legalandgeneral.invisionapp.com/share/J4ZQ1VDY96K#/436223077_AN_03-0_ChangeBankOutsideWindow_Annuity_XL](https://legalandgeneral.invisionapp.com/share/J4ZQ1VDY96K#/436223077_AN_03-0_ChangeBankOutsideWindow_Annuity_XL)
[https://legalandgeneral.invisionapp.com/share/P9ZEVI5KVBW#/screens/437597110_AN_02-0_ChangeBeneficiariesForm_Annuity_XL](https://legalandgeneral.invisionapp.com/share/P9ZEVI5KVBW#/screens/437597110_AN_02-0_ChangeBeneficiariesForm_Annuity_XL)
Screenshot: 
![Screenshot 2020-12-15 at 16 40 51](https://user-images.githubusercontent.com/68600084/102229340-58f00780-3ef4-11eb-9720-21483bf33f85.png)
![Screenshot 2020-12-15 at 11 07 54](https://user-images.githubusercontent.com/68600084/102210532-f76f6f00-3eda-11eb-8d84-74bf29bf02ca.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
