### PR TITLE
fix(input-field): update error class logic

### DIFF
--- a/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
@@ -3,8 +3,8 @@ import { async, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { MockComponents, MockRender, MockedComponentFixture } from 'ng-mocks';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { MockComponents, MockedComponentFixture, MockRender } from 'ng-mocks';
+import { instance, mock, spy, when } from 'ts-mockito';
 
 import { LgHintComponent } from '../hint';
 import { LgInputFieldComponent } from '../input/input-field.component';
@@ -18,6 +18,7 @@ import { LgErrorStateMatcher } from '../validation';
 
 describe('LgInputFieldComponent', () => {
   let fixture: MockedComponentFixture<LgInputFieldComponent>;
+  let component: LgInputFieldComponent;
   let labelInstance: LgLabelComponent;
   let inputDirectiveInstance: LgInputDirective;
   let inputDirectiveDebugElement: DebugElement;
@@ -70,6 +71,7 @@ describe('LgInputFieldComponent', () => {
         ${hasSuffix && `<span lgSuffix id="${suffixId}">${suffixText}</span>`}
         </lg-input-field>
     `);
+    component = fixture.point.componentInstance;
     fixture.detectChanges();
 
     inputFieldDebugElement = fixture.debugElement.query(
@@ -191,24 +193,27 @@ describe('LgInputFieldComponent', () => {
   });
 
   describe('error', () => {
+    let componentSpy: LgInputFieldComponent;
+
     beforeEach(() => {
       renderComponent({});
+      componentSpy = spy(component);
       fixture.detectChanges();
     });
+
     it('adds an error class to the input wrapper when the control is invalid', () => {
-      when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-        true,
-      );
+      when(componentSpy.errorClass).thenReturn(true);
       fixture.detectChanges();
+
       expect(inputFieldDebugElement.nativeElement.getAttribute('class')).toContain(
         'lg-input-field--error',
       );
     });
+
     it('does not add the error class to the input wrapper when the control is valid', () => {
-      when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-        false,
-      );
+      when(componentSpy.errorClass).thenReturn(false);
       fixture.detectChanges();
+
       expect(inputFieldDebugElement.nativeElement.getAttribute('class')).not.toContain(
         'lg-input-field--error',
       );

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -1,17 +1,15 @@
 import {
+  AfterContentInit,
   Component,
   ContentChild,
+  ContentChildren,
   HostBinding,
   Input,
+  OnDestroy,
+  QueryList,
   ViewChild,
   ViewEncapsulation,
-  AfterContentInit,
-  ContentChildren,
-  QueryList,
-  OnDestroy,
-  Optional,
 } from '@angular/core';
-import { FormGroupDirective } from '@angular/forms';
 
 import { Subscription } from 'rxjs';
 
@@ -23,7 +21,6 @@ import { LgInputDirective } from './input.directive';
 import { LgButtonComponent } from '../../button';
 import { LgSuffixDirective } from '../../suffix/suffix.directive';
 import { LgPrefixDirective } from '../../prefix/prefix.directive';
-import { LgErrorStateMatcher } from '../validation/error-state-matcher';
 
 let nextUniqueId = 0;
 
@@ -56,10 +53,7 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
 
   @HostBinding('class.lg-input-field--error')
   get errorClass(): boolean {
-    return this.errorState.isControlInvalid(
-      this._inputElement.control,
-      this.controlContainer,
-    );
+    return this._inputElement.errorClass;
   }
 
   @HostBinding('class.lg-input-field--block')
@@ -150,12 +144,7 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
 
   @Input() id = `lg-input-${this._id++}`;
 
-  constructor(
-    private domService: LgDomService,
-    private errorState: LgErrorStateMatcher,
-    @Optional()
-    private controlContainer: FormGroupDirective,
-  ) {}
+  constructor(private domService: LgDomService) {}
 
   /*
     The input field control element mimics the border of the input field.

--- a/projects/canopy/src/lib/forms/input/input.directive.ts
+++ b/projects/canopy/src/lib/forms/input/input.directive.ts
@@ -17,6 +17,8 @@ let nextUniqueId = 0;
   selector: '[lgInput]',
 })
 export class LgInputDirective {
+  uniqueId = nextUniqueId++;
+
   @HostBinding('class.lg-input') class = true;
   @HostBinding('class.lg-input--block')
   public get blockClass() {
@@ -33,11 +35,11 @@ export class LgInputDirective {
 
   @Input()
   @HostBinding('name')
-  name = `lg-input-${nextUniqueId++}`;
+  name = `lg-input-${this.uniqueId}`;
 
   @Input()
   @HostBinding('id')
-  id = `lg-input-${nextUniqueId++}`;
+  id = `lg-input-${this.uniqueId}`;
 
   @Input()
   @HostBinding('disabled')


### PR DESCRIPTION
# Description

Update logic so that when the input itself has an error the parent will get the
error class too.
Reason being that we are using the input field in a table and can’t put the validation component in the same cell, but still want the field highlighted red when invalid.

Storybook link: https://deploy-preview-129--legal-and-general-canopy.netlify.app/?path=/story/components-form-form-validation--standard

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
