### PR TITLE
feat(forms): add focus input to fields

### DIFF
--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.html
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.html
@@ -1,4 +1,8 @@
-<fieldset [attr.aria-describedby]="ariaDescribedBy">
+<fieldset
+  [attr.aria-describedby]="ariaDescribedBy"
+  [attr.tabindex]="focus ? '-1' : null"
+  [lgFocus]="focus"
+>
   <legend lg-label [attr.for]="id" lgMarginBottom="xs">
     <ng-content></ng-content>
   </legend>

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
@@ -125,6 +125,15 @@ describe('LgCheckboxGroupComponent', () => {
     );
   });
 
+  it('adds the tabindex attribute to the fieldset element', () => {
+    expect(fieldsetDebugElement.nativeElement.getAttribute('tabindex')).toBeNull();
+
+    groupInstance.focus = true;
+    fixture.detectChanges();
+
+    expect(fieldsetDebugElement.nativeElement.getAttribute('tabindex')).toBe('-1');
+  });
+
   it('sets all checkbox buttons to the same name', () => {
     expect(groupInstance.name.length > 0).toBe(true);
     const name = checkboxInstances.pop().name;

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts
@@ -38,6 +38,7 @@ export class LgCheckboxGroupComponent implements ControlValueAccessor {
   @Input() id = `lg-checkbox-group-id-${this.nextUniqueId}`;
   @Input() inline = false;
   @Input() disabled = false;
+  @Input() focus: boolean;
   @Input() ariaDescribedBy: string;
   _variant: CheckboxGroupVariant;
 

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.module.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.module.ts
@@ -3,9 +3,10 @@ import { NgModule } from '@angular/core';
 import { LgLabelModule } from '../label/label.module';
 import { LgCheckboxGroupComponent } from './checkbox-group.component';
 import { LgMarginModule } from '../../spacing/margin/margin.module';
+import { LgFocusModule } from '../../focus/focus.module';
 
 @NgModule({
-  imports: [LgLabelModule, LgMarginModule],
+  imports: [LgLabelModule, LgMarginModule, LgFocusModule],
   declarations: [LgCheckboxGroupComponent],
   exports: [LgCheckboxGroupComponent],
   entryComponents: [LgCheckboxGroupComponent],

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts
@@ -52,6 +52,7 @@ or
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-checkbox-group-id-\${this.nextUniqueId}' | No |
 | \`\`name\`\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-checkbox-group-\${this.nextUniqueId}' | No |
 | \`\`value\`\` | HTML value attribute. Sets the default checked ${name.toLowerCase()} buttons, must match the values of the ${name.toLowerCase()} buttons | array of strings | null | No |
+| \`\`focus\`\` | Set the focus on the fieldset | boolean | null | No |
 | \`\`inline\`\` | If true, displays the ${
   name.toLowerCase
 }s inline rather than stacked | boolean | false | No |
@@ -63,6 +64,7 @@ or
 | \`\`name\`\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\${++nextUniqueId}' | No |
 | \`\`value\`\` | HTML value attribute. Value that is set when the toggle is checked | string | null | No |
 | \`\`checked\`\` | Check status of the toggle | boolean | false | No |
+| \`\`focus\`\` | Set the focus on the input | boolean | null | No |
 
 
 ## Using only the SCSS files

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts
@@ -12,7 +12,7 @@ import { notes } from './checkbox-group.notes';
   selector: 'lg-reactive-form',
   template: `
     <form [formGroup]="form">
-      <lg-checkbox-group [inline]="inline" formControlName="colors">
+      <lg-checkbox-group [inline]="inline" [focus]="focus" formControlName="colors">
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
         <lg-toggle value="red">Red</lg-toggle>
@@ -23,6 +23,7 @@ import { notes } from './checkbox-group.notes';
 })
 class ReactiveFormComponent {
   @Input() inline = false;
+  @Input() focus = false;
   @Input() label: string;
   @Input() hint: string;
   @Input()
@@ -68,6 +69,7 @@ export const standard = () => ({
     [disabled]="disabled"
     [hint]="hint"
     [inline]="inline"
+    [focus]="focus"
     [label]="label"
     (checkboxChange)="checkboxChange($event)">
   </lg-reactive-form>
@@ -78,5 +80,6 @@ export const standard = () => ({
     hint: text('hint', 'Please select all colors that apply'),
     checkboxChange: action('checkboxChange'),
     disabled: boolean('disabled', false),
+    focus: boolean('focus', false),
   },
 });

--- a/projects/canopy/src/lib/forms/date/date-field.component.html
+++ b/projects/canopy/src/lib/forms/date/date-field.component.html
@@ -1,4 +1,8 @@
-<fieldset [attr.aria-describedby]="ariaDescribedBy">
+<fieldset
+  [attr.aria-describedby]="ariaDescribedBy || null"
+  [attr.tabindex]="focus ? '-1' : null"
+  [lgFocus]="focus"
+>
   <legend lg-label>
     <ng-content></ng-content>
   </legend>

--- a/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
@@ -147,6 +147,15 @@ describe('LgDateFieldComponent', () => {
     });
   });
 
+  it('adds the tabindex attribute to the fieldset element', () => {
+    expect(fieldsetElement.nativeElement.getAttribute('tabindex')).toBeNull();
+
+    dateFieldInstance.focus = true;
+    fixture.detectChanges();
+
+    expect(fieldsetElement.nativeElement.getAttribute('tabindex')).toBe('-1');
+  });
+
   it('sets the individual input fields when a date value is provided', () => {
     const testDate = '1970-05-05';
     component.form.get('dateOfBirth').setValue(testDate);

--- a/projects/canopy/src/lib/forms/date/date-field.component.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.ts
@@ -60,6 +60,7 @@ export class LgDateFieldComponent implements OnInit, ControlValueAccessor, OnDes
 
   @Input() value: string;
   @Input() disabled = false;
+  @Input() focus: boolean;
   @Input() dateId = `lg-input-date-${this.uniqueId++}`;
   @Input() monthId = `lg-input-month-${this.uniqueId++}`;
   @Input() yearId = `lg-input-year-${this.uniqueId++}`;

--- a/projects/canopy/src/lib/forms/date/date-field.module.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.module.ts
@@ -7,6 +7,7 @@ import { LgLabelModule } from '../label/label.module';
 import { LgValidationModule } from '../validation/validation.module';
 import { LgDateFieldComponent } from './date-field.component';
 import { LgMarginModule } from '../../spacing/margin/margin.module';
+import { LgFocusModule } from '../../focus/focus.module';
 
 @NgModule({
   imports: [
@@ -16,6 +17,7 @@ import { LgMarginModule } from '../../spacing/margin/margin.module';
     LgInputModule,
     LgValidationModule,
     LgMarginModule,
+    LgFocusModule,
   ],
   declarations: [LgDateFieldComponent],
   exports: [LgDateFieldComponent],

--- a/projects/canopy/src/lib/forms/date/date-field.notes.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.notes.ts
@@ -57,6 +57,7 @@ and in your HTML:
 | \`\`monthId\`\` | HTML ID attribute for the month input, auto generated if not provided | string | 'lg-input-month-\${nextUniqueId++}' | No |
 | \`\`yearId\`\` | HTML ID attribute for the year input, auto generated if not provided | string | 'lg-input-year-\${nextUniqueId++}' | No |
 | \`\`ariaDescribedBy\`\` | HTML ID for the corresponding element that describes the date field, if not provided it will use the hint field where appropriate | string | null | No |
+| \`\`focus\`\` | Set the focus on the fieldset | boolean | null | No |
 
 ## Validation
 Date validation is quite complex with a range of different validation errors, where possible we have encapsulated as much of that complexity into the components as we can.

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.ts
@@ -48,7 +48,7 @@ export class LgRadioButtonComponent implements OnInit {
 
   @Input() id = `lg-radio-button-${++nextUniqueId}`;
   @Input() name: string;
-  @Input() value: string;
+  @Input() value: boolean | string;
 
   _stacked: RadioStackBreakpoint;
   set stacked(stacked: RadioStackBreakpoint) {

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.html
@@ -1,4 +1,8 @@
-<fieldset [attr.aria-describedby]="ariaDescribedBy">
+<fieldset
+  [attr.aria-describedby]="ariaDescribedBy || null"
+  [attr.tabindex]="focus ? '-1' : null"
+  [lgFocus]="focus"
+>
   <legend lg-label [attr.for]="id" lgMarginBottom="xs">
     <ng-content></ng-content>
   </legend>

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
@@ -89,9 +89,9 @@ describe('LgRadioGroupComponent', () => {
         ],
       }).compileComponents();
 
-    fixture = TestBed.createComponent(TestRadioGroupComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+      fixture = TestBed.createComponent(TestRadioGroupComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
 
       groupDebugElement = fixture.debugElement.query(By.directive(LgRadioGroupComponent));
       groupInstance = groupDebugElement.injector.get<LgRadioGroupComponent>(
@@ -104,8 +104,9 @@ describe('LgRadioGroupComponent', () => {
 
       radioDebugElements = fixture.debugElement.queryAll(By.css('lg-radio-button'));
 
-    radioInstances = radioDebugElements.map((debugEl) => debugEl.componentInstance);
-  }));
+      radioInstances = radioDebugElements.map((debugEl) => debugEl.componentInstance);
+    }),
+  );
 
   it('sets all radio buttons to the same name', () => {
     expect(groupInstance.name.length > 0).toBe(true);
@@ -212,6 +213,15 @@ describe('LgRadioGroupComponent', () => {
     expect(fieldsetDebugElement.nativeElement.getAttribute('aria-describedby')).toBe(
       `${hintId} ${errorId}`,
     );
+  });
+
+  it('adds the tabindex attribute to the fieldset element', () => {
+    expect(fieldsetDebugElement.nativeElement.getAttribute('tabindex')).toBeNull();
+
+    groupInstance.focus = true;
+    fixture.detectChanges();
+
+    expect(fieldsetDebugElement.nativeElement.getAttribute('tabindex')).toBe('-1');
   });
 
   it('disables the options when the disabled property is set', () => {

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.ts
@@ -113,7 +113,7 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
     this._validationElement = element;
   }
 
-  _value: string = null;
+  _value: boolean | string = null;
   @Input()
   get value() {
     return this._value;
@@ -157,7 +157,7 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
     }
   }
 
-  public onChange(value: string) {
+  public onChange(value: boolean | string) {
     this._value = value;
   }
 

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.ts
@@ -38,6 +38,7 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
   @Input() id = `lg-radio-group-id-${this.nextUniqueId}`;
   @Input() inline = false;
   @Input() disabled = false;
+  @Input() focus = false;
   @Input() ariaDescribedBy: string;
   variant: RadioVariant;
 

--- a/projects/canopy/src/lib/forms/radio/radio.module.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.module.ts
@@ -5,9 +5,10 @@ import { LgLabelModule } from '../label/label.module';
 import { LgRadioButtonComponent } from './radio-button.component';
 import { LgRadioGroupComponent } from './radio-group.component';
 import { LgMarginModule } from '../../spacing/margin/margin.module';
+import { LgFocusModule } from '../../focus/focus.module';
 
 @NgModule({
-  imports: [LgLabelModule, LgMarginModule, CommonModule],
+  imports: [LgLabelModule, LgMarginModule, CommonModule, LgFocusModule],
   declarations: [LgRadioGroupComponent, LgRadioButtonComponent],
   exports: [LgRadioGroupComponent, LgRadioButtonComponent],
   entryComponents: [LgRadioGroupComponent, LgRadioButtonComponent],

--- a/projects/canopy/src/lib/forms/radio/radio.notes.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.notes.ts
@@ -50,7 +50,7 @@ Radios are displayed inline, unless given a \`RadioStackBreakpoint\`, which tell
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\${nextUniqueId++}' | No |
 | \`\`name\`\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\${nextUniqueId++}' | No |
-| \`\`value\`\` | Set the default checked radio button, must match the value of the radio button | string | null | No |
+| \`\`value\`\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |
 | \`\`focus\`\` | Set the focus on the fieldset | boolean | null | No |
 ${
   name === 'Radio'

--- a/projects/canopy/src/lib/forms/radio/radio.notes.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.notes.ts
@@ -51,6 +51,7 @@ Radios are displayed inline, unless given a \`RadioStackBreakpoint\`, which tell
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\${nextUniqueId++}' | No |
 | \`\`name\`\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\${nextUniqueId++}' | No |
 | \`\`value\`\` | Set the default checked radio button, must match the value of the radio button | string | null | No |
+| \`\`focus\`\` | Set the focus on the fieldset | boolean | null | No |
 ${
   name === 'Radio'
     ? `| \`\`inline\`\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`

--- a/projects/canopy/src/lib/forms/radio/segment.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/segment.stories.ts
@@ -13,7 +13,7 @@ import { RadioStackBreakpoint } from './radio.interface';
   selector: 'lg-reactive-form-segment',
   template: `
     <form [formGroup]="form">
-      <lg-segment-group formControlName="color" [stack]="stack">
+      <lg-segment-group formControlName="color" [stack]="stack" [focus]="focus">
         {{ label }} {{ itemsInSegment }}
         <lg-segment-button value="red">Red</lg-segment-button>
         <lg-segment-button value="yellow">{{ secondButtonLabel }}</lg-segment-button>
@@ -27,6 +27,7 @@ class ReactiveFormSegmentComponent {
   @Input() label: string;
   @Input() secondButtonLabel: string;
   @Input() stack: RadioStackBreakpoint;
+  @Input() focus: boolean;
   @Input()
   set disabled(isDisabled: boolean) {
     if (isDisabled === true) {
@@ -73,6 +74,7 @@ export const standard = () => ({
     <lg-reactive-form-segment
     [stack]="stack === 'false' ? false : stack"
     [disabled]="disabled"
+    [focus]="focus"
     [label]="label"
     [secondButtonLabel]="secondButtonLabel"
     (segmentChange)="segmentChange($event)">
@@ -83,6 +85,7 @@ export const standard = () => ({
     secondButtonLabel: text('secondButtonLabel', 'Yellow'),
     segmentChange: action('segmentChange'),
     disabled: boolean('disabled', false),
+    focus: boolean('focus', false),
     stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),
   },
 });

--- a/projects/canopy/src/lib/forms/select/select.directive.ts
+++ b/projects/canopy/src/lib/forms/select/select.directive.ts
@@ -17,6 +17,7 @@ let nextUniqueId = 0;
   selector: '[lgSelect]',
 })
 export class LgSelectDirective {
+  private uniqueId = nextUniqueId++;
   @HostBinding('class.lg-select') class = true;
   @HostBinding('class.lg-select--block')
   public get blockClass() {
@@ -33,11 +34,11 @@ export class LgSelectDirective {
 
   @Input()
   @HostBinding('name')
-  name = `lg-select-${nextUniqueId++}`;
+  name = `lg-select-${this.uniqueId}`;
 
   @Input()
   @HostBinding('id')
-  id = `lg-select-${nextUniqueId++}`;
+  id = `lg-select-${this.uniqueId}`;
 
   @Input()
   @HostBinding('attr.aria-describedby')

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.html
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.html
@@ -1,4 +1,8 @@
-<fieldset [attr.aria-describedby]="ariaDescribedBy">
+<fieldset
+  [attr.aria-describedby]="ariaDescribedBy || null"
+  [attr.tabindex]="focus ? '-1' : null"
+  [lgFocus]="focus"
+>
   <legend lg-label [id]="labelId">
     <ng-content></ng-content>
   </legend>

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
@@ -49,6 +49,7 @@ export class LgSortCodeComponent implements OnInit, ControlValueAccessor {
 
   @Input() value: string;
   @Input() disabled: false;
+  @Input() focus: boolean;
   @Input() labelId = `lg-input-sort-code-label-${this.uniqueId}`;
   @Input() firstId = `lg-input-sort-code-first-${this.uniqueId}`;
   @Input() secondId = `lg-input-sort-code-second-${this.uniqueId}`;

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.module.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.module.ts
@@ -7,6 +7,7 @@ import { LgHintModule } from '../hint/hint.module';
 import { LgInputModule } from '../input/input.module';
 import { LgSortCodeComponent } from './sort-code.component';
 import { LgMarginModule } from '../../spacing/margin';
+import { LgFocusModule } from '../../focus/focus.module';
 
 @NgModule({
   imports: [
@@ -16,6 +17,7 @@ import { LgMarginModule } from '../../spacing/margin';
     LgHintModule,
     LgLabelModule,
     LgMarginModule,
+    LgFocusModule,
   ],
   declarations: [LgSortCodeComponent],
   exports: [LgSortCodeComponent],

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
@@ -32,7 +32,8 @@ and in your HTML:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`value\`\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |
-| \`\`disabled\`\` | Sets the three inner input fields to disbaled if \`\`true\`\` | boolean | \`\`false\`\` | No |
+| \`\`disabled\`\` | Set the three inner input fields to disabled if \`\`true\`\` | boolean | \`\`false\`\` | No |
+| \`\`focus\`\` | Set the focus on the fieldset | boolean | null | No |
 | \`\`labelId\`\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \`\`lg-input-sort-code-label-\${nextUniqueId}\`\` | No |
 | \`\`firstId\`\` | HTML ID attribute for the first number input, auto generated if not provided | string | \`\`lg-input-sort-code-first-\${nextUniqueId}\`\` | No |
 | \`\`secondId\`\` | HTML ID attribute for the second number input, auto generated if not provided | string | \`\`lg-input-sort-code-second-\${nextUniqueId}\`\` | No |

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts
@@ -13,7 +13,7 @@ import { notes } from './sort-code.notes';
   selector: 'lg-reactive-form',
   template: `
     <form [formGroup]="form">
-      <lg-sort-code formControlName="sortCode">
+      <lg-sort-code formControlName="sortCode" [focus]="focus">
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
       </lg-sort-code>
@@ -23,6 +23,7 @@ import { notes } from './sort-code.notes';
 class ReactiveFormComponent {
   @Input() hint: string;
   @Input() label: string;
+  @Input() focus: boolean;
 
   @Input()
   set disabled(disabled: boolean) {
@@ -71,11 +72,13 @@ export const standard = () => ({
     [disabled]="disabled"
     [hint]="hint"
     [label]="label"
+    [focus]="focus"
   ></lg-reactive-form>`,
   props: {
     inputChange: action('inputChange'),
     label: text('label', 'Sort code'),
     hint: text('hint', 'Must be 6 digits long'),
     disabled: boolean('disabled', false),
+    focus: boolean('focus', false),
   },
 });

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.html
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.html
@@ -6,6 +6,7 @@
   [attr.id]="id"
   [attr.name]="name"
   [attr.value]="value"
+  [lgFocus]="focus"
   class="lg-toggle__input"
   type="checkbox"
 />

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.ts
@@ -40,6 +40,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
   @Input() id = `lg-toggle-${this.uniqueId}`;
   @Input() name = `lg-toggle-${this.uniqueId}`;
   @Input() value: boolean | string = false;
+  @Input() focus: boolean;
   @Input() ariaDescribedBy: string;
   @Input() variant: ToggleVariant = 'checkbox';
   @Input()

--- a/projects/canopy/src/lib/forms/toggle/toggle.module.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.module.ts
@@ -10,11 +10,12 @@ import {
 } from '../../icon/icons.interface';
 
 import { LgToggleComponent } from './toggle.component';
+import { LgFocusModule } from '../../focus/focus.module';
 
 @NgModule({
   declarations: [LgToggleComponent],
   exports: [LgToggleComponent],
-  imports: [CommonModule, LgIconModule],
+  imports: [CommonModule, LgIconModule, LgFocusModule],
   entryComponents: [LgToggleComponent],
 })
 export class LgToggleModule {

--- a/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
@@ -35,6 +35,7 @@ or
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\${nextUniqueId++}' | No |
 | \`\`name\`\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\${nextUniqueId++}' | No |
 | \`\`variant\`\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |
+| \`\`focus\`\` | Set the focus on the input field | boolean | null | No |
 
 ## Using only the SCSS files
 

--- a/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
@@ -31,7 +31,7 @@ or
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`checked\`\` | Check status of the toggle | boolean | false | No |
-| \`\`value\`\` | Value that is set when the toggle is checked | string | 'on' | No |
+| \`\`value\`\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\${nextUniqueId++}' | No |
 | \`\`name\`\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\${nextUniqueId++}' | No |
 | \`\`variant\`\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |

--- a/projects/canopy/src/lib/forms/toggle/toggle.stories.common.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.stories.common.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
 import { action } from '@storybook/addon-actions';
@@ -15,6 +22,7 @@ import { ToggleVariant } from './toggle.interface';
         [value]="true"
         [variant]="variant"
         [checked]="umbrella.value"
+        [focus]="focus"
       >
         {{ label }}
       </lg-toggle>
@@ -25,6 +33,7 @@ export class ReactiveToggleFormComponent implements OnChanges {
   @Input() label: string;
   @Input() variant: ToggleVariant;
   @Input() checked: boolean;
+  @Input() focus: boolean;
 
   @Input()
   set disabled(disabled: boolean) {
@@ -53,8 +62,10 @@ export class ReactiveToggleFormComponent implements OnChanges {
     this.form.valueChanges.subscribe((val) => this.toggleChange.emit(val));
   }
 
-  ngOnChanges(changes): void {
-    this.umbrella.setValue(changes.checked.currentValue);
+  ngOnChanges({ checked }: SimpleChanges): void {
+    if (checked?.currentValue) {
+      this.umbrella.setValue(checked.currentValue);
+    }
   }
 }
 
@@ -65,6 +76,7 @@ export const createToggleStory = (variant: string) => ({
     [label]="label"
     variant="${variant}"
     [checked]="checked"
+    [focus]="focus"
     (toggleChange)="toggleChange($event)">
   </lg-reactive-form>`,
   props: {
@@ -72,5 +84,6 @@ export const createToggleStory = (variant: string) => ({
     label: text('label', 'I will bring my Umbrella if it is raining'),
     disabled: boolean('disabled', false),
     checked: boolean('reactively checked', false),
+    focus: boolean('focus', false),
   },
 });


### PR DESCRIPTION
# Description

Add a `focus` input to the form fields to allow for dynamic focusing.

This is particularly important when having to set the focus on a field that has an error so that screen reader users can amend the issue.

Storybook link: https://deploy-preview-218--legal-and-general-canopy.netlify.app/

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
