### PR TITLE
build(commitizen): bump commitizen from 4.2.1 to 4.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "babel-loader": "^8.1.0",
     "codelyzer": "^6.0.1",
     "color-convert": "^2.0.1",
-    "commitizen": "^4.2.1",
+    "commitizen": "^4.2.3",
     "copy-webpack-plugin": "^6.4.1",
     "css-vars-ponyfill": "^2.4.2",
     "cz-conventional-changelog": "^3.2.0",


### PR DESCRIPTION
# Description

Bumps [commitizen](https://github.com/commitizen/cz-cli) from 4.2.1 to 4.2.3.


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)