### PR TITLE
fix(brand-icons): ensure ids are unique

### DIFF
--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
@@ -47,7 +47,7 @@ describe('LgBrandIconComponent', () => {
   describe('setting the name', () => {
     it('should append the correct svg element to the component', () => {
       expect(fixture.nativeElement.querySelector('#test')).toBeNull();
-      expect(fixture.nativeElement.querySelector('#lg-brand-icon-0')).toBeNull();
+      expect(fixture.nativeElement.querySelector('#lg-brand-icon-0-1')).toBeNull();
 
       when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
         '<svg id="test">test-svg</svg>',
@@ -57,7 +57,7 @@ describe('LgBrandIconComponent', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('#test')).toBeNull();
-      expect(fixture.nativeElement.querySelector('#lg-brand-icon-0')).toBeDefined();
+      expect(fixture.nativeElement.querySelector('#lg-brand-icon-0-1')).not.toBeNull();
     });
   });
 

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
@@ -47,7 +47,7 @@ describe('LgBrandIconComponent', () => {
   describe('setting the name', () => {
     it('should append the correct svg element to the component', () => {
       expect(fixture.nativeElement.querySelector('#test')).toBeNull();
-      expect(fixture.nativeElement.querySelector('#lg-brand-icon-0-1')).toBeNull();
+      expect(fixture.nativeElement.querySelector('svg')).toBeNull();
 
       when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
         '<svg id="test">test-svg</svg>',
@@ -57,7 +57,11 @@ describe('LgBrandIconComponent', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('#test')).toBeNull();
-      expect(fixture.nativeElement.querySelector('#lg-brand-icon-0-1')).not.toBeNull();
+      expect(
+        /lg-brand-icon-\d-\d/.test(
+          fixture.nativeElement.querySelector('svg').getAttribute('id'),
+        ),
+      ).toBeTrue();
     });
   });
 

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
@@ -80,14 +80,11 @@ export class LgBrandIconComponent {
     let xlinkCount = 0;
 
     return svgData
-      .replace(/id="([^"]+)"/g, () => {
-        idCount++;
-        return `id="lg-brand-icon-${this.id}-${idCount}"`;
-      })
-      .replace(/xlink:href="#\w+"/g, () => {
-        xlinkCount++;
-        return `xlink:href="#lg-brand-icon-${this.id}-${xlinkCount}"`;
-      });
+      .replace(/id="([^"]+)"/g, () => `id="lg-brand-icon-${this.id}-${idCount++}"`)
+      .replace(
+        /xlink:href="#\w+"/g,
+        () => `xlink:href="#lg-brand-icon-${this.id}-${xlinkCount++}"`,
+      );
   }
 
   private svgElementFromString(svgContent: string): SVGElement {

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
@@ -76,9 +76,18 @@ export class LgBrandIconComponent {
    * incorrect brand-icon.
    */
   private setSVGAttributes(svgData: string): string {
+    let idCount = 0;
+    let xlinkCount = 0;
+
     return svgData
-      .replace(/id="\w+"/g, () => `id="lg-brand-icon-${this.id}"`)
-      .replace(/xlink:href="#\w+"/g, () => `xlink:href="#lg-brand-icon-${this.id}"`);
+      .replace(/id="([^"]+)"/g, () => {
+        idCount++;
+        return `id="lg-brand-icon-${this.id}-${idCount}"`;
+      })
+      .replace(/xlink:href="#\w+"/g, () => {
+        xlinkCount++;
+        return `xlink:href="#lg-brand-icon-${this.id}-${xlinkCount}"`;
+      });
   }
 
   private svgElementFromString(svgContent: string): SVGElement {


### PR DESCRIPTION
# Description

Ensures ids in brand icons are unique to comply with accessibility requirements

Fixes #226

## Requirements

The change can be validated on the brand icons component page using the Axe Dev Tools extension (in Chrome) which should no longer flag 'id attribute value must be unique'

Storybook link: https://deploy-preview-247--legal-and-general-canopy.netlify.app/?path=/story/components-brand-icon--standard
Screenshot: 

![Screenshot 2021-03-09 at 12 21 18](https://user-images.githubusercontent.com/7768665/110470116-5e638500-80d2-11eb-8d6e-0e646030b277.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
