### PR TITLE
fix(input-field): add showLabel to the input field

### DIFF
--- a/projects/canopy/src/lib/forms/input/input-field.component.html
+++ b/projects/canopy/src/lib/forms/input/input-field.component.html
@@ -1,4 +1,4 @@
-<label lg-label>
+<label lg-label [class.lg-visually-hidden]="!showLabel">
   <ng-content></ng-content>
 </label>
 <ng-content select="lg-hint"></ng-content>

--- a/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
@@ -24,6 +24,7 @@ describe('LgInputFieldComponent', () => {
   let inputFieldDebugElement: DebugElement;
   let inputWrapperDebugElement: DebugElement;
   let errorStateMatcherMock: LgErrorStateMatcher;
+  let labelDebugElement: DebugElement;
 
   const errorId = 'test-error-id';
   const hintId = 'test-hint-id';
@@ -59,9 +60,14 @@ describe('LgInputFieldComponent', () => {
     }).compileComponents();
   }));
 
-  function renderComponent({ block = false, hasPrefix = false, hasSuffix = false }) {
+  function renderComponent({
+    block = false,
+    hasPrefix = false,
+    hasSuffix = false,
+    showLabel = true,
+  }) {
     fixture = MockRender(`
-      <lg-input-field [block]="${block}">
+      <lg-input-field [block]="${block}" [showLabel]="${showLabel}">
         Label
         <input lgInput />
         <lg-hint id="${hintId}">Hint</lg-hint>
@@ -84,6 +90,7 @@ describe('LgInputFieldComponent', () => {
       By.css('.lg-input-field__inputs'),
     );
     inputDirectiveInstance = inputDirectiveDebugElement.componentInstance;
+    labelDebugElement = fixture.debugElement.query(By.directive(LgLabelComponent));
   }
 
   describe('markup', () => {
@@ -105,6 +112,23 @@ describe('LgInputFieldComponent', () => {
 
     it('combines both the hint and error ids to create the aria described attribute', () => {
       expect(inputDirectiveInstance.ariaDescribedBy).toBe(`${hintId} ${errorId}`);
+    });
+  });
+
+  describe('showLabel', () => {
+    it("doesn't add the visually hidden class if the showLabel property is true", () => {
+      renderComponent({ showLabel: true });
+      expect(labelDebugElement.nativeElement.getAttribute('class')).not.toContain(
+        'lg-visually-hidden',
+      );
+    });
+
+    it('adds the visually hidden class if the showLabel property is false', () => {
+      renderComponent({ showLabel: false });
+
+      expect(labelDebugElement.nativeElement.getAttribute('class')).toContain(
+        'lg-visually-hidden',
+      );
     });
   });
 

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -36,6 +36,7 @@ let nextUniqueId = 0;
 export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
   private _id = nextUniqueId++;
 
+  @Input() showLabel = true;
   @Input() public set block(block: boolean) {
     if (this._inputElement) {
       this._inputElement.block = block;

--- a/projects/canopy/src/lib/forms/input/input.notes.ts
+++ b/projects/canopy/src/lib/forms/input/input.notes.ts
@@ -28,7 +28,7 @@ and in your HTML:
 
 Buttons can be added within input fields to provide functionality linked to the input.
 The \`lgSuffix\` directive needs to be added to the button to place it in the correct place.
-Only small size buttons should be placed in the input field. 
+Only small size buttons should be placed in the input field.
 There is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.
 
 #### Button suffix
@@ -93,6 +93,7 @@ Prefix and suffix text can be added to input fields using the \`lgSuffix\` and \
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-input-\${nextUniqueId++}' | No |
 | \`\`block\`\` | Property to make the input full width (for small screens only). | boolean | false | no
+| \`\`showLabel\`\` | Show or visually hide the label | boolean | true | No |
 
 ## Using only the SCSS files
 

--- a/projects/canopy/src/lib/forms/input/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/input.stories.ts
@@ -28,6 +28,7 @@ interface KnobsConfig {
   icon?: string;
   iconButton?: boolean;
   label?: string;
+  showLabel?: boolean;
   showButton?: boolean;
   showSecondaryButton?: boolean;
   showTextPrefix?: boolean;
@@ -49,6 +50,7 @@ const createInputStory = (config: KnobsConfig) => ({
       [icon]="icon"
       [iconButton]="iconButton"
       [label]="label"
+      [showLabel]="showLabel"
       [prefix]="prefix"
       [size]="size"
       [suffix]="suffix"
@@ -82,6 +84,7 @@ const createInputStory = (config: KnobsConfig) => ({
     ),
     inputChange: action('inputChange'),
     label: text('label', config.label || 'Name', contentGroupId),
+    showLabel: boolean('show label', true, propsGroupId),
     prefix: text('prefix', '£', contentGroupId),
     showButton: boolean('show button', config.showButton, contentGroupId),
     iconButton: boolean('icon button', true, contentGroupId),
@@ -101,7 +104,7 @@ const createInputStory = (config: KnobsConfig) => ({
   selector: 'lg-reactive-form',
   template: `
     <form [formGroup]="form" (ngSubmit)="onSubmit(form)">
-      <lg-input-field [block]="block">
+      <lg-input-field [block]="block" [showLabel]="showLabel">
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
         <span lgPrefix *ngIf="showTextPrefix">{{ prefix }}</span>
@@ -153,6 +156,7 @@ class ReactiveFormComponent {
   @Input() icon: string;
   @Input() iconButton: boolean;
   @Input() label: string;
+  @Input() showLabel: boolean;
   @Input() prefix: string;
   @Input() showButton: boolean;
   @Input() showSecondaryButton: boolean;


### PR DESCRIPTION
# Description

Add an input to the `inputField` to show or visually hide the label. 
This is required when the label has to be visually hidden - for example an input within a table row.

Fixes #109

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
