### PR TITLE
feat(table): add configurable fullSizeBp setting

### DIFF
--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -1,13 +1,9 @@
 @import '../../../styles/mixins.scss';
+@import '../table.breakpoints';
 
 .lg-table-cell {
   display: flex;
   align-items: baseline;
-
-  @include lg-breakpoint('md') {
-    display: table-cell;
-    padding: var(--space-sm);
-  }
 
   &--toggle-cell {
     order: 1;
@@ -20,25 +16,11 @@
     .lg-table-cell__content {
       margin-left: 0;
     }
-
-    @include lg-breakpoint('md') {
-      min-width: var(--table-toggle-width);
-    }
   }
 }
 
 .lg-table-cell__content {
   margin-left: auto;
-
-  @include lg-breakpoint('md') {
-    text-align: left;
-  }
-
-  &--align-end {
-    @include lg-breakpoint('md') {
-      text-align: right;
-    }
-  }
 }
 
 .lg-table-cell--expandable-content {
@@ -49,8 +31,40 @@
 
 .lg-table-cell__label {
   font-weight: var(--font-weight-bold);
+}
 
-  @include lg-breakpoint('md') {
-    display: none;
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    .lg-table-cell {
+      @include lg-breakpoint($columns-breakpoint) {
+        display: table-cell;
+        padding: var(--space-sm);
+      }
+
+      &--toggle-cell {
+        @include lg-breakpoint($columns-breakpoint) {
+          min-width: var(--table-toggle-width);
+          padding: 0;
+        }
+      }
+
+      &__content {
+        @include lg-breakpoint($columns-breakpoint) {
+          text-align: left;
+        }
+
+        &--align-end {
+          @include lg-breakpoint($columns-breakpoint) {
+            text-align: right;
+          }
+        }
+      }
+
+      &__label {
+        @include lg-breakpoint($columns-breakpoint) {
+          display: none;
+        }
+      }
+    }
   }
 }

--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.scss
@@ -1,4 +1,5 @@
 @import '../../../styles/mixins.scss';
+@import '../table.breakpoints';
 
 .lg-table-head-cell {
   display: block;
@@ -7,12 +8,18 @@
   border-bottom: solid var(--table-header-border-width) var(--table-header-border-color);
   padding: var(--space-xs) 0;
 
-  @include lg-breakpoint('md') {
-    padding: var(--space-sm);
-    display: table-cell;
-  }
-
   &--align-end {
     text-align: right;
+  }
+}
+
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    .lg-table-head-cell {
+      @include lg-breakpoint($columns-breakpoint) {
+        padding: var(--space-sm);
+        display: table-cell;
+      }
+    }
   }
 }

--- a/projects/canopy/src/lib/table/table-head/table-head.component.scss
+++ b/projects/canopy/src/lib/table/table-head/table-head.component.scss
@@ -1,11 +1,16 @@
 @import '../../../styles/mixins.scss';
+@import '../table.breakpoints';
 
-.lg-table-head {
-  @include lg-breakpoint('md', 'max-width') {
-    @include lg-visually-hidden();
-  }
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    .lg-table-head {
+      @include lg-breakpoint($columns-breakpoint, 'max-width') {
+        @include lg-visually-hidden();
+      }
 
-  @include lg-breakpoint('md') {
-    display: table-header-group;
+      @include lg-breakpoint($columns-breakpoint) {
+        display: table-header-group;
+      }
+    }
   }
 }

--- a/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
+++ b/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
@@ -1,11 +1,8 @@
 @import '../../../styles/mixins.scss';
+@import '../table.breakpoints';
 
 .lg-table-row-toggle {
   font-weight: var(--font-weight-bold);
-
-  @include lg-breakpoint('md') {
-    font-weight: normal;
-  }
 
   &__btn {
     border: none;
@@ -16,18 +13,8 @@
     min-width: var(--table-toggle-width);
     min-height: var(--table-toggle-width);
 
-    @include lg-breakpoint('md') {
-      padding: 0;
-    }
-
     &:focus {
       @include lg-inner-focus-outline(var(--default-focus-color));
-    }
-  }
-
-  &__label {
-    @include lg-breakpoint('md') {
-      @include lg-visually-hidden;
     }
   }
 
@@ -35,12 +22,36 @@
     transition: transform var(--animation-duration) var(--animation-fn);
     margin-right: var(--space-xxs);
 
-    @include lg-breakpoint('md') {
-      margin-right: 0;
-    }
-
     &--active {
       transform: rotateX(180deg);
+    }
+  }
+}
+
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    .lg-table-row-toggle {
+      @include lg-breakpoint($columns-breakpoint) {
+        font-weight: normal;
+      }
+
+      &__btn {
+        @include lg-breakpoint($columns-breakpoint) {
+          padding: 0;
+        }
+      }
+
+      &__label {
+        @include lg-breakpoint($columns-breakpoint) {
+          @include lg-visually-hidden;
+        }
+      }
+
+      &__heading-icon {
+        @include lg-breakpoint($columns-breakpoint) {
+          margin-right: 0;
+        }
+      }
     }
   }
 }

--- a/projects/canopy/src/lib/table/table-row/table-row.component.scss
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.scss
@@ -1,13 +1,10 @@
 @import '../../../styles/mixins.scss';
+@import '../table.breakpoints';
 
 .lg-table-row {
   display: flex;
   flex-direction: column;
   padding: var(--space-xs);
-
-  @include lg-breakpoint('md') {
-    display: table-row;
-  }
 
   &__detail {
     padding: 0;
@@ -15,5 +12,15 @@
 
   &--hidden {
     @include lg-visually-hidden;
+  }
+}
+
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    .lg-table-row {
+      @include lg-breakpoint($columns-breakpoint) {
+        display: table-row;
+      }
+    }
   }
 }

--- a/projects/canopy/src/lib/table/table.breakpoints.scss
+++ b/projects/canopy/src/lib/table/table.breakpoints.scss
@@ -1,0 +1,1 @@
+$columns-breakpoints: 'sm', 'md', 'lg' !default;

--- a/projects/canopy/src/lib/table/table.interface.ts
+++ b/projects/canopy/src/lib/table/table.interface.ts
@@ -8,3 +8,9 @@ export interface TableColumn {
   align: AlignmentOptions;
   showLabel: boolean;
 }
+
+export enum TableColumnLayoutBreakpoints {
+  Small = 'sm',
+  Medium = 'md',
+  Large = 'lg',
+}

--- a/projects/canopy/src/lib/table/table.notes.ts
+++ b/projects/canopy/src/lib/table/table.notes.ts
@@ -71,6 +71,14 @@ and in your HTML:
 
 ## Inputs
 
+### LgTableComponent
+A component that acts as a standard table.
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| \`\`showColumnsAt\`\` | Sets the minimum screen width from which the column layout is displayed. Accepts \`sm\`, \`md\` or \`lg\` | string | 'md' | No |
+
+
 ### LgTableBodyComponent
 A component that acts as a standard table body.
 

--- a/projects/canopy/src/lib/table/table.notes.ts
+++ b/projects/canopy/src/lib/table/table.notes.ts
@@ -101,7 +101,7 @@ A component that acts as a standard table header cell.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`align\`\` | Alignment option for the header and its respective column | \`\`start\`\`, \`\`end\`\` | n/a | No |
-| \`\`showLabel\`\` | Whether to show label for this header in each row on mobile | boolean | true | No |
+| \`\`showLabel\`\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |
 
 ### LgTableRowComponent
 A component that acts as a standard table row.

--- a/projects/canopy/src/lib/table/table.stories.ts
+++ b/projects/canopy/src/lib/table/table.stories.ts
@@ -3,7 +3,7 @@ import { ChangeDetectorRef, Component, Input } from '@angular/core';
 import { boolean, object, select, withKnobs } from '@storybook/addon-knobs';
 import { moduleMetadata } from '@storybook/angular';
 
-import { AlignmentOptions } from './table.interface';
+import { AlignmentOptions, TableColumnLayoutBreakpoints } from './table.interface';
 import { LgInputModule } from '../forms';
 import { LgMarginModule } from '../spacing';
 import { LgSuffixModule } from '../suffix';
@@ -74,7 +74,7 @@ function getDefaultTableContent(): Array<TableStoryItem> {
 @Component({
   selector: 'story-table-detail',
   template: `
-    <table lg-table>
+    <table lg-table [showColumnsAt]="columnBreakpoint">
       <thead lg-table-head>
         <tr lg-table-row>
           <th scope="col" lg-table-head-cell>
@@ -118,6 +118,7 @@ export class StoryTableDetailComponent {
 
   @Input() alignPublishColumn: AlignmentOptions;
   @Input() showAuthorLabel: boolean;
+  @Input() columnBreakpoint: TableColumnLayoutBreakpoints;
 
   @Input() expandedRows: Array<number> = [];
 
@@ -143,7 +144,7 @@ export class StoryTableDetailComponent {
 }
 
 export default {
-  title: 'Components/Table  ',
+  title: 'Components/Table',
   excludeStories: ['StoryTableDetailComponent'],
   parameters: {
     decorators: [
@@ -164,7 +165,7 @@ export default {
 
 export const standard = () => ({
   template: `
-    <table lg-table>
+    <table lg-table [showColumnsAt]="columnBreakpoint">
       <thead lg-table-head>
         <tr lg-table-row>
           <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
@@ -184,33 +185,63 @@ export const standard = () => ({
   `,
 
   props: {
-    books: object('Books', getDefaultTableContent(), 'lg-table'),
+    books: object('Books', getDefaultTableContent(), 'Table data'),
     alignTitleColumn: select(
       'Align Title column',
       [AlignmentOptions.End, AlignmentOptions.Start],
       AlignmentOptions.Start,
+      'Alignment',
     ),
     alignPublishColumn: select(
       'Align Publish column',
       [AlignmentOptions.End, AlignmentOptions.Start],
       AlignmentOptions.End,
+      'Alignment',
     ),
-    showAuthorLabel: boolean('Display author label on mobile', false, 'lg-table'),
+    columnBreakpoint: select(
+      'Minimum breakpoint where column layout is used',
+      [
+        TableColumnLayoutBreakpoints.Small,
+        TableColumnLayoutBreakpoints.Medium,
+        TableColumnLayoutBreakpoints.Large,
+      ],
+      TableColumnLayoutBreakpoints.Medium,
+      'Responsive options',
+    ),
+    showAuthorLabel: boolean(
+      'Display author label on mobile',
+      false,
+      'Responsive options',
+    ),
   },
 });
 
 export const detail = () => ({
-  template: `<story-table-detail [books]="books" [alignPublishColumn]="alignPublishColumn" [showAuthorLabel]="showAuthorLabel"></story-table-detail>`,
+  template: `<story-table-detail [books]="books" [alignPublishColumn]="alignPublishColumn" [showAuthorLabel]="showAuthorLabel" [columnBreakpoint]="columnBreakpoint"></story-table-detail>`,
 
   props: {
-    books: object('Books', getDefaultTableContent(), 'lg-table'),
+    books: object('Books', getDefaultTableContent(), 'Table data'),
     alignPublishColumn: select(
-      'Published column alignment',
+      'Align Publish column',
       [AlignmentOptions.Start, AlignmentOptions.End],
       AlignmentOptions.End,
-      'lg-table',
+      'Alignment',
     ),
-    showAuthorLabel: boolean('Display author label on mobile', false, 'lg-table'),
+    columnBreakpoint: select(
+      'Minimum breakpoint where column layout is used',
+      [
+        TableColumnLayoutBreakpoints.Small,
+        TableColumnLayoutBreakpoints.Medium,
+        TableColumnLayoutBreakpoints.Large,
+      ],
+      TableColumnLayoutBreakpoints.Medium,
+      'Responsive options',
+    ),
+    showAuthorLabel: boolean(
+      'Display author label on mobile',
+      false,
+      'Responsive options',
+    ),
   },
 });
 
@@ -239,6 +270,6 @@ export const withInput = () => ({
   `,
 
   props: {
-    books: object('Books', getDefaultTableContent(), 'lg-table'),
+    books: object('Books', getDefaultTableContent(), 'Table data'),
   },
 });

--- a/projects/canopy/src/lib/table/table.stories.ts
+++ b/projects/canopy/src/lib/table/table.stories.ts
@@ -209,7 +209,7 @@ export const standard = () => ({
       'Responsive options',
     ),
     showAuthorLabel: boolean(
-      'Display author label on mobile',
+      'Display author label in non-columns view',
       false,
       'Responsive options',
     ),
@@ -238,7 +238,7 @@ export const detail = () => ({
       'Responsive options',
     ),
     showAuthorLabel: boolean(
-      'Display author label on mobile',
+      'Display author label in non-columns view',
       false,
       'Responsive options',
     ),

--- a/projects/canopy/src/lib/table/table/table.component.scss
+++ b/projects/canopy/src/lib/table/table/table.component.scss
@@ -1,16 +1,11 @@
 @import '../../../styles/mixins.scss';
+@import '../table.breakpoints';
 
 .lg-table {
   display: flex;
   flex-direction: column;
   margin-bottom: var(--component-margin);
   border-spacing: 0;
-
-  @include lg-breakpoint('md') {
-    display: table;
-    table-layout: auto;
-    width: 100%;
-  }
 
   &--expandable {
     tr {
@@ -29,6 +24,16 @@
       &:nth-child(even) {
         background-color: var(--table-stripe-color);
       }
+    }
+  }
+}
+
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    @include lg-breakpoint($columns-breakpoint) {
+      display: table;
+      table-layout: auto;
+      width: 100%;
     }
   }
 }

--- a/projects/canopy/src/lib/table/table/table.component.spec.ts
+++ b/projects/canopy/src/lib/table/table/table.component.spec.ts
@@ -351,7 +351,7 @@ describe('TableComponent', () => {
 
     describe('when showColumnsAt is not set', () => {
       beforeEach(() => {
-        fixture = MockRender(getShowColumnsAtMockRender());
+        fixture = MockRender(getShowColumnsAtMockRenderDefault());
         debugElement = fixture.debugElement;
         tableDebugElement = debugElement.query(By.directive(LgTableComponent));
         fixture.detectChanges();
@@ -385,6 +385,23 @@ describe('TableComponent', () => {
   function getShowColumnsAtMockRender() {
     return `
     <table lg-table [showColumnsAt]="showColumnsAt">
+      <thead lg-table-head>
+        <tr lg-table-row>
+          <th lg-table-head-cell>Title</th>
+        </tr>
+      </thead>
+
+      <tbody lg-table-body>
+        <tr lg-table-row>
+          <td lg-table-cell>Accelerate: The Science of Lean Software and Devops</td>
+        </tr>
+      </tbody>
+    </table>`;
+  }
+
+  function getShowColumnsAtMockRenderDefault() {
+    return `
+    <table lg-table>
       <thead lg-table-head>
         <tr lg-table-row>
           <th lg-table-head-cell>Title</th>

--- a/projects/canopy/src/lib/table/table/table.component.spec.ts
+++ b/projects/canopy/src/lib/table/table/table.component.spec.ts
@@ -85,7 +85,9 @@ describe('TableComponent', () => {
   });
 
   it('should have the default class', () => {
-    expect(tableDebugElement.nativeElement.getAttribute('class')).toBe('lg-table');
+    expect(tableDebugElement.nativeElement.getAttribute('class')).toBe(
+      'lg-table--columns-md lg-table',
+    );
   });
 
   it('passes the head content to the respective label template', () => {
@@ -329,12 +331,63 @@ describe('TableComponent', () => {
     });
   });
 
+  describe('showColumnsAt setting', () => {
+    describe('when showColumnsAt is set', () => {
+      beforeEach(() => {
+        fixture = MockRender(getShowColumnsAtMockRender(), {
+          showColumnsAt: 'sm',
+        });
+        debugElement = fixture.debugElement;
+        tableDebugElement = debugElement.query(By.directive(LgTableComponent));
+        fixture.detectChanges();
+      });
+
+      it('should add the lg-table--columns-* class to the table', () => {
+        expect(tableDebugElement.classes['lg-table--columns-sm']).toBe(true);
+        expect(tableDebugElement.classes['lg-table--columns-lg']).toBe(undefined);
+        expect(tableDebugElement.classes['lg-table--columns-md']).toBe(undefined);
+      });
+    });
+
+    describe('when showColumnsAt is not set', () => {
+      beforeEach(() => {
+        fixture = MockRender(getShowColumnsAtMockRender());
+        debugElement = fixture.debugElement;
+        tableDebugElement = debugElement.query(By.directive(LgTableComponent));
+        fixture.detectChanges();
+      });
+
+      it('should add the default lg-table--columns-md class to the table', () => {
+        expect(tableDebugElement.classes['lg-table--columns-md']).toBe(true);
+        expect(tableDebugElement.classes['lg-table--columns-sm']).toBe(undefined);
+        expect(tableDebugElement.classes['lg-table--columns-lg']).toBe(undefined);
+      });
+    });
+  });
+
   function getShowLabelMockRender() {
     return `
     <table lg-table>
       <thead lg-table-head>
         <tr lg-table-row>
           <th lg-table-head-cell [showLabel]="showLabel">Title</th>
+        </tr>
+      </thead>
+
+      <tbody lg-table-body>
+        <tr lg-table-row>
+          <td lg-table-cell>Accelerate: The Science of Lean Software and Devops</td>
+        </tr>
+      </tbody>
+    </table>`;
+  }
+
+  function getShowColumnsAtMockRender() {
+    return `
+    <table lg-table [showColumnsAt]="showColumnsAt">
+      <thead lg-table-head>
+        <tr lg-table-row>
+          <th lg-table-head-cell>Title</th>
         </tr>
       </thead>
 

--- a/projects/canopy/src/lib/table/table/table.component.ts
+++ b/projects/canopy/src/lib/table/table/table.component.ts
@@ -1,15 +1,19 @@
 import {
+  AfterContentChecked,
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
-  ViewEncapsulation,
-  AfterContentChecked,
   ContentChild,
+  ElementRef,
+  HostBinding,
+  Input,
+  OnInit,
+  Renderer2,
+  ViewEncapsulation,
 } from '@angular/core';
 
 import { LgTableBodyComponent } from '../table-body/table-body.component';
 import { LgTableHeadComponent } from '../table-head/table-head.component';
-import { TableColumn } from '../table.interface';
+import { TableColumn, TableColumnLayoutBreakpoints } from '../table.interface';
 
 let nextUniqueId = 0;
 
@@ -20,7 +24,7 @@ let nextUniqueId = 0;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgTableComponent implements AfterContentChecked {
+export class LgTableComponent implements AfterContentChecked, OnInit {
   @HostBinding('class') class = 'lg-table';
 
   @ContentChild(LgTableHeadComponent, { static: false }) tableHead: LgTableHeadComponent;
@@ -32,11 +36,22 @@ export class LgTableComponent implements AfterContentChecked {
     return this.isExpandable;
   }
 
+  private _columnsBreakpoint: TableColumnLayoutBreakpoints;
+  @Input()
+  set showColumnsAt(columnsBreakpoint: TableColumnLayoutBreakpoints) {
+    this.addColumnsBreakpoint(columnsBreakpoint);
+  }
+  get showColumnsAt(): TableColumnLayoutBreakpoints {
+    return this._columnsBreakpoint;
+  }
+
   isExpandable = false;
 
   id = nextUniqueId++;
 
   columns = new Map<number, TableColumn>();
+
+  constructor(private renderer: Renderer2, private hostElement: ElementRef) {}
 
   ngAfterContentChecked() {
     if (this.tableHead && this.tableBody) {
@@ -55,6 +70,26 @@ export class LgTableComponent implements AfterContentChecked {
 
       this.handleBodyRows();
     }
+  }
+
+  ngOnInit() {
+    if (!this._columnsBreakpoint) {
+      this.addColumnsBreakpoint(TableColumnLayoutBreakpoints.Medium);
+    }
+  }
+
+  private addColumnsBreakpoint(columnsBreakpoint: TableColumnLayoutBreakpoints) {
+    this.renderer.removeClass(
+      this.hostElement.nativeElement,
+      `lg-table--columns-${this._columnsBreakpoint}`,
+    );
+
+    this.renderer.addClass(
+      this.hostElement.nativeElement,
+      `lg-table--columns-${columnsBreakpoint}`,
+    );
+
+    this._columnsBreakpoint = columnsBreakpoint;
   }
 
   private handleHeadCells() {

--- a/projects/canopy/src/lib/table/table/table.component.ts
+++ b/projects/canopy/src/lib/table/table/table.component.ts
@@ -6,7 +6,6 @@ import {
   ElementRef,
   HostBinding,
   Input,
-  OnInit,
   Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
@@ -24,7 +23,7 @@ let nextUniqueId = 0;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgTableComponent implements AfterContentChecked, OnInit {
+export class LgTableComponent implements AfterContentChecked {
   @HostBinding('class') class = 'lg-table';
 
   @ContentChild(LgTableHeadComponent, { static: false }) tableHead: LgTableHeadComponent;
@@ -36,13 +35,14 @@ export class LgTableComponent implements AfterContentChecked, OnInit {
     return this.isExpandable;
   }
 
-  private _columnsBreakpoint: TableColumnLayoutBreakpoints;
+  private _showColumnsAt: TableColumnLayoutBreakpoints;
   @Input()
   set showColumnsAt(columnsBreakpoint: TableColumnLayoutBreakpoints) {
     this.addColumnsBreakpoint(columnsBreakpoint);
+    this._showColumnsAt = columnsBreakpoint;
   }
   get showColumnsAt(): TableColumnLayoutBreakpoints {
-    return this._columnsBreakpoint;
+    return this._showColumnsAt;
   }
 
   isExpandable = false;
@@ -51,7 +51,9 @@ export class LgTableComponent implements AfterContentChecked, OnInit {
 
   columns = new Map<number, TableColumn>();
 
-  constructor(private renderer: Renderer2, private hostElement: ElementRef) {}
+  constructor(private renderer: Renderer2, private hostElement: ElementRef) {
+    this.showColumnsAt = TableColumnLayoutBreakpoints.Medium;
+  }
 
   ngAfterContentChecked() {
     if (this.tableHead && this.tableBody) {
@@ -72,24 +74,16 @@ export class LgTableComponent implements AfterContentChecked, OnInit {
     }
   }
 
-  ngOnInit() {
-    if (!this._columnsBreakpoint) {
-      this.addColumnsBreakpoint(TableColumnLayoutBreakpoints.Medium);
-    }
-  }
-
   private addColumnsBreakpoint(columnsBreakpoint: TableColumnLayoutBreakpoints) {
     this.renderer.removeClass(
       this.hostElement.nativeElement,
-      `lg-table--columns-${this._columnsBreakpoint}`,
+      `lg-table--columns-${this._showColumnsAt}`,
     );
 
     this.renderer.addClass(
       this.hostElement.nativeElement,
       `lg-table--columns-${columnsBreakpoint}`,
     );
-
-    this._columnsBreakpoint = columnsBreakpoint;
   }
 
   private handleHeadCells() {


### PR DESCRIPTION
# Description

The LgTable currently always uses the non-mobile layout at and above the `md` breakpoint. However, if the table is placed in a container that does not fill the width of the screen then it can be desirable to show the mobile layout at larger screen widths.

This PR adds a new input which allows the consumer to specify at which breakpoint the full size layout should be displayed: 

`[fullSizeBp]="'sm'"` or `[fullSizeBp]="'md'"` or `[fullSizeBp]="'lg'"`

It defaults to using `md` if not provided, so should not introduce a breaking change. I also improved the LgTable storybook Knobs to make them easier to use.

## Requirements

Storybook link: https://deploy-preview-146--legal-and-general-canopy.netlify.app/

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story