### PR TITLE
feat(table): add variant input to table

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     ],
     "projects/canopy/src/**/*.{scss, css}": [
       "prettier --write",
-      "stylelint --fix",
+      "stylelint --syntax scss --fix",
       "git add"
     ],
     "projects/canopy/src/**/*.ts": [

--- a/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 
 import { MockComponents } from 'ng-mocks';
+import { spy, when } from 'ts-mockito';
 
 import { LgTableCellComponent } from '../table-cell/table-cell.component';
 import { LgTableRowToggleComponent } from '../table-row-toggle/table-row-toggle.component';
@@ -9,6 +10,7 @@ import { LgTableRowComponent } from './table-row.component';
 
 describe('LgTableRowComponent', () => {
   let component: LgTableRowComponent;
+  let componentSpy: LgTableRowComponent;
   let fixture: ComponentFixture<LgTableRowComponent>;
   let debugElement: DebugElement;
 
@@ -24,6 +26,7 @@ describe('LgTableRowComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LgTableRowComponent);
     component = fixture.componentInstance;
+    componentSpy = spy(component);
     debugElement = fixture.debugElement;
     fixture.detectChanges();
   });
@@ -34,6 +37,40 @@ describe('LgTableRowComponent', () => {
 
   it('should have the table row class', () => {
     expect(fixture.nativeElement.getAttribute('class')).toContain('lg-table-row');
+  });
+
+  it('should have the table row toggle class if the row is expandable', () => {
+    when(componentSpy.hasToggle).thenReturn(true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-table-row__toggle');
+  });
+
+  it("shouldn't have the table row toggle class if the row is not expandable", () => {
+    when(componentSpy.hasToggle).thenReturn(false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+      'lg-table-row__toggle',
+    );
+  });
+
+  it('should have the active class if the row is toggled active', () => {
+    when(componentSpy.isToggledActive).thenReturn(true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.getAttribute('class')).toContain(
+      'lg-table-row__toggle--active',
+    );
+  });
+
+  it("shouldn't have the active class if the row is not toggled active", () => {
+    when(componentSpy.isToggledActive).thenReturn(false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+      'lg-table-row__toggle--active',
+    );
   });
 
   describe('when the id by is not set', () => {

--- a/projects/canopy/src/lib/table/table-row/table-row.component.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.ts
@@ -2,11 +2,12 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
   ContentChildren,
   HostBinding,
+  Input,
   QueryList,
   ViewEncapsulation,
-  Input,
 } from '@angular/core';
 
 import { LgTableCellComponent } from '../table-cell/table-cell.component';
@@ -46,9 +47,21 @@ export class LgTableRowComponent {
 
   @ContentChildren(LgTableCellComponent) bodyCells: QueryList<LgTableCellComponent>;
 
-  @ContentChildren(LgTableHeadCellComponent) headCells: QueryList<
-    LgTableHeadCellComponent
-  >;
+  @ContentChildren(LgTableHeadCellComponent)
+  headCells: QueryList<LgTableHeadCellComponent>;
+
+  @ContentChild(LgTableCellComponent, { static: true })
+  tableCellComponent: LgTableCellComponent;
+
+  @HostBinding('class.lg-table-row__toggle--active')
+  get isToggledActive(): boolean {
+    return !!this.tableCellComponent?.toggleClass?.isActive;
+  }
+
+  @HostBinding('class.lg-table-row__toggle')
+  get hasToggle(): boolean {
+    return !!this.tableCellComponent?.toggleClass;
+  }
 
   isDetailRow = false;
 

--- a/projects/canopy/src/lib/table/table.interface.ts
+++ b/projects/canopy/src/lib/table/table.interface.ts
@@ -1,3 +1,5 @@
+export type TableVariant = 'striped' | 'bordered';
+
 export enum AlignmentOptions {
   Start = 'start',
   End = 'end',

--- a/projects/canopy/src/lib/table/table.notes.ts
+++ b/projects/canopy/src/lib/table/table.notes.ts
@@ -77,6 +77,7 @@ A component that acts as a standard table.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`showColumnsAt\`\` | Sets the minimum screen width from which the column layout is displayed. Accepts \`sm\`, \`md\` or \`lg\` | string | 'md' | No |
+| \`\`variant\`\` | The variant of table. Accepts \`striped\` or \`bordered\` | string | 'striped' | No |
 
 
 ### LgTableBodyComponent

--- a/projects/canopy/src/lib/table/table.stories.ts
+++ b/projects/canopy/src/lib/table/table.stories.ts
@@ -3,7 +3,11 @@ import { ChangeDetectorRef, Component, Input } from '@angular/core';
 import { boolean, object, select, withKnobs } from '@storybook/addon-knobs';
 import { moduleMetadata } from '@storybook/angular';
 
-import { AlignmentOptions, TableColumnLayoutBreakpoints } from './table.interface';
+import {
+  AlignmentOptions,
+  TableColumnLayoutBreakpoints,
+  TableVariant,
+} from './table.interface';
 import { LgInputModule } from '../forms';
 import { LgMarginModule } from '../spacing';
 import { LgSuffixModule } from '../suffix';
@@ -74,7 +78,7 @@ function getDefaultTableContent(): Array<TableStoryItem> {
 @Component({
   selector: 'story-table-detail',
   template: `
-    <table lg-table [showColumnsAt]="columnBreakpoint">
+    <table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
       <thead lg-table-head>
         <tr lg-table-row>
           <th scope="col" lg-table-head-cell>
@@ -115,11 +119,10 @@ function getDefaultTableContent(): Array<TableStoryItem> {
 })
 export class StoryTableDetailComponent {
   @Input() books: Array<TableStoryItem> = [];
-
+  @Input() variant: TableVariant;
   @Input() alignPublishColumn: AlignmentOptions;
   @Input() showAuthorLabel: boolean;
   @Input() columnBreakpoint: TableColumnLayoutBreakpoints;
-
   @Input() expandedRows: Array<number> = [];
 
   get colspan() {
@@ -165,7 +168,7 @@ export default {
 
 export const standard = () => ({
   template: `
-    <table lg-table [showColumnsAt]="columnBreakpoint">
+    <table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
       <thead lg-table-head>
         <tr lg-table-row>
           <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
@@ -186,6 +189,7 @@ export const standard = () => ({
 
   props: {
     books: object('Books', getDefaultTableContent(), 'Table data'),
+    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),
     alignTitleColumn: select(
       'Align Title column',
       [AlignmentOptions.End, AlignmentOptions.Start],
@@ -217,10 +221,11 @@ export const standard = () => ({
 });
 
 export const detail = () => ({
-  template: `<story-table-detail [books]="books" [alignPublishColumn]="alignPublishColumn" [showAuthorLabel]="showAuthorLabel" [columnBreakpoint]="columnBreakpoint"></story-table-detail>`,
+  template: `<story-table-detail [books]="books" [variant]="variant" [alignPublishColumn]="alignPublishColumn" [showAuthorLabel]="showAuthorLabel" [columnBreakpoint]="columnBreakpoint"></story-table-detail>`,
 
   props: {
     books: object('Books', getDefaultTableContent(), 'Table data'),
+    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),
     alignPublishColumn: select(
       'Align Publish column',
       [AlignmentOptions.Start, AlignmentOptions.End],
@@ -247,7 +252,7 @@ export const detail = () => ({
 
 export const withInput = () => ({
   template: `
-    <table lg-table>
+    <table lg-table [variant]="variant">
       <thead lg-table-head>
         <tr lg-table-row>
           <th lg-table-head-cell>Author</th>
@@ -271,5 +276,6 @@ export const withInput = () => ({
 
   props: {
     books: object('Books', getDefaultTableContent(), 'Table data'),
+    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),
   },
 });

--- a/projects/canopy/src/lib/table/table/table.component.scss
+++ b/projects/canopy/src/lib/table/table/table.component.scss
@@ -7,23 +7,33 @@
   margin-bottom: var(--component-margin);
   border-spacing: 0;
 
-  &--expandable {
-    tr {
-      &:nth-child(4n + 3) {
-        background-color: var(--table-stripe-color);
-      }
+  &--striped:not(&--expandable) tr:nth-child(even) {
+    background-color: var(--table-stripe-color);
+  }
 
-      &:nth-child(4n + 4) {
-        background-color: var(--table-stripe-color);
-      }
+  &--bordered {
+    border-collapse: collapse;
+
+    tr {
+      border-bottom: solid var(--border-width) var(--table-row-border-color);
     }
   }
 
-  &:not(&--expandable) {
-    tr {
-      &:nth-child(even) {
-        background-color: var(--table-stripe-color);
+  &--expandable {
+    &.lg-table--striped {
+      tr {
+        &:nth-child(4n + 3) {
+          background-color: var(--table-stripe-color);
+        }
+
+        &:nth-child(4n + 4) {
+          background-color: var(--table-stripe-color);
+        }
       }
+    }
+
+    &.lg-table--bordered .lg-table-row__toggle--active {
+      border-bottom: 0;
     }
   }
 }

--- a/projects/canopy/src/lib/table/table/table.component.spec.ts
+++ b/projects/canopy/src/lib/table/table/table.component.spec.ts
@@ -84,10 +84,27 @@ describe('TableComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have the default class', () => {
+  it('should have the default classes', () => {
     expect(tableDebugElement.nativeElement.getAttribute('class')).toBe(
-      'lg-table--columns-md lg-table',
+      'lg-table--striped lg-table--columns-md lg-table',
     );
+    expect(tableDebugElement.nativeElement.getAttribute('class')).not.toContain(
+      'lg-table--bordered',
+    );
+  });
+
+  describe('when a variant is specified', () => {
+    it('should set the correct class modifier', () => {
+      component.variant = 'bordered';
+      fixture.detectChanges();
+
+      expect(tableDebugElement.nativeElement.getAttribute('class')).toContain(
+        'lg-table--bordered',
+      );
+      expect(tableDebugElement.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table--striped',
+      );
+    });
   });
 
   it('passes the head content to the respective label template', () => {

--- a/projects/canopy/src/lib/table/table/table.component.ts
+++ b/projects/canopy/src/lib/table/table/table.component.ts
@@ -12,7 +12,11 @@ import {
 
 import { LgTableBodyComponent } from '../table-body/table-body.component';
 import { LgTableHeadComponent } from '../table-head/table-head.component';
-import { TableColumn, TableColumnLayoutBreakpoints } from '../table.interface';
+import {
+  TableColumn,
+  TableColumnLayoutBreakpoints,
+  TableVariant,
+} from '../table.interface';
 
 let nextUniqueId = 0;
 
@@ -27,7 +31,6 @@ export class LgTableComponent implements AfterContentChecked {
   @HostBinding('class') class = 'lg-table';
 
   @ContentChild(LgTableHeadComponent, { static: false }) tableHead: LgTableHeadComponent;
-
   @ContentChild(LgTableBodyComponent, { static: false }) tableBody: LgTableBodyComponent;
 
   @HostBinding('class.lg-table--expandable')
@@ -45,6 +48,22 @@ export class LgTableComponent implements AfterContentChecked {
     return this._showColumnsAt;
   }
 
+  _variant: TableVariant;
+  @Input()
+  set variant(variant: TableVariant) {
+    if (this._variant) {
+      this.renderer.removeClass(
+        this.hostElement.nativeElement,
+        `lg-table--${this.variant}`,
+      );
+    }
+    this.renderer.addClass(this.hostElement.nativeElement, `lg-table--${variant}`);
+    this._variant = variant;
+  }
+  get variant() {
+    return this._variant;
+  }
+
   isExpandable = false;
 
   id = nextUniqueId++;
@@ -52,6 +71,7 @@ export class LgTableComponent implements AfterContentChecked {
   columns = new Map<number, TableColumn>();
 
   constructor(private renderer: Renderer2, private hostElement: ElementRef) {
+    this.variant = 'striped';
     this.showColumnsAt = TableColumnLayoutBreakpoints.Medium;
   }
 

--- a/projects/canopy/src/styles/variables/components/_table.scss
+++ b/projects/canopy/src/styles/variables/components/_table.scss
@@ -2,5 +2,6 @@
   --table-stripe-color: var(--color-white-smoke);
   --table-header-border-width: 0.125rem;
   --table-header-border-color: var(--color-charcoal);
+  --table-row-border-color: var(--color-platinum);
   --table-toggle-width: var(--space-xxl);
 }


### PR DESCRIPTION
# Description

Add a new `variant` input to the table to cater for a new alternative style. This style will be mainly used to overcome accessibility issues when the text is a lighter colour (for example with the blue links).

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Storybook link: https://deploy-preview-155--legal-and-general-canopy.netlify.app/?path=/story/components-table--standard
Design link: (link to design or delete if not required)
Screenshots:
Expandable table:
![Screenshot 2021-01-12 at 17 01 39](https://user-images.githubusercontent.com/8397116/104351549-72896c80-54fd-11eb-8fd4-0b32723071a5.png)
![Screenshot 2021-01-12 at 17 01 53](https://user-images.githubusercontent.com/8397116/104351581-79b07a80-54fd-11eb-90dd-788c2a2b1777.png)

Regular table:
![Screenshot 2021-01-12 at 17 02 23](https://user-images.githubusercontent.com/8397116/104351630-8b921d80-54fd-11eb-95b3-8509dd651a30.png)
![Screenshot 2021-01-12 at 17 02 12](https://user-images.githubusercontent.com/8397116/104351638-8df47780-54fd-11eb-9a1b-283a7f8f2961.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
