### PR TITLE
feat(breadcrumb-item): add input to show items on sm screen

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -13,7 +13,7 @@
                   Home
                 </a>
               </lg-breadcrumb-item>
-              <lg-breadcrumb-item [showItemAt]="breadcrumbBreakpoints.Small">
+              <lg-breadcrumb-item [showItemAt]="breadcrumbItemBreakpoints.Small">
                 <a href="#">Products</a>
               </lg-breadcrumb-item>
               <lg-breadcrumb-item>
@@ -288,7 +288,7 @@
                   <lg-card lgPadding="none">
                     <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
                       <lg-breadcrumb lgMarginBottom="none">
-                        <lg-breadcrumb-item [showItemAt]="breadcrumbBreakpoints.Small">
+                        <lg-breadcrumb-item [showItemAt]="breadcrumbItemBreakpoints.Small">
                           <a href="#">
                             <lg-icon [name]="'chevron-left'"></lg-icon>
                             Back

--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -13,7 +13,7 @@
                   Home
                 </a>
               </lg-breadcrumb-item>
-              <lg-breadcrumb-item showOnSmScreens="true">
+              <lg-breadcrumb-item [showItemAt]="breadcrumbBreakpoints.Small">
                 <a href="#">Products</a>
               </lg-breadcrumb-item>
               <lg-breadcrumb-item>
@@ -288,7 +288,7 @@
                   <lg-card lgPadding="none">
                     <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
                       <lg-breadcrumb lgMarginBottom="none">
-                        <lg-breadcrumb-item showOnSmScreens="true">
+                        <lg-breadcrumb-item [showItemAt]="breadcrumbBreakpoints.Small">
                           <a href="#">
                             <lg-icon [name]="'chevron-left'"></lg-icon>
                             Back

--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -13,7 +13,7 @@
                   Home
                 </a>
               </lg-breadcrumb-item>
-              <lg-breadcrumb-item>
+              <lg-breadcrumb-item showOnSmScreens="true">
                 <a href="#">Products</a>
               </lg-breadcrumb-item>
               <lg-breadcrumb-item>
@@ -288,7 +288,7 @@
                   <lg-card lgPadding="none">
                     <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
                       <lg-breadcrumb lgMarginBottom="none">
-                        <lg-breadcrumb-item>
+                        <lg-breadcrumb-item showOnSmScreens="true">
                           <a href="#">
                             <lg-icon [name]="'chevron-left'"></lg-icon>
                             Back

--- a/projects/canopy-test-app/src/app/app.component.ts
+++ b/projects/canopy-test-app/src/app/app.component.ts
@@ -11,7 +11,7 @@ import {
   lgIconSearch,
   lgIconChevronLeft,
 } from 'projects/canopy/src/lib/icon';
-import { BreadcrumbBreakpoints } from 'projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component';
+import { BreadcrumbItemBreakpoints } from 'projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.interface';
 
 @Component({
   selector: 'app-root',
@@ -25,7 +25,7 @@ export class AppComponent {
   form: FormGroup;
   selectedTabIndex = 0;
   tabs: Array<any>;
-  breadcrumbBreakpoints = BreadcrumbBreakpoints;
+  breadcrumbItemBreakpoints = BreadcrumbItemBreakpoints;
 
   toggleTableRow(index: number) {
     this.expandedTableRow = this.expandedTableRow === index ? null : index;

--- a/projects/canopy-test-app/src/app/app.component.ts
+++ b/projects/canopy-test-app/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {
   lgIconSearch,
   lgIconChevronLeft,
 } from 'projects/canopy/src/lib/icon';
+import { BreadcrumbBreakpoints } from 'projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component';
 
 @Component({
   selector: 'app-root',
@@ -24,6 +25,7 @@ export class AppComponent {
   form: FormGroup;
   selectedTabIndex = 0;
   tabs: Array<any>;
+  breadcrumbBreakpoints = BreadcrumbBreakpoints;
 
   toggleTableRow(index: number) {
     this.expandedTableRow = this.expandedTableRow === index ? null : index;

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item-breakpoints.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item-breakpoints.scss
@@ -1,0 +1,1 @@
+$columns-breakpoints: 'sm', 'md', 'lg' !default;

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
@@ -1,9 +1,12 @@
 <div
   class="lg-breadcrumb-item__container"
   [ngClass]="{
-    'lg-breadcrumb-item__container--visible-sm': showItemAt === breadcrumbBreakpoints.Small,
-    'lg-breadcrumb-item__container--visible-md': showItemAt === breadcrumbBreakpoints.Medium,
-    'lg-breadcrumb-item__container--visible-lg': showItemAt === breadcrumbBreakpoints.Large
+    'lg-breadcrumb-item__container--visible-sm':
+      showItemAt === breadcrumbItemBreakpoints.Small,
+    'lg-breadcrumb-item__container--visible-md':
+      showItemAt === breadcrumbItemBreakpoints.Medium,
+    'lg-breadcrumb-item__container--visible-lg':
+      showItemAt === breadcrumbItemBreakpoints.Large
   }"
 >
   <span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showBackChevron">

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
@@ -1,8 +1,7 @@
 <div
   class="lg-breadcrumb-item__container"
   [ngClass]="{
-    'lg-breadcrumb-item__container--visible-sm': isSmScreenFeaturedItem,
-    'lg-breadcrumb-item__container--hide-icons': hideIcons
+    'lg-breadcrumb-item__container--visible-sm': showOnSmScreens
   }"
 >
   <span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showBackChevron">

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.html
@@ -1,7 +1,9 @@
 <div
   class="lg-breadcrumb-item__container"
   [ngClass]="{
-    'lg-breadcrumb-item__container--visible-sm': showOnSmScreens
+    'lg-breadcrumb-item__container--visible-sm': showItemAt === breadcrumbBreakpoints.Small,
+    'lg-breadcrumb-item__container--visible-md': showItemAt === breadcrumbBreakpoints.Medium,
+    'lg-breadcrumb-item__container--visible-lg': showItemAt === breadcrumbBreakpoints.Large
   }"
 >
   <span class="lg-breadcrumb-item__icon-wrapper" *ngIf="showBackChevron">

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
@@ -16,13 +16,11 @@
     }
   }
 
-  &__container--hide-icons {
-    .lg-breadcrumb-item__content .lg-icon {
-      display: none;
+  .lg-breadcrumb-item__content .lg-icon {
+    display: none;
 
-      @include lg-breakpoint('md') {
-        display: inline;
-      }
+    @include lg-breakpoint('md') {
+      display: inline;
     }
   }
 
@@ -96,3 +94,4 @@
     }
   }
 }
+

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
@@ -7,12 +7,22 @@
     display: none;
     margin-right: var(--space-xxs);
 
-    @include lg-breakpoint('md') {
-      display: flex;
+    &--visible-sm {
+      @include lg-breakpoint('sm') {
+        display: flex;
+      }
     }
 
-    &--visible-sm {
-      display: flex;
+    &--visible-md {
+      @include lg-breakpoint('md') {
+        display: flex;
+      }
+    }
+
+    &--visible-lg {
+      @include lg-breakpoint('lg') {
+        display: flex;
+      }
     }
   }
 

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
@@ -1,4 +1,5 @@
 @import '../../../styles/mixins';
+@import './breadcrumb-item-breakpoints.scss';
 
 .lg-breadcrumb-item {
   align-items: center;
@@ -7,21 +8,11 @@
     display: none;
     margin-right: var(--space-xxs);
 
-    &--visible-sm {
-      @include lg-breakpoint('sm') {
-        display: flex;
-      }
-    }
-
-    &--visible-md {
-      @include lg-breakpoint('md') {
-        display: flex;
-      }
-    }
-
-    &--visible-lg {
-      @include lg-breakpoint('lg') {
-        display: flex;
+    @each $columns-breakpoint in $columns-breakpoints {
+      &--visible-#{$columns-breakpoint} {
+        @include lg-breakpoint($columns-breakpoint) {
+          display: flex;
+        }
       }
     }
   }
@@ -104,4 +95,3 @@
     }
   }
 }
-

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
@@ -2,7 +2,7 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockRender, MockedComponentFixture } from 'ng-mocks';
 
 import { LgIconComponent } from '../../icon/icon.component';
 import { LgBreadcrumbItemComponent } from './breadcrumb-item.component';
@@ -74,14 +74,16 @@ describe('LgBreadcrumbItemComponent', () => {
     });
   });
 
-  describe('when isSmScreenFeaturedItem is true', () => {
+  describe('when showOnSmScreens is true', () => {
+    let localFixture: MockedComponentFixture<LgBreadcrumbItemComponent>;
     beforeEach(() => {
-      component.isSmScreenFeaturedItem = true;
-      fixture.detectChanges();
+      localFixture = MockRender(`<lg-breadcrumb-item [showOnSmScreens]="true"></lg-breadcrumb-item>`)
+      component = localFixture.debugElement.children[0].componentInstance;
+      localFixture.detectChanges();
     });
 
     it(`the class should contain small screen visibility class`, () => {
-      const containerEL = fixture.debugElement.query(
+      const containerEL = localFixture.debugElement.query(
         By.css('.lg-breadcrumb-item__container'),
       );
       expect(containerEL.nativeElement.getAttribute('class')).toContain(
@@ -90,19 +92,4 @@ describe('LgBreadcrumbItemComponent', () => {
     });
   });
 
-  describe('when hideIcons is true', () => {
-    beforeEach(() => {
-      component.hideIcons = true;
-      fixture.detectChanges();
-    });
-
-    it('the class should contain hide-icons class', () => {
-      const containerEL = fixture.debugElement.query(
-        By.css('.lg-breadcrumb-item__container'),
-      );
-      expect(containerEL.nativeElement.getAttribute('class')).toContain(
-        'lg-breadcrumb-item__container--hide-icons',
-      );
-    });
-  });
 });

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { MockComponent, MockRender, MockedComponentFixture } from 'ng-mocks';
 
 import { LgIconComponent } from '../../icon/icon.component';
-import { LgBreadcrumbItemComponent } from './breadcrumb-item.component';
+import { LgBreadcrumbItemComponent, BreadcrumbBreakpoints } from './breadcrumb-item.component';
 import { BreadcrumbVariant } from './breadcrumb-item.interface';
 
 describe('LgBreadcrumbItemComponent', () => {
@@ -74,10 +74,10 @@ describe('LgBreadcrumbItemComponent', () => {
     });
   });
 
-  describe('when showOnSmScreens is true', () => {
+  describe('when showItemAt is sm', () => {
     let localFixture: MockedComponentFixture<LgBreadcrumbItemComponent>;
     beforeEach(() => {
-      localFixture = MockRender(`<lg-breadcrumb-item [showOnSmScreens]="true"></lg-breadcrumb-item>`)
+      localFixture = MockRender(`<lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}"></lg-breadcrumb-item>`)
       component = localFixture.debugElement.children[0].componentInstance;
       localFixture.detectChanges();
     });

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.spec.ts
@@ -5,8 +5,11 @@ import { By } from '@angular/platform-browser';
 import { MockComponent, MockRender, MockedComponentFixture } from 'ng-mocks';
 
 import { LgIconComponent } from '../../icon/icon.component';
-import { LgBreadcrumbItemComponent, BreadcrumbBreakpoints } from './breadcrumb-item.component';
-import { BreadcrumbVariant } from './breadcrumb-item.interface';
+import { LgBreadcrumbItemComponent } from './breadcrumb-item.component';
+import {
+  BreadcrumbVariant,
+  BreadcrumbItemBreakpoints,
+} from './breadcrumb-item.interface';
 
 describe('LgBreadcrumbItemComponent', () => {
   let component: LgBreadcrumbItemComponent;
@@ -77,7 +80,9 @@ describe('LgBreadcrumbItemComponent', () => {
   describe('when showItemAt is sm', () => {
     let localFixture: MockedComponentFixture<LgBreadcrumbItemComponent>;
     beforeEach(() => {
-      localFixture = MockRender(`<lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}"></lg-breadcrumb-item>`)
+      localFixture = MockRender(
+        `<lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}"></lg-breadcrumb-item>`,
+      );
       component = localFixture.debugElement.children[0].componentInstance;
       localFixture.detectChanges();
     });
@@ -91,5 +96,4 @@ describe('LgBreadcrumbItemComponent', () => {
       );
     });
   });
-
 });

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
@@ -10,13 +10,10 @@ import {
 } from '@angular/core';
 
 import * as iconSet from '../../icon/icons.interface';
-import { BreadcrumbVariant } from './breadcrumb-item.interface';
-
-export enum BreadcrumbBreakpoints {
-  Small = 'sm',
-  Medium = 'md',
-  Large = 'lg',
-}
+import {
+  BreadcrumbVariant,
+  BreadcrumbItemBreakpoints,
+} from './breadcrumb-item.interface';
 
 @Component({
   selector: 'lg-breadcrumb-item',
@@ -28,9 +25,9 @@ export enum BreadcrumbBreakpoints {
 export class LgBreadcrumbItemComponent {
   @HostBinding('class.lg-breadcrumb-item') class = true;
 
-  @Input() showItemAt: BreadcrumbBreakpoints = BreadcrumbBreakpoints.Medium;
+  @Input() showItemAt = BreadcrumbItemBreakpoints.Medium;
 
-  breadcrumbBreakpoints = BreadcrumbBreakpoints;
+  breadcrumbItemBreakpoints = BreadcrumbItemBreakpoints;
 
   icons = iconSet;
 

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
@@ -12,6 +12,12 @@ import {
 import * as iconSet from '../../icon/icons.interface';
 import { BreadcrumbVariant } from './breadcrumb-item.interface';
 
+export enum BreadcrumbBreakpoints {
+  Small = 'sm',
+  Medium = 'md',
+  Large = 'lg',
+}
+
 @Component({
   selector: 'lg-breadcrumb-item',
   templateUrl: './breadcrumb-item.component.html',
@@ -22,7 +28,9 @@ import { BreadcrumbVariant } from './breadcrumb-item.interface';
 export class LgBreadcrumbItemComponent {
   @HostBinding('class.lg-breadcrumb-item') class = true;
 
-  @Input() showOnSmScreens = false;
+  @Input() showItemAt: BreadcrumbBreakpoints = BreadcrumbBreakpoints.Medium;
+
+  breadcrumbBreakpoints = BreadcrumbBreakpoints;
 
   icons = iconSet;
 

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
@@ -6,6 +6,7 @@ import {
   ViewEncapsulation,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  Input,
 } from '@angular/core';
 
 import * as iconSet from '../../icon/icons.interface';
@@ -21,29 +22,11 @@ import { BreadcrumbVariant } from './breadcrumb-item.interface';
 export class LgBreadcrumbItemComponent {
   @HostBinding('class.lg-breadcrumb-item') class = true;
 
+  @Input() showOnSmScreens = false;
+
   icons = iconSet;
 
   index: number;
-
-  set hideIcons(hideIcons: boolean) {
-    this._hideIcons = hideIcons;
-
-    this.cd.detectChanges();
-  }
-
-  get hideIcons() {
-    return this._hideIcons;
-  }
-
-  set isSmScreenFeaturedItem(isSmScreenFeaturedItem: boolean) {
-    this._isSmScreenFeaturedItem = isSmScreenFeaturedItem;
-
-    this.cd.detectChanges();
-  }
-
-  get isSmScreenFeaturedItem() {
-    return this._isSmScreenFeaturedItem;
-  }
 
   set variant(variant: BreadcrumbVariant) {
     if (this._variant) {
@@ -88,10 +71,6 @@ export class LgBreadcrumbItemComponent {
   private _showBackChevron = false;
 
   private _showForwardChevron = false;
-
-  private _isSmScreenFeaturedItem = false;
-
-  private _hideIcons = false;
 
   constructor(
     private renderer: Renderer2,

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.interface.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.interface.ts
@@ -4,3 +4,9 @@ export enum BreadcrumbVariant {
   light = 'light',
   dark = 'dark',
 }
+
+export enum BreadcrumbItemBreakpoints {
+  Small = 'sm',
+  Medium = 'md',
+  Large = 'lg',
+}

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponent, MockRender } from 'ng-mocks';
 
 import { LgBreadcrumbItemEllipsisComponent } from './breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component';
-import { LgBreadcrumbItemComponent } from './breadcrumb-item/breadcrumb-item.component';
+import { LgBreadcrumbItemComponent, BreadcrumbBreakpoints } from './breadcrumb-item/breadcrumb-item.component';
 import { BreadcrumbVariant } from './breadcrumb-item/breadcrumb-item.interface';
 import { LgBreadcrumbComponent } from './breadcrumb.component';
 
@@ -54,7 +54,7 @@ describe('LgBreadcrumbComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
-          <lg-breadcrumb-item [showOnSmScreens]="true">Home</lg-breadcrumb-item>
+          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">Home</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
       component = localFixture.debugElement.children[0].componentInstance;
@@ -69,8 +69,8 @@ describe('LgBreadcrumbComponent', () => {
       expect(component.crumbs.first.showForwardChevron).toBe(false);
     });
 
-    it('the first item should set showOnSmScreens to true', () => {
-      expect(component.crumbs.first.showOnSmScreens).toBe(true);
+    it('the first item should set showItemAt to sm', () => {
+      expect(component.crumbs.first.showItemAt).toBe(BreadcrumbBreakpoints.Small);
     });
 
     it('the breadcrumb item variant should be dark', () => {
@@ -84,7 +84,7 @@ describe('LgBreadcrumbComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
-          <lg-breadcrumb-item [showOnSmScreens]="true">Home</lg-breadcrumb-item>
+          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">Home</lg-breadcrumb-item>
           <lg-breadcrumb-item>Retirement</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
@@ -100,8 +100,8 @@ describe('LgBreadcrumbComponent', () => {
       expect(component.crumbs.first.showForwardChevron).toBe(true);
     });
 
-    it('the first item should set showOnSmScreens to true', () => {
-      expect(component.crumbs.first.showOnSmScreens).toBe(true);
+    it('the first item should set showItemAt to sm', () => {
+      expect(component.crumbs.first.showItemAt).toBe(BreadcrumbBreakpoints.Small);
     });
   });
 
@@ -110,7 +110,7 @@ describe('LgBreadcrumbComponent', () => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
           <lg-breadcrumb-item>Home</lg-breadcrumb-item>
-          <lg-breadcrumb-item [showOnSmScreens]="true">Retirement</lg-breadcrumb-item>
+          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">Retirement</lg-breadcrumb-item>
           <lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>
           <lg-breadcrumb-item>Pensions</lg-breadcrumb-item>
         </lg-breadcrumb>
@@ -143,16 +143,16 @@ describe('LgBreadcrumbComponent', () => {
       expect(component.crumbs.toArray()[2].showForwardChevron).toBe(false);
     });
 
-    it('the first item should set showOnSmScreens to false', () => {
-      expect(component.crumbs.toArray()[0].showOnSmScreens).toBe(false);
+    it('the first item should set showItemAt to md', () => {
+      expect(component.crumbs.toArray()[0].showItemAt).toBe(BreadcrumbBreakpoints.Medium);
     });
 
-    it('the second item should set showOnSmScreens to true', () => {
-      expect(component.crumbs.toArray()[1].showOnSmScreens).toBe(true);
+    it('the second item should set showItemAt to sm', () => {
+      expect(component.crumbs.toArray()[1].showItemAt).toBe(BreadcrumbBreakpoints.Small);
     });
 
-    it('the third item should set showOnSmScreens to false', () => {
-      expect(component.crumbs.toArray()[2].showOnSmScreens).toBe(false);
+    it('the third item should set showItemAt to md', () => {
+      expect(component.crumbs.toArray()[2].showItemAt).toBe(BreadcrumbBreakpoints.Medium);
     });
 
     it('the breadcrumb item ellipsis variant should be dark', () => {

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -54,15 +54,11 @@ describe('LgBreadcrumbComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
-          <lg-breadcrumb-item>Home</lg-breadcrumb-item>
+          <lg-breadcrumb-item [showOnSmScreens]="true">Home</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
       component = localFixture.debugElement.children[0].componentInstance;
       localFixture.detectChanges();
-    });
-
-    it('hide custom items should be false', () => {
-      expect(component.crumbs.first.hideIcons).toBe(false);
     });
 
     it('show back button should be false', () => {
@@ -73,8 +69,8 @@ describe('LgBreadcrumbComponent', () => {
       expect(component.crumbs.first.showForwardChevron).toBe(false);
     });
 
-    it('the first item should be the isSmScreenFeaturedItem', () => {
-      expect(component.crumbs.first.isSmScreenFeaturedItem).toBe(true);
+    it('the first item should set showOnSmScreens to true', () => {
+      expect(component.crumbs.first.showOnSmScreens).toBe(true);
     });
 
     it('the breadcrumb item variant should be dark', () => {
@@ -88,16 +84,12 @@ describe('LgBreadcrumbComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
-          <lg-breadcrumb-item>Home</lg-breadcrumb-item>
+          <lg-breadcrumb-item [showOnSmScreens]="true">Home</lg-breadcrumb-item>
           <lg-breadcrumb-item>Retirement</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
       component = localFixture.debugElement.children[0].componentInstance;
       localFixture.detectChanges();
-    });
-
-    it('hide custom icons for the first item', () => {
-      expect(component.crumbs.first.hideIcons).toBe(true);
     });
 
     it('show back button should be true for first item', () => {
@@ -108,8 +100,8 @@ describe('LgBreadcrumbComponent', () => {
       expect(component.crumbs.first.showForwardChevron).toBe(true);
     });
 
-    it('the first item should be the isSmScreenFeaturedItem', () => {
-      expect(component.crumbs.first.isSmScreenFeaturedItem).toBe(true);
+    it('the first item should set showOnSmScreens to true', () => {
+      expect(component.crumbs.first.showOnSmScreens).toBe(true);
     });
   });
 
@@ -118,17 +110,13 @@ describe('LgBreadcrumbComponent', () => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
           <lg-breadcrumb-item>Home</lg-breadcrumb-item>
-          <lg-breadcrumb-item>Retirement</lg-breadcrumb-item>
+          <lg-breadcrumb-item [showOnSmScreens]="true">Retirement</lg-breadcrumb-item>
           <lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>
           <lg-breadcrumb-item>Pensions</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
       component = localFixture.debugElement.children[0].componentInstance;
       localFixture.detectChanges();
-    });
-
-    it('hide custom items should be false for the first item', () => {
-      expect(component.crumbs.first.hideIcons).toBe(false);
     });
 
     it('show back button should be true for first item', () => {
@@ -155,16 +143,16 @@ describe('LgBreadcrumbComponent', () => {
       expect(component.crumbs.toArray()[2].showForwardChevron).toBe(false);
     });
 
-    it('the first item should not be the isSmScreenFeaturedItem', () => {
-      expect(component.crumbs.toArray()[0].isSmScreenFeaturedItem).toBe(false);
+    it('the first item should set showOnSmScreens to false', () => {
+      expect(component.crumbs.toArray()[0].showOnSmScreens).toBe(false);
     });
 
-    it('the second item should be the isSmScreenFeaturedItem', () => {
-      expect(component.crumbs.toArray()[1].isSmScreenFeaturedItem).toBe(true);
+    it('the second item should set showOnSmScreens to true', () => {
+      expect(component.crumbs.toArray()[1].showOnSmScreens).toBe(true);
     });
 
-    it('the third item should not be the isSmScreenFeaturedItem', () => {
-      expect(component.crumbs.toArray()[2].isSmScreenFeaturedItem).toBe(false);
+    it('the third item should set showOnSmScreens to false', () => {
+      expect(component.crumbs.toArray()[2].showOnSmScreens).toBe(false);
     });
 
     it('the breadcrumb item ellipsis variant should be dark', () => {

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -4,8 +4,11 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponent, MockRender } from 'ng-mocks';
 
 import { LgBreadcrumbItemEllipsisComponent } from './breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component';
-import { LgBreadcrumbItemComponent, BreadcrumbBreakpoints } from './breadcrumb-item/breadcrumb-item.component';
-import { BreadcrumbVariant } from './breadcrumb-item/breadcrumb-item.interface';
+import { LgBreadcrumbItemComponent } from './breadcrumb-item/breadcrumb-item.component';
+import {
+  BreadcrumbVariant,
+  BreadcrumbItemBreakpoints,
+} from './breadcrumb-item/breadcrumb-item.interface';
 import { LgBreadcrumbComponent } from './breadcrumb.component';
 
 describe('LgBreadcrumbComponent', () => {
@@ -54,7 +57,7 @@ describe('LgBreadcrumbComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
-          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">Home</lg-breadcrumb-item>
+          <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">Home</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
       component = localFixture.debugElement.children[0].componentInstance;
@@ -70,7 +73,7 @@ describe('LgBreadcrumbComponent', () => {
     });
 
     it('the first item should set showItemAt to sm', () => {
-      expect(component.crumbs.first.showItemAt).toBe(BreadcrumbBreakpoints.Small);
+      expect(component.crumbs.first.showItemAt).toBe(BreadcrumbItemBreakpoints.Small);
     });
 
     it('the breadcrumb item variant should be dark', () => {
@@ -84,7 +87,7 @@ describe('LgBreadcrumbComponent', () => {
     beforeEach(() => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
-          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">Home</lg-breadcrumb-item>
+          <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">Home</lg-breadcrumb-item>
           <lg-breadcrumb-item>Retirement</lg-breadcrumb-item>
         </lg-breadcrumb>
       `);
@@ -101,7 +104,7 @@ describe('LgBreadcrumbComponent', () => {
     });
 
     it('the first item should set showItemAt to sm', () => {
-      expect(component.crumbs.first.showItemAt).toBe(BreadcrumbBreakpoints.Small);
+      expect(component.crumbs.first.showItemAt).toBe(BreadcrumbItemBreakpoints.Small);
     });
   });
 
@@ -110,7 +113,7 @@ describe('LgBreadcrumbComponent', () => {
       const localFixture = MockRender(`
         <lg-breadcrumb>
           <lg-breadcrumb-item>Home</lg-breadcrumb-item>
-          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">Retirement</lg-breadcrumb-item>
+          <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">Retirement</lg-breadcrumb-item>
           <lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>
           <lg-breadcrumb-item>Pensions</lg-breadcrumb-item>
         </lg-breadcrumb>
@@ -144,15 +147,21 @@ describe('LgBreadcrumbComponent', () => {
     });
 
     it('the first item should set showItemAt to md', () => {
-      expect(component.crumbs.toArray()[0].showItemAt).toBe(BreadcrumbBreakpoints.Medium);
+      expect(component.crumbs.toArray()[0].showItemAt).toBe(
+        BreadcrumbItemBreakpoints.Medium,
+      );
     });
 
     it('the second item should set showItemAt to sm', () => {
-      expect(component.crumbs.toArray()[1].showItemAt).toBe(BreadcrumbBreakpoints.Small);
+      expect(component.crumbs.toArray()[1].showItemAt).toBe(
+        BreadcrumbItemBreakpoints.Small,
+      );
     });
 
     it('the third item should set showItemAt to md', () => {
-      expect(component.crumbs.toArray()[2].showItemAt).toBe(BreadcrumbBreakpoints.Medium);
+      expect(component.crumbs.toArray()[2].showItemAt).toBe(
+        BreadcrumbItemBreakpoints.Medium,
+      );
     });
 
     it('the breadcrumb item ellipsis variant should be dark', () => {

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -19,7 +19,7 @@ describe('LgBreadcrumbComponent', () => {
       TestBed.configureTestingModule({
         declarations: [
           LgBreadcrumbComponent,
-          MockComponent(LgBreadcrumbItemComponent),
+          LgBreadcrumbItemComponent,
           MockComponent(LgBreadcrumbItemEllipsisComponent),
         ],
       }).compileComponents();

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.component.ts
@@ -72,14 +72,9 @@ export class LgBreadcrumbComponent implements AfterContentChecked {
 
       crumb.index = index;
 
-      crumb.hideIcons = totalCrumbCount === 2 && !index;
-
       crumb.showBackChevron = totalCrumbCount > 1;
 
       crumb.showForwardChevron = index + 1 !== totalCrumbCount;
-
-      crumb.isSmScreenFeaturedItem =
-        (!index && totalCrumbCount === 1) || index + 2 === totalCrumbCount;
     });
   }
 }

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
@@ -25,7 +25,7 @@ and in your HTML:
       Home
     </a>
   </lg-breadcrumb-item>
-  <lg-breadcrumb-item>
+  <lg-breadcrumb-item showOnSmScreens="true">
     <a href="#">Products</a>
   </lg-breadcrumb-item>
   <lg-breadcrumb-item>
@@ -48,11 +48,17 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
 <lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>
 ~~~
 
-## Inputs
+## Breadcrumb Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`variant\`\` | The colour variants available: \`\`light\`\`, \`\`dark\`\` | string | dark | No |
+
+## Breadcrumb Item Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| \`\`showOnSmScreens\`\` | Specify whether to show a crumb item on small screen devices  | boolean | false | No |
 
 ## Using only the SCSS files
 
@@ -61,7 +67,6 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
 | \`\`lg-breadcrumb\`\` | Adds the default styles to the breadcrumbs
 | \`\`lg-breadcrumb-item\`\` | Adds the default styles to the breadcrumb items
 | \`\`lg-breadcrumb-item__container\`\` | Adds the default styles to the breadcrumb items container
-| \`\`lg-breadcrumb-item__container--hide-icons\`\` | Adds the default styles to hide icons (excluding forward and backward icons)
 | \`\`lg-breadcrumb-item__container--visible-sm\`\` | Adds the default styles to set a breadcrumb item to be visible on small screens
 | \`\`lg-breadcrumb-item__icon-wrapper\`\` | Adds the default styles to set a breadcrumb item icon wrapper
 | \`\`lg-breadcrumb-item__icon\`\` | Adds the default styles to set a breadcrumb item icon
@@ -79,13 +84,13 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
       </span>
     </div>
   </div>
-    <div class="lg-breadcrumb-item--dark lg-breadcrumb-item">
-      <div class="lg-breadcrumb-item__container">
-        <span class="lg-breadcrumb-item__content">
-          <span class="lg-visually-hidden">2.</span>
-          <a href="#" aria-current="page">Product</a>
-        </span>
-      </div>
+  <div class="lg-breadcrumb-item--dark lg-breadcrumb-item">
+    <div class="lg-breadcrumb-item__container">
+      <span class="lg-breadcrumb-item__content">
+        <span class="lg-visually-hidden">2.</span>
+        <a href="#" aria-current="page">Product</a>
+      </span>
+    </div>
   </div>
 </div>
 ~~~

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts
@@ -25,7 +25,7 @@ and in your HTML:
       Home
     </a>
   </lg-breadcrumb-item>
-  <lg-breadcrumb-item showOnSmScreens="true">
+  <lg-breadcrumb-item showItemAt="sm">
     <a href="#">Products</a>
   </lg-breadcrumb-item>
   <lg-breadcrumb-item>
@@ -58,7 +58,7 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| \`\`showOnSmScreens\`\` | Specify whether to show a crumb item on small screen devices  | boolean | false | No |
+| \`\`showItemAt\`\` | Sets the minimum screen width for which a breadcrumb item shows. Accepts \`sm\`, \`md\` or \`lg\`  | string | 'md' | No |
 
 ## Using only the SCSS files
 
@@ -68,6 +68,8 @@ If there are more than 3 levels of hierarchy, a collapsed breadcrumb should be u
 | \`\`lg-breadcrumb-item\`\` | Adds the default styles to the breadcrumb items
 | \`\`lg-breadcrumb-item__container\`\` | Adds the default styles to the breadcrumb items container
 | \`\`lg-breadcrumb-item__container--visible-sm\`\` | Adds the default styles to set a breadcrumb item to be visible on small screens
+| \`\`lg-breadcrumb-item__container--visible-md\`\` | Adds the default styles to set a breadcrumb item to be visible on medium sized screens
+| \`\`lg-breadcrumb-item__container--visible-lg\`\` | Adds the default styles to set a breadcrumb item to be visible on large screens
 | \`\`lg-breadcrumb-item__icon-wrapper\`\` | Adds the default styles to set a breadcrumb item icon wrapper
 | \`\`lg-breadcrumb-item__icon\`\` | Adds the default styles to set a breadcrumb item icon
 | \`\`lg-breadcrumb-item__icon-backward\`\` | Adds the default styles to set a breadcrumb item backward icon

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
@@ -7,7 +7,7 @@ import { LgIconModule } from '../icon/icon.module';
 import { BreadcrumbVariant } from './breadcrumb-item/breadcrumb-item.interface';
 import { LgBreadcrumbModule } from './breadcrumb.module';
 import { notes } from './breadcrumb.notes';
-import { BreadcrumbBreakpoints } from './breadcrumb-item/breadcrumb-item.component';
+import { BreadcrumbItemBreakpoints } from './breadcrumb-item/breadcrumb-item.interface';
 
 interface Breadcrumb {
   text: string;
@@ -17,8 +17,12 @@ interface Breadcrumb {
   selector: 'async-breadcrumb-story',
   template: `
     <lg-breadcrumb [variant]="variant">
-      <lg-breadcrumb-item *ngFor="let crumb of crumbs; index as i"
-        [showItemAt]="i === 1 ? breadcrumbBreakpoints.Small : breadcrumbBreakpoints.Medium">
+      <lg-breadcrumb-item
+        *ngFor="let crumb of crumbs; index as i"
+        [showItemAt]="
+          i === 1 ? breadcrumbItemBreakpoints.Small : breadcrumbItemBreakpoints.Medium
+        "
+      >
         <a href="#" [attr.aria-current]="isCurrentAttribute(i)">
           <lg-icon *ngIf="!i" [name]="'home'"></lg-icon>
           {{ crumb.text }}
@@ -30,7 +34,7 @@ interface Breadcrumb {
 export class AsyncBreadcrumbStoryComponent implements OnInit {
   @Input() variant: BreadcrumbVariant;
 
-  breadcrumbBreakpoints = BreadcrumbBreakpoints;
+  breadcrumbItemBreakpoints = BreadcrumbItemBreakpoints;
 
   crumbs: Array<Breadcrumb> = [];
 
@@ -76,7 +80,7 @@ export default {
 export const twoItems = () => ({
   template: `
     <lg-breadcrumb [variant]="variant">
-      <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
+      <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">
         <a href="#">
           <lg-icon [name]="'home'"></lg-icon>
           Home
@@ -105,7 +109,7 @@ export const threeItems = () => ({
           Home
         </a>
       </lg-breadcrumb-item>
-      <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
+      <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">
         <a href="#">Home Insurance</a>
       </lg-breadcrumb-item>
       <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
@@ -16,7 +16,8 @@ interface Breadcrumb {
   selector: 'async-breadcrumb-story',
   template: `
     <lg-breadcrumb [variant]="variant">
-      <lg-breadcrumb-item *ngFor="let crumb of crumbs; index as i">
+      <lg-breadcrumb-item *ngFor="let crumb of crumbs; index as i"
+        [showOnSmScreens]="i === 1">
         <a href="#" [attr.aria-current]="isCurrentAttribute(i)">
           <lg-icon *ngIf="!i" [name]="'home'"></lg-icon>
           {{ crumb.text }}
@@ -72,7 +73,7 @@ export default {
 export const twoItems = () => ({
   template: `
     <lg-breadcrumb [variant]="variant">
-      <lg-breadcrumb-item>
+      <lg-breadcrumb-item showOnSmScreens="true">
         <a href="#">
           <lg-icon [name]="'home'"></lg-icon>
           Home
@@ -101,7 +102,7 @@ export const threeItems = () => ({
           Home
         </a>
       </lg-breadcrumb-item>
-      <lg-breadcrumb-item>
+      <lg-breadcrumb-item showOnSmScreens="true">
         <a href="#">Home Insurance</a>
       </lg-breadcrumb-item>
       <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
@@ -7,6 +7,7 @@ import { LgIconModule } from '../icon/icon.module';
 import { BreadcrumbVariant } from './breadcrumb-item/breadcrumb-item.interface';
 import { LgBreadcrumbModule } from './breadcrumb.module';
 import { notes } from './breadcrumb.notes';
+import { BreadcrumbBreakpoints } from './breadcrumb-item/breadcrumb-item.component';
 
 interface Breadcrumb {
   text: string;
@@ -17,7 +18,7 @@ interface Breadcrumb {
   template: `
     <lg-breadcrumb [variant]="variant">
       <lg-breadcrumb-item *ngFor="let crumb of crumbs; index as i"
-        [showOnSmScreens]="i === 1">
+        [showItemAt]="i === 1 ? breadcrumbBreakpoints.Small : breadcrumbBreakpoints.Medium">
         <a href="#" [attr.aria-current]="isCurrentAttribute(i)">
           <lg-icon *ngIf="!i" [name]="'home'"></lg-icon>
           {{ crumb.text }}
@@ -28,6 +29,8 @@ interface Breadcrumb {
 })
 export class AsyncBreadcrumbStoryComponent implements OnInit {
   @Input() variant: BreadcrumbVariant;
+
+  breadcrumbBreakpoints = BreadcrumbBreakpoints;
 
   crumbs: Array<Breadcrumb> = [];
 
@@ -73,7 +76,7 @@ export default {
 export const twoItems = () => ({
   template: `
     <lg-breadcrumb [variant]="variant">
-      <lg-breadcrumb-item showOnSmScreens="true">
+      <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
         <a href="#">
           <lg-icon [name]="'home'"></lg-icon>
           Home
@@ -102,7 +105,7 @@ export const threeItems = () => ({
           Home
         </a>
       </lg-breadcrumb-item>
-      <lg-breadcrumb-item showOnSmScreens="true">
+      <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
         <a href="#">Home Insurance</a>
       </lg-breadcrumb-item>
       <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/card/card.notes.ts
+++ b/projects/canopy/src/lib/card/card.notes.ts
@@ -78,7 +78,7 @@ Creates the Form Journey template, used to display a single page form. Note that
       <lg-card lgPadding="none">
         <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
           <lg-breadcrumb lgMarginBottom="none">
-            <lg-breadcrumb-item>
+            <lg-breadcrumb-item showOnSmScreens="true">
               <a href="#">
                 <lg-icon [name]="'chevron-left'"></lg-icon>
                 Back

--- a/projects/canopy/src/lib/card/card.notes.ts
+++ b/projects/canopy/src/lib/card/card.notes.ts
@@ -78,7 +78,7 @@ Creates the Form Journey template, used to display a single page form. Note that
       <lg-card lgPadding="none">
         <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
           <lg-breadcrumb lgMarginBottom="none">
-            <lg-breadcrumb-item showOnSmScreens="true">
+            <lg-breadcrumb-item showItemAt="sm">
               <a href="#">
                 <lg-icon [name]="'chevron-left'"></lg-icon>
                 Back

--- a/projects/canopy/src/lib/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/card.stories.ts
@@ -19,7 +19,7 @@ import { LgHintModule } from '../forms/hint/hint.module';
 import { LgSeparatorModule } from '../separator/separator.module';
 import { iconsArray } from '../icon/icons.stories';
 import { LgIconRegistry } from '../icon/icon.registry';
-import { BreadcrumbBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-item.component';
+import { BreadcrumbItemBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-item.interface';
 
 @Component({
   selector: 'lg-form-journey',
@@ -31,7 +31,7 @@ import { BreadcrumbBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-
             <lg-card lgPadding="none">
               <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
                 <lg-breadcrumb lgMarginBottom="none">
-                  <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
+                  <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">
                     <a href="#">
                       <lg-icon [name]="'chevron-left'"></lg-icon>
                       Back

--- a/projects/canopy/src/lib/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/card.stories.ts
@@ -19,6 +19,7 @@ import { LgHintModule } from '../forms/hint/hint.module';
 import { LgSeparatorModule } from '../separator/separator.module';
 import { iconsArray } from '../icon/icons.stories';
 import { LgIconRegistry } from '../icon/icon.registry';
+import { BreadcrumbBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-item.component';
 
 @Component({
   selector: 'lg-form-journey',
@@ -30,7 +31,7 @@ import { LgIconRegistry } from '../icon/icon.registry';
             <lg-card lgPadding="none">
               <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
                 <lg-breadcrumb lgMarginBottom="none">
-                  <lg-breadcrumb-item showOnSmScreens="true">
+                  <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
                     <a href="#">
                       <lg-icon [name]="'chevron-left'"></lg-icon>
                       Back

--- a/projects/canopy/src/lib/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/card.stories.ts
@@ -30,7 +30,7 @@ import { LgIconRegistry } from '../icon/icon.registry';
             <lg-card lgPadding="none">
               <lg-card-header lgPadding="sm" lgPaddingBottom="xs" lgMarginBottom="lg">
                 <lg-breadcrumb lgMarginBottom="none">
-                  <lg-breadcrumb-item>
+                  <lg-breadcrumb-item showOnSmScreens="true">
                     <a href="#">
                       <lg-icon [name]="'chevron-left'"></lg-icon>
                       Back

--- a/projects/canopy/src/lib/hero/hero.notes.ts
+++ b/projects/canopy/src/lib/hero/hero.notes.ts
@@ -50,7 +50,7 @@ Using the \`\`LgHeroCardHeaderComponent\`\` together with \`\`LgBreadcrumbCompon
       <div lgRow>
         <div [lgCol]="12">
           <lg-breadcrumb lgMarginBottom="none">
-            <lg-breadcrumb-item showOnSmScreens="true">
+            <lg-breadcrumb-item showItemAt="sm">
               <a href="#"><lg-icon [name]="'home'"></lg-icon>Home</a>
             </lg-breadcrumb-item>
             <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/hero/hero.notes.ts
+++ b/projects/canopy/src/lib/hero/hero.notes.ts
@@ -50,7 +50,7 @@ Using the \`\`LgHeroCardHeaderComponent\`\` together with \`\`LgBreadcrumbCompon
       <div lgRow>
         <div [lgCol]="12">
           <lg-breadcrumb lgMarginBottom="none">
-            <lg-breadcrumb-item>
+            <lg-breadcrumb-item showOnSmScreens="true">
               <a href="#"><lg-icon [name]="'home'"></lg-icon>Home</a>
             </lg-breadcrumb-item>
             <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/hero/hero.stories.ts
+++ b/projects/canopy/src/lib/hero/hero.stories.ts
@@ -4,6 +4,7 @@ import { moduleMetadata } from '@storybook/angular';
 import { fullScreen } from '../../../../../.storybook/addons/full-screen';
 import { CanopyModule } from '../canopy.module';
 import { notes } from './hero.notes';
+import { BreadcrumbBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-item.component';
 
 const bodyHTML = `
   <div lgContainer>
@@ -42,7 +43,7 @@ export const productHeroHTML = `
               Home
             </a>
           </lg-breadcrumb-item>
-          <lg-breadcrumb-item showOnSmScreens="true">
+          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
             <a href="#">Products</a>
           </lg-breadcrumb-item>
           <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/hero/hero.stories.ts
+++ b/projects/canopy/src/lib/hero/hero.stories.ts
@@ -4,7 +4,7 @@ import { moduleMetadata } from '@storybook/angular';
 import { fullScreen } from '../../../../../.storybook/addons/full-screen';
 import { CanopyModule } from '../canopy.module';
 import { notes } from './hero.notes';
-import { BreadcrumbBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-item.component';
+import { BreadcrumbItemBreakpoints } from '../breadcrumb/breadcrumb-item/breadcrumb-item.interface';
 
 const bodyHTML = `
   <div lgContainer>
@@ -43,7 +43,7 @@ export const productHeroHTML = `
               Home
             </a>
           </lg-breadcrumb-item>
-          <lg-breadcrumb-item showItemAt="${BreadcrumbBreakpoints.Small}">
+          <lg-breadcrumb-item showItemAt="${BreadcrumbItemBreakpoints.Small}">
             <a href="#">Products</a>
           </lg-breadcrumb-item>
           <lg-breadcrumb-item>

--- a/projects/canopy/src/lib/hero/hero.stories.ts
+++ b/projects/canopy/src/lib/hero/hero.stories.ts
@@ -42,7 +42,7 @@ export const productHeroHTML = `
               Home
             </a>
           </lg-breadcrumb-item>
-          <lg-breadcrumb-item>
+          <lg-breadcrumb-item showOnSmScreens="true">
             <a href="#">Products</a>
           </lg-breadcrumb-item>
           <lg-breadcrumb-item>


### PR DESCRIPTION
BREAKING CHANGE: `showOnSmScreens` attribute needs to be applied on breadcrumb items to enable them to be shown on small screen devices

# Description

The current breadcrumb implementation does not allow the user to select which breadcrumb items should be visible on small screen devices automatically selecting what it considers to be the correct ones but this does not necessarily offer the flexibility an open source component library should provide.

In addition to this the current `hideIcons` mechanism offers little and can be removed as it only targets the first crumb item in a 2 item breadcrumb

`      crumb.hideIcons = totalCrumbCount === 2 && !index;
`

The reason being, custom icons (those created via content projection) are typically only inserted on the first item in the breadcrumb (e.g. the home icon) and (as per our examples) we only show the penultimate breadcrumb item on small screens. It is simpler and more flexible to blanket hide all icons on small screens and (when/if the requirement arises) create an input of the form `showContentIconOnSmScreens` to allow the user to select which icons they want to show on small screens.

# Screenshot
2 items tablet the content icon is visible
![Screenshot 2021-01-19 at 12 46 12](https://user-images.githubusercontent.com/7768665/105039703-c72a6b80-5a58-11eb-8269-9ed4167a5300.png)

2 items sm screen the content icon is hidden
![Screenshot 2021-01-19 at 12 45 40](https://user-images.githubusercontent.com/7768665/105039758-de695900-5a58-11eb-83a9-141a78936ce7.png)

3 items tablet the content icon is visible
![Screenshot 2021-01-19 at 12 46 00](https://user-images.githubusercontent.com/7768665/105039792-ede8a200-5a58-11eb-8dd6-269dd22a853d.png)

3 items sm screen the content icon is hidden
![Screenshot 2021-01-19 at 12 45 49](https://user-images.githubusercontent.com/7768665/105039823-f6d97380-5a58-11eb-8652-2fb9b2a69883.png)


Fixes #15 

## Requirements

The existing components should behave in the same way as they currently do once the `showOnSmScreens` attribute is added to the relevant breadcrumb item. This applies to the breadcrumb component, card component, hero component and the test app.

Storybook link: 
https://deploy-preview-167--legal-and-general-canopy.netlify.app/?path=/story/components-breadcrumb--two-items
https://deploy-preview-167--legal-and-general-canopy.netlify.app/?path=/story/components-breadcrumb--three-items
https://deploy-preview-167--legal-and-general-canopy.netlify.app/?path=/story/components-breadcrumb--asynchronous-loading
https://deploy-preview-167--legal-and-general-canopy.netlify.app/?path=/story/components-card--form-journey
https://deploy-preview-167--legal-and-general-canopy.netlify.app/?path=/story/components-hero--product-details
https://deploy-preview-167--legal-and-general-canopy.netlify.app/?path=/story/test-page--standard

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
