### PR TITLE
Fix issue with Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,27 @@ updates:
       include: 'scope'
     versioning-strategy: increase
     ignore:
-      - dependency_name: "@storybook/*"
+      - dependency_name: "@storybook/addon-a11y"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-actions"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-backgrounds"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-docs"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-knobs"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-notes"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-options"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-storysource"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addon-viewport"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/addons"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/angular"
+        versions: ["6.x"]
+      - dependency_name: "@storybook/theming"
         versions: ["6.x"]

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ storybook-static
 /bazel-out
 
 # dependencies
-/node_modules
+node_modules/
 /.dsm
 
 # profiling files


### PR DESCRIPTION
# Description

The current `"@storybook/*"` should work but it doesn't. I've found another person with the same issue but no answer.
I've updated the current list to be more specific which hopefully should work.

In addition to that I've modified the `.gitignore` to cover the nested node modules.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
