### PR TITLE
fix(table): update spacing styles of cells on small devices

### DIFF
--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -21,9 +21,14 @@
 
 .lg-table-cell__content {
   margin-left: auto;
+  white-space: nowrap;
 }
 
 .lg-table-cell--expandable-content {
+  .lg-table-cell__label {
+    padding-right: 0;
+  }
+
   .lg-table-cell__content {
     margin-left: 0;
   }
@@ -31,6 +36,7 @@
 
 .lg-table-cell__label {
   font-weight: var(--font-weight-bold);
+  padding-right: var(--space-md);
 }
 
 @each $columns-breakpoint in $columns-breakpoints {

--- a/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.scss
+++ b/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.scss
@@ -1,0 +1,3 @@
+.lg-table-expanded-detail {
+  white-space: normal;
+}

--- a/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.ts
+++ b/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.ts
@@ -8,6 +8,7 @@ import {
 @Component({
   selector: 'lg-table-expanded-detail',
   templateUrl: './table-expanded-detail.component.html',
+  styleUrls: ['./table-expanded-detail.component.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
# Description

We found a bug where on mobile long table cell labels were too close to the table cell value. In addition to that the table cell was wrapping so I've set the table cell content to never do that since the table cell value should always be short.

Before:
![Screenshot 2021-02-01 at 10 47 54](https://user-images.githubusercontent.com/8397116/106448751-191cb980-647b-11eb-89bd-3ab863b709b9.png)

After:
![Screenshot 2021-02-01 at 10 48 30](https://user-images.githubusercontent.com/8397116/106448736-14f09c00-647b-11eb-8bf4-2ccae5137357.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
