### PR TITLE
Details component updates

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -167,6 +167,8 @@
               </lg-tab-item>
             </lg-tabs>
 
+            <lg-heading level="3">Tabs</lg-heading>
+
             <lg-tab-nav-bar label="Test nav tabs">
               <a
                 id="nav-tab-{{ i }}"
@@ -182,6 +184,8 @@
             <lg-tab-nav-content [selectedTabId]="'nav-tab-' + selectedTabIndex">
               <router-outlet></router-outlet>
             </lg-tab-nav-content>
+
+            <lg-heading level="3">Accordion</lg-heading>
 
             <lg-accordion [headingLevel]="3">
               <lg-accordion-item>
@@ -204,6 +208,40 @@
               </lg-accordion-item>
             </lg-accordion>
 
+            <lg-heading level="3">Details</lg-heading>
+
+            <lg-details>
+              <lg-details-panel-heading headingLevel="4">Details component</lg-details-panel-heading>
+              Give us a call on <a href="tel:08001234567">0800 123 4567</a> and we'll be happy to help you change your
+      payment details
+            </lg-details>
+
+            <lg-details variant="info">
+              <lg-details-panel-heading headingLevel="4">Details component</lg-details-panel-heading>
+              Give us a call on <a href="tel:08001234567">0800 123 4567</a> and we'll be happy to help you change your
+      payment details
+            </lg-details>
+
+            <lg-details variant="warning">
+              <lg-details-panel-heading headingLevel="4">Details component</lg-details-panel-heading>
+              Give us a call on <a href="tel:08001234567">0800 123 4567</a> and we'll be happy to help you change your
+      payment details
+            </lg-details>
+
+            <lg-details variant="success">
+              <lg-details-panel-heading headingLevel="4">Details component</lg-details-panel-heading>
+              Give us a call on <a href="tel:08001234567">0800 123 4567</a> and we'll be happy to help you change your
+      payment details
+            </lg-details>
+
+            <lg-details variant="error">
+              <lg-details-panel-heading headingLevel="4">Details component</lg-details-panel-heading>
+              Give us a call on <a href="tel:08001234567">0800 123 4567</a> and we'll be happy to help you change your
+      payment details
+            </lg-details>
+
+            <lg-heading level="3">Alert</lg-heading>
+
             <lg-alert variant="info">
               <lg-heading level="4">Test heading</lg-heading>
               Information alert
@@ -213,9 +251,10 @@
 
             <lg-alert variant="success"> Success alert </lg-alert>
 
-            <lg-alert variant="error" lgMarginBottom="xxxl"> Error alert </lg-alert>
+            <lg-alert variant="error"> Error alert </lg-alert>
 
             <lg-alert variant="generic">
+              Generic alert
               <ul>
                 <li>Item 1</li>
                 <li>Item 2</li>
@@ -223,6 +262,8 @@
                 <li>Item 4</li>
               </ul>
             </lg-alert>
+
+            <lg-heading level="3">Cards</lg-heading>
 
             <lg-card>
               <lg-card-header>
@@ -298,6 +339,8 @@
               </div>
             </div>
 
+            <lg-heading level="3">Buttons</lg-heading>
+
             <button lg-button variant="solid-primary">Solid primary button</button>
             <br />
 
@@ -344,6 +387,8 @@
             <br />
 
             <lg-separator></lg-separator>
+
+            <lg-heading level="3">Form</lg-heading>
 
             <form [formGroup]="form" (ngSubmit)="onSubmit(form)">
               <lg-input-field>
@@ -475,6 +520,8 @@
 
             <lg-separator></lg-separator>
 
+            <lg-heading level="3">Spinners</lg-heading>
+
             <lg-spinner variant="dark"></lg-spinner>
 
             <lg-spinner
@@ -489,6 +536,9 @@
               lgMarginTop="xxl"
               size="sm"
             ></lg-spinner>
+
+
+            <lg-heading level="3">Table</lg-heading>
 
             <table lg-table>
               <thead lg-table-head>

--- a/projects/canopy/src/lib/alert/alert.notes.ts
+++ b/projects/canopy/src/lib/alert/alert.notes.ts
@@ -5,6 +5,9 @@ export const notes = `
 ## Purpose
 Alerts are used to communicate important information to the user.
 
+The "alert" ARIA role is automatically added to the component if it's one of these variants: \`\`warning\`\`, \`\`error\`\`, \`\`success\`\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.
+
+A decorative icon is also added next to the heading if it's one of the these variants: \`\`info\`\`, \`\`warning\`\`, \`\`error\`\`, \`\`success\`\`.
 
 ## Usage
 ~~~js
@@ -25,8 +28,8 @@ and in your HTML:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| \`\`variant\`\` | The variant of alert: \`\`info\`\`, \`\`warning\`\`, \`\`error\`\`, \`\`success\`\` | string | 'info' | No |
-| \`\`showIcon\`\` | Whether the icon should display | boolean | true | No |
+| \`\`variant\`\` | Applies colour treatment and ARIA role if applicable: \`\`generic\`\`, \`\`info\`\`, \`\`warning\`\`, \`\`error\`\`, \`\`success\`\` | string | 'generic' | No |
+| \`\`showIcon\`\` | Whether the icon should display on the warning, error or success variants | boolean | true | No |
 
 
 ## Using only the SCSS files
@@ -45,7 +48,7 @@ In addition to \`\`lg-alert\`\`, one of the following is required to apply the s
 
 ### Accessibility
 
-Add the correct Aria role attribute depending on the type of alert. \`\`role="alert"\`\` can be quite intrusive, so only use it when required.
+Add the correct ARIA role attribute depending on the type of alert. \`\`role="alert"\`\` can be quite intrusive, so only use it when required.
 
 See the Mozilla docs on [ARIA alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role).
 

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.html
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.html
@@ -8,6 +8,16 @@
     [attr.aria-controls]="panelId"
     (click)="toggle()"
   >
+    <div
+      *ngIf="showIcon && variant !== 'generic'"
+      [ngSwitch]="variant"
+      class="lg-details-panel-heading__icon"
+    >
+      <lg-icon *ngSwitchCase="'error'" name="crossmark-spot-fill"></lg-icon>
+      <lg-icon *ngSwitchCase="'info'" name="information-fill"></lg-icon>
+      <lg-icon *ngSwitchCase="'warning'" name="warning-fill"></lg-icon>
+      <lg-icon *ngSwitchCase="'success'" name="checkmark-spot-fill"></lg-icon>
+    </div>
     <ng-content></ng-content>
     <lg-icon [name]="chevronDown" class="lg-details-panel-heading__state-icon"></lg-icon>
   </button>

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
@@ -8,7 +8,7 @@
   &__toggle {
     background: transparent;
     border: none;
-    color: var(--details-color);
+    color: inherit;
     cursor: pointer;
     display: inline-flex;
     padding: var(--space-sm);
@@ -34,4 +34,8 @@
     top: var(--details-chevron-top-positon);
     transition: transform var(--animation-duration) var(--animation-fn);
   }
+}
+
+.lg-details-panel-heading__icon {
+  margin-right: var(--space-xs);
 }

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
@@ -8,6 +9,7 @@ import {
 } from '@angular/core';
 
 import { lgIconChevronDown } from '../../icon';
+import { DetailsVariant } from '../details.interface';
 
 let nextUniqueId = 0;
 @Component({
@@ -20,12 +22,35 @@ let nextUniqueId = 0;
 export class LgDetailsPanelHeadingComponent {
   @Input() headingLevel;
   @Input() isActive = false;
+
+  _showIcon = true;
+  @Input()
+  set showIcon(showIcon: boolean) {
+    this._showIcon = showIcon;
+    this.cdr.detectChanges();
+  }
+  get showIcon(): boolean {
+    return this._showIcon;
+  }
+
+  _variant: DetailsVariant = 'generic';
+  @Input()
+  set variant(variant: DetailsVariant) {
+    this._variant = variant;
+    this.cdr.detectChanges();
+  }
+  get variant(): DetailsVariant {
+    return this._variant;
+  }
+
   @Output() toggleActive = new EventEmitter<boolean>();
 
   chevronDown = lgIconChevronDown.name;
   id = nextUniqueId++;
   toggleId = `lg-details-header-${this.id}`;
   panelId = `lg-details-content-${this.id}`;
+
+  constructor(private cdr: ChangeDetectorRef) {}
 
   toggle() {
     this.isActive = !this.isActive;

--- a/projects/canopy/src/lib/details/details.component.scss
+++ b/projects/canopy/src/lib/details/details.component.scss
@@ -15,3 +15,23 @@
     }
   }
 }
+
+.lg-details--generic {
+  @include lg-variant('generic');
+}
+
+.lg-details--info {
+  @include lg-variant('info');
+}
+
+.lg-details--success {
+  @include lg-variant('success');
+}
+
+.lg-details--warning {
+  @include lg-variant('warning');
+}
+
+.lg-details--error {
+  @include lg-variant('error');
+}

--- a/projects/canopy/src/lib/details/details.component.spec.ts
+++ b/projects/canopy/src/lib/details/details.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 
 import { MockComponent, MockRender, MockedComponentFixture } from 'ng-mocks';
@@ -12,11 +12,13 @@ describe('LgDetailsComponent', () => {
   let detailsDebugElement: DebugElement;
   let detailsEl: HTMLElement;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [LgDetailsComponent, MockComponent(LgDetailsPanelHeadingComponent)],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [LgDetailsComponent, MockComponent(LgDetailsPanelHeadingComponent)],
+      }).compileComponents();
+    }),
+  );
 
   describe('component', () => {
     beforeEach(() => {
@@ -37,6 +39,51 @@ describe('LgDetailsComponent', () => {
 
     it('should have the default class', () => {
       expect(detailsEl.getAttribute('class')).toContain('lg-details');
+    });
+
+    it('adds generic as the default variant', () => {
+      expect(detailsEl.getAttribute('class')).toContain('generic');
+    });
+  });
+
+  describe('Aria roles', () => {
+    beforeEach(() => {
+      fixture = MockRender(`
+        <lg-details>
+          <lg-details-panel-heading></lg-details-panel-heading>
+        </lg-details>
+      `);
+      detailsDebugElement = fixture.debugElement;
+      detailsEl = detailsDebugElement.children[0].nativeElement;
+      component = fixture.point.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('does not add an Aria role for the generic variant', () => {
+      expect(detailsEl.getAttribute('role')).toBeNull();
+    });
+
+    it('does not add an Aria role for the info variant', () => {
+      component.variant = 'info';
+      expect(detailsEl.getAttribute('role')).toBeNull();
+    });
+
+    it('adds an Aria role "alert" for the warning variant', () => {
+      component.variant = 'warning';
+      fixture.detectChanges();
+      expect(detailsEl.getAttribute('role')).toBe('alert');
+    });
+
+    it('adds an Aria role "alert" for the error variant', () => {
+      component.variant = 'error';
+      fixture.detectChanges();
+      expect(detailsEl.getAttribute('role')).toBe('alert');
+    });
+
+    it('adds an Aria role "success" for the error variant', () => {
+      component.variant = 'success';
+      fixture.detectChanges();
+      expect(detailsEl.getAttribute('role')).toBe('alert');
     });
   });
 

--- a/projects/canopy/src/lib/details/details.component.ts
+++ b/projects/canopy/src/lib/details/details.component.ts
@@ -4,17 +4,20 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChild,
+  ElementRef,
   EventEmitter,
   HostBinding,
   Input,
   OnDestroy,
   Output,
+  Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
 
 import { Subscription } from 'rxjs';
 
 import { LgDetailsPanelHeadingComponent } from './details-panel-heading/details-panel-heading.component';
+import { DetailsVariant } from './details.interface';
 
 let nextUniqueId = 0;
 
@@ -32,6 +35,44 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
   panelHeading: LgDetailsPanelHeadingComponent;
 
   @Input() isActive = false;
+
+  _showIcon = true;
+  @Input()
+  set showIcon(showIcon: boolean) {
+    this._showIcon = showIcon;
+    if (this.panelHeading) {
+      this.panelHeading.showIcon = showIcon;
+    }
+  }
+  get showIcon() {
+    return this._showIcon;
+  }
+
+  _variant: DetailsVariant;
+  @Input()
+  set variant(variant: DetailsVariant) {
+    if (this._variant) {
+      this.renderer.removeClass(
+        this.hostElement.nativeElement,
+        `lg-details--${this._variant}`,
+      );
+    }
+    if (this.panelHeading) {
+      this.panelHeading.variant = variant;
+    }
+    this.renderer.addClass(this.hostElement.nativeElement, `lg-details--${variant}`);
+    this._variant = variant;
+  }
+  get variant() {
+    return this._variant;
+  }
+
+  @HostBinding('attr.role') get role(): string {
+    if (this.variant !== 'info' && this.variant !== 'generic') {
+      return 'alert';
+    }
+  }
+
   @Output() opened = new EventEmitter<void>();
   @Output() closed = new EventEmitter<void>();
 
@@ -41,10 +82,18 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
 
   private subscription: Subscription;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(
+    private renderer: Renderer2,
+    private hostElement: ElementRef,
+    private cdr: ChangeDetectorRef,
+  ) {
+    this.variant = 'generic';
+  }
 
   ngAfterContentInit() {
     this.panelHeading.isActive = this.isActive;
+    this.panelHeading.variant = this.variant;
+    this.panelHeading.showIcon = this.showIcon;
 
     this.subscription = this.panelHeading.toggleActive.subscribe((isActive) => {
       this.isActive = isActive;

--- a/projects/canopy/src/lib/details/details.interface.ts
+++ b/projects/canopy/src/lib/details/details.interface.ts
@@ -1,0 +1,1 @@
+export type DetailsVariant = 'generic' | 'info' | 'success' | 'warning' | 'error';

--- a/projects/canopy/src/lib/details/details.module.ts
+++ b/projects/canopy/src/lib/details/details.module.ts
@@ -4,7 +4,13 @@ import { NgModule } from '@angular/core';
 import { LgHeadingModule } from '../heading/heading.module';
 import { LgIconModule } from '../icon/icon.module';
 import { LgIconRegistry } from '../icon/icon.registry';
-import { lgIconChevronDown } from '../icon/icons.interface';
+import {
+  lgIconChevronDown,
+  lgIconCheckmarkSpotFill,
+  lgIconCrossmarkSpotFill,
+  lgIconInformationFill,
+  lgIconWarningFill,
+} from '../icon/icons.interface';
 import { LgDetailsPanelHeadingComponent } from './details-panel-heading/details-panel-heading.component';
 import { LgDetailsComponent } from './details.component';
 
@@ -15,6 +21,12 @@ import { LgDetailsComponent } from './details.component';
 })
 export class LgDetailsModule {
   constructor(private registry: LgIconRegistry) {
-    this.registry.registerIcons([lgIconChevronDown]);
+    this.registry.registerIcons([
+      lgIconChevronDown,
+      lgIconCrossmarkSpotFill,
+      lgIconInformationFill,
+      lgIconWarningFill,
+      lgIconCheckmarkSpotFill,
+    ]);
   }
 }

--- a/projects/canopy/src/lib/details/details.notes.ts
+++ b/projects/canopy/src/lib/details/details.notes.ts
@@ -3,7 +3,11 @@ export const notes = `
 
 
 ## Purpose
-The Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it.
+The Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.
+
+The "alert" ARIA role is automatically added to the component if it's one of these variants: \`\`warning\`\`, \`\`error\`\`, \`\`success\`\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.
+
+A decorative icon is also added next to the heading if it's one of the these variants: \`\`info\`\`, \`\`warning\`\`, \`\`error\`\`, \`\`success\`\`.
 
 ## Usage
 ~~~js
@@ -30,7 +34,9 @@ and in your HTML:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`isActive\`\` | Expand the details | boolean | false | no |
-| \`\`headingLevel\`\` | The level of the accordion headings: \`\`1\`\`, \`\`2\`\`, \`\`3\`\`, \`\`4\`\`, \`\`5\`\`, \`\`6\`\` | number | n/a | Yes |
+| \`\`headingLevel\`\` | The level of the details heading: \`\`1\`\`, \`\`2\`\`, \`\`3\`\`, \`\`4\`\`, \`\`5\`\`, \`\`6\`\` | number | n/a | Yes |
+|\`\`variant\`\`| Applies colour treatment and ARIA role if applicable: \`\`generic\`\`, \`\`info\`\`, \`\`warning\`\`, \`\`error\`\`, \`\`success\`\` | string | 'generic' | No |
+| \`\`showIcon\`\` | Whether the icon should display on the warning, error or success variants | boolean | true | No |
 
 ## Outputs
 

--- a/projects/canopy/src/lib/details/details.stories.ts
+++ b/projects/canopy/src/lib/details/details.stories.ts
@@ -5,6 +5,7 @@ import { action } from '@storybook/addon-actions';
 import { LgHeadingModule } from '../heading';
 import { LgDetailsModule } from './details.module';
 import { notes } from './details.notes';
+import { LgIconModule } from '../icon';
 
 export default {
   title: 'Components/Details',
@@ -12,7 +13,7 @@ export default {
     decorators: [
       withKnobs,
       moduleMetadata({
-        imports: [LgDetailsModule, LgHeadingModule],
+        imports: [LgDetailsModule, LgHeadingModule, LgIconModule],
       }),
     ],
     'in-dsm': {
@@ -28,11 +29,12 @@ export const standard = () => ({
   template: `
     <lg-details
       [isActive]="expand"
+      [variant]="variant"
+      [showIcon]="showIcon"
       (opened)="toggle('Detail opened')"
       (closed)="toggle('Detail closed')">
       <lg-details-panel-heading [headingLevel]="headingLevel">{{ header }}</lg-details-panel-heading>
-
-      Give us a call on 0800 123 4567 and we'll be happy to help you change your
+      Give us a call on <a href="tel:08001234567">0800 123 4567</a> and we'll be happy to help you change your
       payment details
     </lg-details>
   `,
@@ -41,5 +43,11 @@ export const standard = () => ({
     expand: boolean('Default expand', false),
     headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 5),
     toggle: action('Details active state change'),
+    variant: select(
+      'variant',
+      ['generic', 'info', 'success', 'warning', 'error'],
+      'generic',
+    ),
+    showIcon: boolean('Show icon (warning, success & error variants only)', true),
   },
 });

--- a/projects/canopy/src/styles/variables/components/_details.scss
+++ b/projects/canopy/src/styles/variables/components/_details.scss
@@ -1,5 +1,4 @@
 :root {
-  --details-color: var(--color-charcoal);
   --details-bg-color: var(--color-white-smoke);
   --details-chevron-top-positon: 0.2rem;
 }


### PR DESCRIPTION
# Description

Adds the same variants to the Details component that can be used with the Alert component. Also automatically sets the ARIA role to "alert" for specific variants, and adds an icon to the panel heading component if applicable.



## Requirements

Storybook link: https://deploy-preview-169--legal-and-general-canopy.netlify.app/?path=/story/components-details--standard
Design:
<img width="1357" alt="Screenshot 2021-01-18 at 14 16 55" src="https://user-images.githubusercontent.com/1943532/105161660-863e5f80-5b09-11eb-8aed-f0249bc92063.png">

Screenshot: 
![Screenshot 2021-01-20 at 10 24 14](https://user-images.githubusercontent.com/1943532/105161785-acfc9600-5b09-11eb-9149-dd43c8b94b6c.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)