### PR TITLE
fix(data-point): layout issue in IE11 with flex shorthand

### DIFF
--- a/projects/canopy/src/lib/data-point/data-point/data-point.component.scss
+++ b/projects/canopy/src/lib/data-point/data-point/data-point.component.scss
@@ -1,6 +1,6 @@
 .lg-data-point {
   display: flex;
-  flex: 1;
+  flex: 1 1 0;
   flex-direction: column;
   margin-bottom: var(--component-margin);
   margin-right: var(--space-sm);


### PR DESCRIPTION
In IE11, `flex: 1` is internally treated as `flex: 1 1 0px` instead of `flex: 1 1 0` like other browsers which causes items to mis-align, as that means the item has a width of 0px rather than the width of it's content:

<img width="229" alt="Screenshot 2021-03-15 at 17 23 14" src="https://user-images.githubusercontent.com/4497410/111194732-62504500-85b3-11eb-9dde-2ba83bfc6f9b.png">

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
