### PR TITLE
fix(grid): update lg-breakpoint mixin

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -64,7 +64,15 @@ $breakpoints: (
 */
 @mixin lg-breakpoint($breakpoint, $range: 'min-width') {
   @if map-has-key($breakpoints, $breakpoint) {
-    @media ($range: map-get($breakpoints, $breakpoint)) {
+    $value: map-get($breakpoints, $breakpoint);
+
+    @if $range == 'max-width' {
+      // Removes 1 pixel if using max-width so that there is no
+      // overlap when used with min-width.
+      $value: $value - 0.06rem;
+    }
+
+    @media ($range: $value) {
       @content;
     }
   } @else {


### PR DESCRIPTION
# Description

Update the `lg-breakpoint` mixin to remove `1px` from the `max-width` breakpoint so that there is no overlap between min and max width media queries.

Behaving before the change:

https://user-images.githubusercontent.com/8397116/114399098-767a6880-9b98-11eb-9a87-1a5553ff1be8.mov

Behaviour after the change:

https://user-images.githubusercontent.com/8397116/114399124-7da17680-9b98-11eb-9295-29a9ba52bfae.mov


Storybook link: (once netlify has deployed link provide a link to the component)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
