### PR TITLE
feat(table): align items to center - not baseline - in table cell

### DIFF
--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -3,7 +3,7 @@
 
 .lg-table-cell {
   display: flex;
-  align-items: baseline;
+  align-items: center;
 
   &--toggle-cell {
     order: 1;

--- a/projects/canopy/src/lib/table/table.stories.ts
+++ b/projects/canopy/src/lib/table/table.stories.ts
@@ -264,7 +264,7 @@ export const withInput = () => ({
         <tr lg-table-row *ngFor="let book of books">
           <td lg-table-cell>{{ book.author }}</td>
           <td lg-table-cell>
-            <lg-input-field lgMarginBottom="none">
+            <lg-input-field lgMarginBottom="none" [showLabel]="false">
               <input lgInput size="2" />
               <span lgSuffix>%</span>
             </lg-input-field>


### PR DESCRIPTION
# Description

Fixes an alignment issue when a table column's header label wraps onto multiple lines in the non-column (aka mobile) layout.

Fixes #108 

## Requirements

Storybook link: (once netlify has deployed link provide a link to the component)

Screenshot:
<img width="293" alt="Screenshot 2021-01-20 at 12 01 31" src="https://user-images.githubusercontent.com/1677737/105172282-4a11fb80-5b17-11eb-86c9-8aec0b87a3e7.png">

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- *N/A* I have provided an adequate amount of test coverage
- *N/A* I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- *N/A* I have provided a story in storybook to document the changes
- *N/A* I have provided documentation in the notes section of the story
- *N/A* I have added any new public feature modules to public-api.ts
- *N/A* I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
