### PR TITLE
fix(spacing): add !important to all lgMargin and lgPadding classes

### DIFF
--- a/projects/canopy/src/styles/spacing.scss
+++ b/projects/canopy/src/styles/spacing.scss
@@ -40,59 +40,55 @@ $spacing-list: (
   'xxxxl'
 );
 
-body {
-  // utility classes require additional specificity
+@function space($val) {
+  @if $val == 'none' {
+    @return 0;
+  } @else {
+    @return var(--space-#{$val});
+  }
+}
 
-  @function space($val) {
-    @if $val == 'none' {
-      @return 0;
-    } @else {
-      @return var(--space-#{$val});
-    }
+@each $val in $spacing-list {
+  .lg-margin--#{$val} {
+    margin: space($val) !important;
   }
 
-  @each $val in $spacing-list {
-    .lg-margin--#{$val} {
-      margin: space($val);
-    }
+  .lg-padding--#{$val} {
+    padding: space($val) !important;
+  }
+}
 
-    .lg-padding--#{$val} {
-      padding: space($val);
-    }
+@each $val in $spacing-list {
+  .lg-margin__top--#{$val} {
+    margin-top: space($val) !important;
   }
 
-  @each $val in $spacing-list {
-    .lg-margin__top--#{$val} {
-      margin-top: space($val);
-    }
+  .lg-padding__top--#{$val} {
+    padding-top: space($val) !important;
+  }
 
-    .lg-padding__top--#{$val} {
-      padding-top: space($val);
-    }
+  .lg-margin__right--#{$val} {
+    margin-right: space($val) !important;
+  }
 
-    .lg-margin__right--#{$val} {
-      margin-right: space($val);
-    }
+  .lg-padding__right--#{$val} {
+    padding-right: space($val) !important;
+  }
 
-    .lg-padding__right--#{$val} {
-      padding-right: space($val);
-    }
+  .lg-margin__bottom--#{$val} {
+    margin-bottom: space($val) !important;
+  }
 
-    .lg-margin__bottom--#{$val} {
-      margin-bottom: space($val);
-    }
+  .lg-padding__bottom--#{$val} {
+    padding-bottom: space($val) !important;
+  }
 
-    .lg-padding__bottom--#{$val} {
-      padding-bottom: space($val);
-    }
+  .lg-margin__left--#{$val} {
+    margin-left: space($val) !important;
+  }
 
-    .lg-margin__left--#{$val} {
-      margin-left: space($val);
-    }
-
-    .lg-padding__left--#{$val} {
-      padding-left: space($val);
-    }
+  .lg-padding__left--#{$val} {
+    padding-left: space($val) !important;
   }
 }
 


### PR DESCRIPTION
# Description

When using LgPadding and LgMargin, the styles applied by the directives can be overridden as they
have low specificity. It was agreed that they should make use of !important to overcome this. For details see the issue discussion: #49

Fixes #49

## Requirements

To test, I suggest checking that the padding and margin directives all still work as expected in story book. As a step further, you could import a build from this branch into your project and check it there too. 

Storybook link: (once netlify has deployed link provide a link to the component)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
