### PR TITLE
ci(semantic-release): update config to create pre-releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,9 @@
 {
   "plugins": [
-    "branches": [ "master", {"name": "next", "prerelease": true} ],
+    "branches": [
+      "master",
+      {"name": "next", "channel": "next", "prerelease": "next"}
+    ],
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", {


### PR DESCRIPTION
# Description

After creating the `next` branch with the Angular upgrade I've noticed that the version was set to `4.0.0` instead of `4.0.0-next.1`. 
The documentation says that if we set `"prerelease": true` this will take the name of the branch which did not happen in our case 🤔  I have updated the config to be more specific `"prerelease": "next"` hoping that this fixes the issue.
More info here: https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#prerelease

I've also added the `channel` property which will allow users to install using the `@next` tag.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
