### PR TITLE
fix(checkbox-group): uncheck child toggles when parent form is reset

### DIFF
--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
@@ -138,6 +138,17 @@ describe('LgCheckboxGroupComponent', () => {
     expect(checkedOption.componentInstance.value).toContain('red');
   });
 
+  it('unchecks the selected checkbox buttons when an empty array value is provided', () => {
+    groupInstance.value = ['red'];
+    fixture.detectChanges();
+    groupInstance.value = [];
+    fixture.detectChanges();
+    const checkedOptions: DebugElement = checkboxDebugElements.find(
+      (checkboxDebugElement) => checkboxDebugElement.componentInstance.checked === true,
+    );
+    expect(checkedOptions).not.toBeDefined();
+  });
+
   it('uses same unique id when setting the group id and the group name', () => {
     const checkboxGroupNextUniqueId = groupInstance.nextUniqueId;
     const checkboxGroupId = groupInstance.id;

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts
@@ -102,21 +102,22 @@ export class LgCheckboxGroupComponent implements ControlValueAccessor {
     this._validationElement = element;
   }
 
-  _value: Array<string> = null;
+  private _value: Array<string> = [];
   @Input()
   get value() {
     return this._value;
   }
-  set value(value) {
+  set value(value: Array<string>) {
     this._value = value;
     this.onChange(value);
-    if (this.checkboxes) {
-      this.checkboxes.forEach((checkbox) => {
-        if (value.includes(checkbox.value.toString())) {
-          checkbox.checked = true;
-        }
-      });
+
+    if (!this.checkboxes) {
+      return;
     }
+
+    this.checkboxes.forEach(
+      (checkbox) => (checkbox.checked = value.includes(checkbox.value.toString())),
+    );
   }
 
   @Input()


### PR DESCRIPTION
Calling `form.reset()` from the parent form failed to uncheck the checked child toggle components.
So I have updated the `value` setter to uncheck all children when an empty array is passed in.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
