### PR TITLE
feat(skeleton): adds skeleton loader directive

### DIFF
--- a/projects/canopy/src/lib/skeleton/skeleton.directive.ts
+++ b/projects/canopy/src/lib/skeleton/skeleton.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, ElementRef, Renderer2, Input, HostBinding } from '@angular/core';
+
+@Directive({
+  selector: '[lgSkeleton]',
+})
+export class LgSkeletonDirective {
+  @Input('lgSkeleton') lgSkeletonWidth = 4;
+
+  @HostBinding('style.width')
+  get backgroundSize(): string {
+    return `${this.lgSkeletonWidth}em`;
+  }
+
+  constructor(private renderer: Renderer2, private hostElement: ElementRef) {
+    console.log('adds skeleton');
+    this.hostElement.nativeElement.innerHTML = 'loading...';
+    this.renderer.addClass(this.hostElement.nativeElement, 'lg-skeleton');
+  }
+}

--- a/projects/canopy/src/lib/skeleton/skeleton.module.ts
+++ b/projects/canopy/src/lib/skeleton/skeleton.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { LgSkeletonDirective } from './skeleton.directive';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [LgSkeletonDirective],
+  exports: [LgSkeletonDirective],
+})
+export class LgSkeletonModule {}

--- a/projects/canopy/src/lib/skeleton/skeleton.stories.ts
+++ b/projects/canopy/src/lib/skeleton/skeleton.stories.ts
@@ -1,0 +1,78 @@
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { moduleMetadata } from '@storybook/angular';
+
+import { LgCardModule } from '../card/card.module';
+import { LgGridModule } from '../grid/grid.module';
+
+import { LgPaddingModule } from '../spacing/padding/padding.module';
+import { LgSkeletonModule } from './skeleton.module';
+
+export default {
+  title: 'Components/Skeleton',
+  parameters: {
+    decorators: [
+      withKnobs,
+      moduleMetadata({
+        imports: [LgCardModule, LgGridModule, LgPaddingModule, LgSkeletonModule],
+      }),
+    ],
+    'in-dsm': {
+      // id: '5ede22091f488863e2eeaa35',
+    },
+    notes: {
+      // markdown: notes,
+    },
+  },
+};
+
+export const product = () => ({
+  template: `
+  <div style="position:relative">
+    <div style="position: absolute; top: 0">
+      <lg-card>
+        <lg-card-header>
+          <lg-card-title headingLevel="4">
+            <a lgSkeleton="8" href="#"></a>
+          </lg-card-title>
+          <lg-card-subtitle lgSkeleton="5">
+          </lg-card-subtitle>
+          <lg-card-principle-data-point>
+            <lg-card-principle-data-point-label lgSkeleton="8">
+            </lg-card-principle-data-point-label>
+            <lg-card-principle-data-point-value lgSkeleton="5">
+            </lg-card-principle-data-point-value>
+            <lg-card-principle-data-point-date lgSkeleton="4">
+            </lg-card-principle-data-point-date>
+          </lg-card-principle-data-point>
+        </lg-card-header>
+      </lg-card>
+    </div>
+    <div style="display: none; position: absolute; top: 0; opacity: 0.2">
+      <lg-card>
+      <lg-card-header>
+        <lg-card-title headingLevel="4">
+          <a href="#">{{title}}</a>
+        </lg-card-title>
+        <lg-card-subtitle>
+          Payroll Reference Number P23456
+        </lg-card-subtitle>
+        <lg-card-principle-data-point>
+          <lg-card-principle-data-point-label>
+            Last payment (after tax and deductions)
+          </lg-card-principle-data-point-label>
+          <lg-card-principle-data-point-value>
+            <span><span class="lg-font-size-3">£</span>230.20</span>
+          </lg-card-principle-data-point-value>
+          <lg-card-principle-data-point-date>
+            as of 01 Jan 2020
+          </lg-card-principle-data-point-date>
+        </lg-card-principle-data-point>
+      </lg-card-header>
+    </lg-card>
+  </div>
+  </div>
+  `,
+  props: {
+    title: text('title', 'Standard Lifetime Annuity Joint Life Full'),
+  },
+});

--- a/projects/canopy/src/styles/styles.scss
+++ b/projects/canopy/src/styles/styles.scss
@@ -7,3 +7,39 @@
 @import './typography';
 @import './utils';
 @import './variants';
+
+.lg-skeleton {
+  position: relative;
+  opacity: 0.25;
+  border-radius: var(--border-radius);
+  text-indent: 1000rem;
+  display: inline-block;
+  background-position: center;
+  background-size: 100% 0.9em;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(currentColor 1em, transparent 0);
+}
+
+.lg-skeleton::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(255, 255, 255, 0.002) 45%,
+    rgba(255, 255, 255, 0.002) 55%,
+    rgba(255, 255, 255, 1) 100%
+  );
+  animation: shimmer 4s infinite;
+  content: '';
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
# Description

A very very draft piece of work for some experimentation around loading spinners, the code is quite old so probably doesn't follow more recent best practice.

Sharing as I think @paul-request might be looking to formalise it.

Amongst the many things I haven't done on this...
- Checked if it's accessible
- Run an example with lazy loaded content.
- Created a nice animation effect

I do quite like the API though, where you just apply the directive to the text element and give it a numeric value for the expected length of the field. e.g. `lgSkeleton="5"`

https://deploy-preview-302--legal-and-general-canopy.netlify.app/?path=/story/components-skeleton--product