### PR TITLE
Updates to brand icons colours

### DIFF
--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.scss
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.scss
@@ -5,7 +5,7 @@
     width: inherit;
     height: inherit;
 
-    #lg-icon-fill-primary {
+    .lg-icon-fill-primary {
       fill: var(--brand-icon-fill-primary);
     }
   }

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.scss
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.scss
@@ -5,7 +5,7 @@
     width: inherit;
     height: inherit;
 
-    .lg-icon-fill-primary {
+    [data-colour='lg-icon-fill-primary'] {
       fill: var(--brand-icon-fill-primary);
     }
   }

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
@@ -50,7 +50,7 @@ describe('LgBrandIconComponent', () => {
       expect(fixture.nativeElement.querySelector('svg')).toBeNull();
 
       when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
-        '<svg id="test">test-svg</svg>',
+        '<svg id="test">test-svg<path id="lg-icon-fill-primary"></path></svg>',
       );
 
       component.name = 'sun';
@@ -62,6 +62,10 @@ describe('LgBrandIconComponent', () => {
           fixture.nativeElement.querySelector('svg').getAttribute('id'),
         ),
       ).toBeTrue();
+
+      const pathEl = fixture.nativeElement.querySelector('path');
+      expect(pathEl.getAttribute('id')).not.toContain('lg-icon-fill-primary');
+      expect(pathEl.getAttribute('class')).toContain('lg-icon-fill-primary');
     });
   });
 

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
@@ -65,7 +65,39 @@ describe('LgBrandIconComponent', () => {
 
       const pathEl = fixture.nativeElement.querySelector('path');
       expect(pathEl.getAttribute('id')).not.toContain('lg-icon-fill-primary');
-      expect(pathEl.getAttribute('class')).toContain('lg-icon-fill-primary');
+      expect(pathEl.getAttribute('data-colour')).toContain('lg-icon-fill-primary');
+    });
+  });
+
+  describe('the colour input', () => {
+    beforeEach(() => {
+      when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
+        '<svg id="test">test-svg<path id="lg-icon-fill-primary"></path></svg>',
+      );
+      component.name = 'sun';
+    });
+
+    describe('when not specified', () => {
+      it("shouldn't set the fill colour", () => {
+        fixture.detectChanges();
+        const el = fixture.nativeElement.querySelector(
+          '[data-colour="lg-icon-fill-primary"]',
+        );
+
+        expect(el.style.fill).toEqual('');
+      });
+    });
+
+    describe('when specified', () => {
+      it('should apply the specific colour', () => {
+        component.colour = '--colour-css-variable';
+        fixture.detectChanges();
+        const el = fixture.nativeElement.querySelector(
+          '[data-colour="lg-icon-fill-primary"]',
+        );
+
+        expect(el.style.fill).toEqual('var(--colour-css-variable)');
+      });
     });
   });
 

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
@@ -31,6 +31,15 @@ export class LgBrandIconComponent {
   @HostBinding('class.lg-brand-icon') class = true;
   @HostBinding('attr.aria-hidden') hidden = true;
 
+  _colour: string;
+  @Input()
+  set colour(colour: string) {
+    const el = this.hostElement.nativeElement.querySelector(
+      '[data-colour="lg-icon-fill-primary"]',
+    );
+    el.style.fill = `var(${colour})`;
+  }
+
   _size: BrandIconSize = 'sm';
   @Input()
   set size(size: BrandIconSize) {
@@ -81,8 +90,8 @@ export class LgBrandIconComponent {
 
     return (
       svgData
-        // Changes the lg-icon-fill-primary id to be a class to avoid issues with duplicated ids.
-        .replace(/id="lg-icon-fill-primary"/g, () => 'class="lg-icon-fill-primary"')
+        // Changes the lg-icon-fill-primary id to be a data attribute to avoid issues with duplicated ids.
+        .replace(/id="lg-icon-fill-primary"/g, () => 'data-colour="lg-icon-fill-primary"')
         .replace(/id="([^"]+)"/g, () => `id="lg-brand-icon-${this.id}-${idCount++}"`)
         .replace(
           /xlink:href="#\w+"/g,

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
@@ -79,12 +79,16 @@ export class LgBrandIconComponent {
     let idCount = 0;
     let xlinkCount = 0;
 
-    return svgData
-      .replace(/id="([^"]+)"/g, () => `id="lg-brand-icon-${this.id}-${idCount++}"`)
-      .replace(
-        /xlink:href="#\w+"/g,
-        () => `xlink:href="#lg-brand-icon-${this.id}-${xlinkCount++}"`,
-      );
+    return (
+      svgData
+        // Changes the lg-icon-fill-primary id to be a class to avoid issues with duplicated ids.
+        .replace(/id="lg-icon-fill-primary"/g, () => 'class="lg-icon-fill-primary"')
+        .replace(/id="([^"]+)"/g, () => `id="lg-brand-icon-${this.id}-${idCount++}"`)
+        .replace(
+          /xlink:href="#\w+"/g,
+          () => `xlink:href="#lg-brand-icon-${this.id}-${xlinkCount++}"`,
+        )
+    );
   }
 
   private svgElementFromString(svgContent: string): SVGElement {

--- a/projects/canopy/src/lib/brand-icon/brand-icon.notes.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.notes.ts
@@ -38,10 +38,14 @@ and in your HTML:
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`name\`\` | the name of the icon | string | undefined | yes |
 | \`\`size\`\` | the size of the icon | BrandIconSize | 'sm' | no |
+| \`\`colour\`\` | the specific colour of the icon (for global colours see the "Branding" section below) | css variable as a string | undefined | no |
 
 ## Branding
 The yellow fill colour of the brand icons can be changed by overriding the \`--brand-icon-fill-primary\` css variable.
+
 Note that changing that variable will update the fill colour of all the icons.
+
+To change the colour of a specific icon use the \`colour\` input (see details in the table above).
 
 ## Using only the SCSS files
 

--- a/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
@@ -34,11 +34,12 @@ export const brandIconsArray: Array<brandIconSet.BrandIcon> = [
 @Component({
   selector: 'lg-swatch-brand-icon',
   template: `
-    <div class="swatch" *ngFor="let icon of icons">
+    <div class="swatch" *ngFor="let icon of icons; let i = index">
       <lg-brand-icon
         class="swatch__svg"
         [name]="icon.name"
         [size]="size"
+        [colour]="i === 0 ? specificColour : null"
         [attr.style]="cssVar"
       ></lg-brand-icon>
       <span class="swatch__name">{{ icon.name }}</span>
@@ -72,6 +73,7 @@ export const brandIconsArray: Array<brandIconSet.BrandIcon> = [
 class SwatchBrandIconComponent implements OnChanges {
   @Input() size: string;
   @Input() colour: string;
+  @Input() specificColour: string;
 
   icons = brandIconsArray;
   cssVar: SafeStyle;
@@ -117,10 +119,19 @@ const colours = [
 
 export const standard = () => ({
   template: `
-    <lg-swatch-brand-icon [size]="size" [colour]="colour"></lg-swatch-brand-icon>
+    <lg-swatch-brand-icon [size]="size" [colour]="colour" [specificColour]="specificColour"></lg-swatch-brand-icon>
   `,
   props: {
     size: select('size', sizes, 'xs'),
-    colour: select('colour examples', colours, '--color-dandelion-yellow'),
+    colour: select(
+      'example of applying colour globally',
+      colours,
+      '--color-dandelion-yellow',
+    ),
+    specificColour: select(
+      'example of applying colour specifically to an icon',
+      colours,
+      '--color-super-blue',
+    ),
   },
 });


### PR DESCRIPTION
# Description

This PR fixes and issue where the global colour for the brand icon was not applied anymore.
It also fixes an issue where it was not possible to set the specific colour for a single item.

@andy-polhill @paul-request I'm wondering if this should be flagged as breaking change. Paul, you will have to update your brand icon to pass the specific colour to it.

Fixes #251

## Requirements

The colour for the brand icons should be have the functionality to be applied both globally and specifically.

Storybook link: https://deploy-preview-252--legal-and-general-canopy.netlify.app/?path=/story/components-brand-icon--standard
Screenshot (first item is using the colour input):
![Screenshot 2021-03-11 at 17 09 34](https://user-images.githubusercontent.com/8397116/110826103-a75f3900-828c-11eb-9f99-a19a1b5dae98.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
