### PR TITLE
fix(code-ql): update camel case pipe regex

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -94,7 +94,7 @@ To ensure that changes come from an entrusted source all commits must be [signed
 
 ## Review Process
 
-Pull requests require two successful approvals before they can be merged. One review must be from a [CODEWONER](./.github/CODEOWNERS). We also require that developers working on a specific project seek review from someone on a different project. The aim being that by removing any immediate delivery pressure we can ensure a high level of quality and negate the risk of factions forming within the codebase, currently we cannot automate this process and so it must be based on trust.
+Pull requests require two successful approvals before they can be merged. One review must be from a [CODEOWNER](./.github/CODEOWNERS). We also require that developers working on a specific project seek review from someone on a different project. The aim being that by removing any immediate delivery pressure we can ensure a high level of quality and negate the risk of factions forming within the codebase, currently we cannot automate this process and so it must be based on trust.
 
 ### Code Owners
 

--- a/projects/canopy/src/lib/pipes/camel-case/camel-case.pipe.ts
+++ b/projects/canopy/src/lib/pipes/camel-case/camel-case.pipe.ts
@@ -12,6 +12,6 @@ export class LgCamelCasePipe implements PipeTransform {
           .replace(/(?:^\w|[A-Z]|\b\w)/g, (ltr, idx) =>
             idx === 0 ? ltr.toLowerCase() : ltr.toUpperCase(),
           )
-          .replace(/(\s|-|\/|')+/g, '');
+          .replace(/(\s|-|\/|')/g, '');
   }
 }


### PR DESCRIPTION
# Description

Apparently there was another instance of the insufficient regular expression.

I've also fixed a typo spotted by Alex C.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
