### PR TITLE
fix(input): fixes size of number input

### DIFF
--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -115,4 +115,11 @@
   &:-webkit-autofill {
     -webkit-background-clip: text;
   }
+
+  // This is a bit ugly, but maybe a compromise
+  @for $var from 1 through 20 {
+    &--size-#{$var} {
+      width: #{$var + 2}rem;
+    }
+  }
 }

--- a/projects/canopy/src/lib/forms/input/input.directive.ts
+++ b/projects/canopy/src/lib/forms/input/input.directive.ts
@@ -1,9 +1,11 @@
 import {
   Directive,
+  ElementRef,
   Host,
   HostBinding,
   Input,
   Optional,
+  Renderer2,
   Self,
   SkipSelf,
 } from '@angular/core';
@@ -49,6 +51,22 @@ export class LgInputDirective {
   @HostBinding('attr.aria-describedby')
   ariaDescribedBy: string | null = null;
 
+  _size: number;
+  @Input()
+  public set size(size) {
+    if (this._size) {
+      this.renderer.removeClass(
+        this.hostElement.nativeElement,
+        `lg-input--size-${this.size}`,
+      );
+    }
+    this.renderer.addClass(this.hostElement.nativeElement, `lg-input--size-${size}`);
+    this._size = size;
+  }
+  public get size(): number {
+    return this._size;
+  }
+
   constructor(
     @Self() @Optional() public control: NgControl,
     private errorState: LgErrorStateMatcher,
@@ -56,5 +74,7 @@ export class LgInputDirective {
     @Host()
     @SkipSelf()
     private controlContainer: FormGroupDirective,
+    private renderer: Renderer2,
+    private hostElement: ElementRef,
   ) {}
 }

--- a/projects/canopy/src/lib/forms/input/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/input.stories.ts
@@ -27,6 +27,7 @@ interface KnobsConfig {
   hint?: string | null;
   icon?: string;
   iconButton?: boolean;
+  inputType?: 'number' | 'text' | 'tel'; // TODO add rest or make a string
   label?: string;
   showLabel?: boolean;
   showButton?: boolean;
@@ -97,6 +98,7 @@ const createInputStory = (config: KnobsConfig) => ({
     ),
     suffix: text('suffix', '%', contentGroupId),
     size: number('input size', 12, undefined, propsGroupId),
+    type: text('input type', config.inputType || 'text', contentGroupId),
   },
 });
 
@@ -108,7 +110,7 @@ const createInputStory = (config: KnobsConfig) => ({
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
         <span lgPrefix *ngIf="showTextPrefix">{{ prefix }}</span>
-        <input lgInput formControlName="name" [size]="size" />
+        <input lgInput formControlName="name" [size]="size" [type]="type" />
         <button
           lg-button
           lgSuffix


### PR DESCRIPTION
# Description

A proposal for controlling input width, we have noticed that the current approach does not work for `type="number"` inputs.  Draft only at present, needs some tidying (@pauleustice, @owensgit )

✅ No breaking change
✅ Fixes input type="number"
❌ Not great CSS, would almost consider doing an inline style


## Requirements


Storybook link: (once netlify has deployed link provide a link to the component)
Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
