### PR TITLE
fix(segment): update style for error state

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
@@ -29,6 +29,11 @@
     }
   }
 
+  &.lg-radio-button--error .lg-radio-button__input:checked + .lg-radio-button__label {
+    background-color: var(--form-error-color);
+    color: var(--radio-color);
+  }
+
   .lg-radio-button__input {
     &:checked + .lg-radio-button__label {
       background-color: var(--radio-bg-color);
@@ -48,11 +53,6 @@
 
     &:focus + .lg-radio-button__label {
       @include lg-inner-focus-outline(var(--default-focus-color));
-    }
-
-    .lg-radio-button--error &:checked + .lg-radio-button__label {
-      background-color: var(--form-error-color);
-      color: var(--radio-color);
     }
   }
 

--- a/projects/canopy/src/lib/forms/radio/radio-group--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-group--segment.component.scss
@@ -4,6 +4,10 @@
   display: inline-flex;
   border: var(--border-width) solid var(--radio-border-color);
   border-radius: var(--border-radius-sm);
+
+  .lg-radio-group--error & {
+    border-color: var(--form-error-color);
+  }
 }
 
 $stack-breakpoints: 'sm', 'md', 'lg' !default;

--- a/projects/canopy/src/lib/forms/validation/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/form.stories.ts
@@ -106,6 +106,25 @@ function invalidValidator(): ValidatorFn {
         </lg-validation>
       </lg-radio-group>
 
+      <lg-segment-group formControlName="segment">
+        Segment option
+        <lg-hint>This is a standard segment group</lg-hint>
+        <lg-segment-button value="yellow">Yellow</lg-segment-button>
+        <lg-segment-button value="red">Red</lg-segment-button>
+        <lg-segment-button value="blue">Blue</lg-segment-button>
+        <lg-segment-button value="invalid">Invalid</lg-segment-button>
+        <lg-validation
+          *ngIf="isControlInvalid(segment, validationForm) && segment.hasError('invalid')"
+        >
+          Please select a valid option
+        </lg-validation>
+        <lg-validation
+          *ngIf="isControlInvalid(radio, validationForm) && radio.hasError('required')"
+        >
+          Please select an option
+        </lg-validation>
+      </lg-segment-group>
+
       <lg-checkbox-group formControlName="colors">
         Checkbox group
         <lg-hint>This is a standard checkbox group</lg-hint>
@@ -207,6 +226,10 @@ class ReactiveFormComponent {
     return this.form.get('radio');
   }
 
+  get segment() {
+    return this.form.get('segment');
+  }
+
   get colors() {
     return this.form.get('colors');
   }
@@ -226,6 +249,7 @@ class ReactiveFormComponent {
       text: ['', [Validators.required, Validators.minLength(4), invalidValidator()]],
       select: ['', [Validators.required, invalidValidator()]],
       radio: ['', [Validators.required, invalidValidator()]],
+      segment: ['', [Validators.required, invalidValidator()]],
       colors: this.fb.control([], [Validators.required]),
       checkbox: ['', [Validators.requiredTrue]],
       switch: ['', [Validators.requiredTrue]],


### PR DESCRIPTION
# Description

Update error styles for segment as incorrect.

Storybook link: https://deploy-preview-216--legal-and-general-canopy.netlify.app/?path=/story/components-form-form-validation--standard

Screenshot before:
![Screenshot 2021-02-15 at 15 36 25](https://user-images.githubusercontent.com/8397116/107967940-aa288000-6fa5-11eb-93ab-4f95b1740bae.png)

Screenshot after:
![Screenshot 2021-02-15 at 15 48 24](https://user-images.githubusercontent.com/8397116/107967973-b1e82480-6fa5-11eb-81dc-fa92f67fda0e.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
