### PR TITLE
fix(data-point): fix IE11 data point layout issue

### DIFF
--- a/projects/canopy/src/lib/data-point/data-point/data-point.component.scss
+++ b/projects/canopy/src/lib/data-point/data-point/data-point.component.scss
@@ -1,6 +1,6 @@
 .lg-data-point {
   display: flex;
-  flex: 1 1 0;
+  flex: 1 1 auto;
   flex-direction: column;
   margin-bottom: var(--component-margin);
   margin-right: var(--space-sm);


### PR DESCRIPTION
# Description

My previous fix to change `flex: 1` to `flex: 1 1 0` worked when updating in dev tools, but when loaded  via the stylesheet it does not work as `flex-basis: 0` is treated an an invalid value as it requires a unit (like px, for example). So changing it to `auto` fixes the layout for IE11.

I suspect `flex-basis: auto` is what we wanted anyway, so that the datapoint have equal width.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
- [ ] I have [linked the new component](<(https://github.com/Legal-and-General/canopy/blob/master/docs/CONTRIBUTING.md#invision-dsm)>) to adobe DSM (if appropriate)
