### PR TITLE
Remove references to non-existent css variables

### DIFF
--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.scss
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.scss
@@ -12,7 +12,6 @@
   position: relative;
   text-align: left;
   width: 100%;
-  line-height: var(--line-height-body);
 
   &:focus {
     @include lg-inner-focus-outline(var(--default-focus-color));

--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -56,11 +56,6 @@
     cursor: not-allowed;
   }
 
-  &--rounded {
-    border-radius: var(--btn-rounded-radius);
-    min-width: auto;
-  }
-
   .lg-icon {
     margin-left: var(--space-xxs);
   }

--- a/projects/canopy/src/lib/card/card-title/card-title.component.scss
+++ b/projects/canopy/src/lib/card/card-title/card-title.component.scss
@@ -8,11 +8,9 @@
     color: var(--link-color);
     outline: none;
     text-decoration: none;
-    padding: var(--link-underline-space);
   }
 }
 
 .lg-card-title__heading {
-  font-weight: var(--font-weight-medium);
   margin-bottom: 0;
 }

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
@@ -3,7 +3,6 @@
 .lg-details-panel-heading {
   font-size: var(--text-base-size);
   font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-body);
   margin-bottom: 0;
 
   &__toggle {

--- a/projects/canopy/src/lib/footer/footer.component.scss
+++ b/projects/canopy/src/lib/footer/footer.component.scss
@@ -120,8 +120,6 @@
 }
 
 .lg-footer__org {
-  font-size: var(--text-xs);
-
   @include lg-breakpoint('md') {
     display: flex;
     flex-direction: column;

--- a/projects/canopy/src/lib/forms/date/date-field.component.scss
+++ b/projects/canopy/src/lib/forms/date/date-field.component.scss
@@ -1,7 +1,6 @@
 .lg-date-field {
   display: block;
   margin-bottom: var(--component-margin);
-  line-height: var(--line-height-sm);
 }
 
 .lg-date-field__fields {

--- a/projects/canopy/src/lib/forms/hint/hint.component.scss
+++ b/projects/canopy/src/lib/forms/hint/hint.component.scss
@@ -4,5 +4,4 @@
   margin-top: calc(var(--space-xxs) * -1);
   margin-bottom: var(--space-xxs);
   font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-sm);
 }

--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -10,7 +10,6 @@
 
   display: block;
   margin-bottom: var(--component-margin);
-  line-height: var(--line-height-sm);
 
   &__prefix,
   &__suffix {

--- a/projects/canopy/src/lib/forms/label/label.component.scss
+++ b/projects/canopy/src/lib/forms/label/label.component.scss
@@ -2,5 +2,4 @@
   display: block;
   margin-bottom: var(--space-xxs);
   font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-sm);
 }

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -17,7 +17,6 @@
   display: flex;
   position: relative;
   font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-sm);
 
   .lg-radio-button__input:disabled + & {
     color: var(--disabled-color);

--- a/projects/canopy/src/lib/forms/select/select-field.component.scss
+++ b/projects/canopy/src/lib/forms/select/select-field.component.scss
@@ -4,7 +4,6 @@
 .lg-select-field {
   display: block;
   margin-bottom: var(--component-margin);
-  line-height: var(--line-height-sm);
 }
 
 .lg-select-field__outer {

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -6,7 +6,6 @@
   padding: var(--select-vertical-padding)
     calc(var(--select-icon-width) + (2 * var(--space-sm))) var(--select-vertical-padding)
     var(--space-sm);
-  line-height: var(--line-height-sm);
   background-color: var(--color-white);
   outline: 0;
   appearance: none;

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -32,7 +32,7 @@
   &--error,
   &--error:hover {
     color: var(--form-error-color);
-    border-color: var(--form-border-error-color);
+    border-color: var(--form-error-border-color);
 
     &:focus {
       color: inherit;

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.scss
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.scss
@@ -1,7 +1,6 @@
 .lg-sort-code-field {
   display: block;
   margin-bottom: var(--component-margin);
-  line-height: var(--line-height-sm);
 }
 
 .lg-sort-code__fields {

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -14,7 +14,6 @@
   align-items: center;
   position: relative;
   font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-sm);
 
   .lg-toggle__input:disabled + & {
     color: var(--disabled-color);

--- a/projects/canopy/src/styles/color.stories.ts
+++ b/projects/canopy/src/styles/color.stories.ts
@@ -48,7 +48,6 @@ interface Color {
       }
       .swatch__name {
         display: block;
-        font-size: var(--text-sm);
         font-weight: var(--font-weight-bold);
         margin-bottom: var(--space-xxxs);
       }
@@ -127,7 +126,6 @@ class SwatchComponent implements AfterViewInit {
       }
       .tint_swatch__name {
         display: block;
-        font-size: var(--text-sm);
         font-weight: var(--font-weight-bold);
         margin-bottom: var(--space-xxxs);
       }

--- a/projects/canopy/src/styles/typography.scss
+++ b/projects/canopy/src/styles/typography.scss
@@ -85,10 +85,6 @@ a {
   }
 }
 
-small {
-  font-size: var(--text-sm);
-}
-
 b,
 strong {
   font-weight: var(--font-weight-bold);
@@ -176,6 +172,7 @@ h6,
   @include lg-font-size('-8');
 }
 
+small,
 .lg-font-size-0-6 {
   @include lg-font-size('-6');
 }


### PR DESCRIPTION
# Description

Somewhere along the way we removed some css variables but didn't update all of the components that used them. We haven't had any issues raised from a styling point of view so for now I just removed all of the references as opposed to researching where they were individually removed. I can't foresee any unintended consequences. 

We could potentially do some work to prevent this happening again, but for now I've just done the minimal amount to clear the bug out of the way.

Fixes #80

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
