### PR TITLE
feat(side-nav): add side-nav menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6462,9 +6462,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.6.tgz",
-      "integrity": "sha512-kgl+oYOLCBt41iba8cetp+QPOqDAaTJnHtVPCE7JzYmda4juglRBLX35opVcANc7TLA/Lp0DEnajbUNnyxGC+Q==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.9.tgz",
+      "integrity": "sha512-B53NIwMj/AO0O+xfSWLYmKB0Mo6TYxfv2Mk8/c1T2w/e38t55iaPR6p7pHXTTtqfTmevPK3i8T1YweYFTZlxDw==",
       "dev": true
     },
     "@types/jasminewd2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1435,9 +1435,9 @@
       }
     },
     "@angular/language-service": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-11.1.0.tgz",
-      "integrity": "sha512-7NQcwNHgUGOdqQsyp1Xw/WFbYvC4WA+Et2DJJvkitmg2ejndtm45FALUu1Z2X6bbKzdJOuNGU5vNh1ZJ/IyGRQ==",
+      "version": "11.2.9",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-11.2.9.tgz",
+      "integrity": "sha512-W7MrMnwjJC0XF/jhKcEcYu0PJoNsxTMR+6lDuLNtLtdl74PnHnhf5SS/Owt1KKmyxeHCx1BrAuWqlfh+cR+dAA==",
       "dev": true
     },
     "@angular/platform-browser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -906,20 +906,20 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.5.tgz",
-      "integrity": "sha512-7RoWgpMvhljPhW9CMz1EtqkwNnGpnsPyy0N29ClHPUq+o8wLR0hvbLBDz1fKSF7j1AwRccaQSNTj8KWsjzQJLQ==",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.2.8.tgz",
+      "integrity": "sha512-EoCgDPr4VfDajoCW5/XDTyxEnaNjE+9XXVp9mXWYMMSBxKCZIrbieN4+SpjxyKDBl2ZKtTtZU1zWJ2Yerk66Cg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.2.5",
+        "@angular-devkit/core": "11.2.8",
         "ora": "5.3.0",
         "rxjs": "6.6.3"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "11.2.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.5.tgz",
-          "integrity": "sha512-DRFvEHRKoC+hTwcOAJqLe6UQa+bpXc/1IGCMHWEbuply0KIFIGQOlmaYwFZKixz3HdFZlmoCMcAVkAXvyaWVsQ==",
+          "version": "11.2.8",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.8.tgz",
+          "integrity": "sha512-iNodaySWW1JrF+oGZCi0rYDJXO96T4K7H6BLz6xapSwFxkY+Xr4CBuTqEp2DKzAZ+sjYFmsItLmNedwOOBnwfA==",
           "dev": true,
           "requires": {
             "ajv": "6.12.6",
@@ -1026,16 +1026,16 @@
       }
     },
     "@angular/cli": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.2.5.tgz",
-      "integrity": "sha512-GIwK8l6wtg/++8aDYW++LSf7v1uqDtB6so2rPjNlOm7oYk5iqM73KaorQb/1A52oxWE3IRSJLNQaSyUlWvHvSA==",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.2.8.tgz",
+      "integrity": "sha512-9TWNPKqaOrg+C5DR8jz4LNVzu/wCV0Hqt3JF4ILm9fv93bh2MgqetUKyHdQNAijtHMlOO1uh0EM2Emjlp5JvXQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.1102.5",
-        "@angular-devkit/core": "11.2.5",
-        "@angular-devkit/schematics": "11.2.5",
-        "@schematics/angular": "11.2.5",
-        "@schematics/update": "0.1102.5",
+        "@angular-devkit/architect": "0.1102.8",
+        "@angular-devkit/core": "11.2.8",
+        "@angular-devkit/schematics": "11.2.8",
+        "@schematics/angular": "11.2.8",
+        "@schematics/update": "0.1102.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.1",
         "debug": "4.3.1",
@@ -1056,30 +1056,19 @@
       },
       "dependencies": {
         "@angular-devkit/architect": {
-          "version": "0.1102.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.5.tgz",
-          "integrity": "sha512-lVc6NmEAZZPzvc18GzMFLoxqKKvPlNOg4vEtFsFldZmrydLJJGFi4KAs2WaJd8qVR1XuY4el841cjDQAJSq6sQ==",
+          "version": "0.1102.8",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1102.8.tgz",
+          "integrity": "sha512-EMl81SRyTntjE9U9m4piGvlbs2PdmBTVl2LS8GK3fimunlIzebu9WhDwAmqZdm4HEXiYmiBcCbVaHkYTU8k0Kg==",
           "dev": true,
           "requires": {
-            "@angular-devkit/core": "11.2.5",
+            "@angular-devkit/core": "11.2.8",
             "rxjs": "6.6.3"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "6.6.3",
-              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-              "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-              "dev": true,
-              "requires": {
-                "tslib": "^1.9.0"
-              }
-            }
           }
         },
         "@angular-devkit/core": {
-          "version": "11.2.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.5.tgz",
-          "integrity": "sha512-DRFvEHRKoC+hTwcOAJqLe6UQa+bpXc/1IGCMHWEbuply0KIFIGQOlmaYwFZKixz3HdFZlmoCMcAVkAXvyaWVsQ==",
+          "version": "11.2.8",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.8.tgz",
+          "integrity": "sha512-iNodaySWW1JrF+oGZCi0rYDJXO96T4K7H6BLz6xapSwFxkY+Xr4CBuTqEp2DKzAZ+sjYFmsItLmNedwOOBnwfA==",
           "dev": true,
           "requires": {
             "ajv": "6.12.6",
@@ -1087,17 +1076,6 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.3",
             "source-map": "0.7.3"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "6.6.3",
-              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-              "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-              "dev": true,
-              "requires": {
-                "tslib": "^1.9.0"
-              }
-            }
           }
         },
         "ansi-colors": {
@@ -1203,6 +1181,15 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "semver": {
@@ -4138,9 +4125,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4442,20 +4429,20 @@
       }
     },
     "@schematics/angular": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.5.tgz",
-      "integrity": "sha512-pjaK0gZyqhzgAVxMKElG6cDpAvNZ3adVCTA8dhEixpH+JaQdoczl59hMn7rH75yQW0PApe+8g7HMwVK6bLRmxQ==",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-11.2.8.tgz",
+      "integrity": "sha512-5iJSzkFC3P4t47I9cbIuiaIm3Hkmr6YsXSPE6t8lmUjdcG+sX/AXlSgHmvE9RqoEWAlo1YiXPmQsQH/QIE0qPQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.2.5",
-        "@angular-devkit/schematics": "11.2.5",
+        "@angular-devkit/core": "11.2.8",
+        "@angular-devkit/schematics": "11.2.8",
         "jsonc-parser": "3.0.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "11.2.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.5.tgz",
-          "integrity": "sha512-DRFvEHRKoC+hTwcOAJqLe6UQa+bpXc/1IGCMHWEbuply0KIFIGQOlmaYwFZKixz3HdFZlmoCMcAVkAXvyaWVsQ==",
+          "version": "11.2.8",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.8.tgz",
+          "integrity": "sha512-iNodaySWW1JrF+oGZCi0rYDJXO96T4K7H6BLz6xapSwFxkY+Xr4CBuTqEp2DKzAZ+sjYFmsItLmNedwOOBnwfA==",
           "dev": true,
           "requires": {
             "ajv": "6.12.6",
@@ -4463,17 +4450,15 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.3",
             "source-map": "0.7.3"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "6.6.3",
-              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-              "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-              "dev": true,
-              "requires": {
-                "tslib": "^1.9.0"
-              }
-            }
+          }
+        },
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "source-map": {
@@ -4491,13 +4476,13 @@
       }
     },
     "@schematics/update": {
-      "version": "0.1102.5",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1102.5.tgz",
-      "integrity": "sha512-iz9pM8mabieqQnPZjrqP5jfRFvPm81/uIg46kY3KjtDtSBi4GAF2dnFyX1dC2mG1rq+e+8zeQLvOvhdLifYlEA==",
+      "version": "0.1102.8",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.1102.8.tgz",
+      "integrity": "sha512-advLOzXtlA71XP+XCkvN4HCDTFfSUAfUcEFWLSxIFu456ED6smGex8ydkH6YcWx9LM+auhyHiJmTNYFDI0vxig==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "11.2.5",
-        "@angular-devkit/schematics": "11.2.5",
+        "@angular-devkit/core": "11.2.8",
+        "@angular-devkit/schematics": "11.2.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "2.0.0",
         "npm-package-arg": "^8.0.0",
@@ -4507,9 +4492,9 @@
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "11.2.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.5.tgz",
-          "integrity": "sha512-DRFvEHRKoC+hTwcOAJqLe6UQa+bpXc/1IGCMHWEbuply0KIFIGQOlmaYwFZKixz3HdFZlmoCMcAVkAXvyaWVsQ==",
+          "version": "11.2.8",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-11.2.8.tgz",
+          "integrity": "sha512-iNodaySWW1JrF+oGZCi0rYDJXO96T4K7H6BLz6xapSwFxkY+Xr4CBuTqEp2DKzAZ+sjYFmsItLmNedwOOBnwfA==",
           "dev": true,
           "requires": {
             "ajv": "6.12.6",
@@ -4517,17 +4502,6 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.3",
             "source-map": "0.7.3"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "6.6.3",
-              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-              "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
-              "dev": true,
-              "requires": {
-                "tslib": "^1.9.0"
-              }
-            }
           }
         },
         "lru-cache": {
@@ -4537,6 +4511,15 @@
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
+          }
+        },
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "semver": {
@@ -17119,9 +17102,9 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
-          "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+          "version": "15.0.6",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.6.tgz",
+          "integrity": "sha512-g1WYDMct/jzW+JdWEyjaX2zoBkZ6ZT9VpOyp2I/VMtDsNLffNat3kqPFfi1eDRSK9/SuKGyORDHcQMcPF8sQ/w==",
           "dev": true,
           "requires": {
             "@npmcli/move-file": "^1.0.1",
@@ -17138,7 +17121,7 @@
             "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^3.0.2",
-            "ssri": "^8.0.0",
+            "ssri": "^8.0.1",
             "tar": "^6.0.2",
             "unique-filename": "^1.1.1"
           }
@@ -18352,9 +18335,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -22386,9 +22369,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -22429,9 +22412,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -22446,9 +22429,9 @@
       }
     },
     "npm-packlist": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.1.4.tgz",
-      "integrity": "sha512-Qzg2pvXC9U4I4fLnUrBmcIT4x0woLtUgxUi9eC+Zrcv1Xx5eamytGAfbDWQ67j7xOcQ2VW1I3su9smVTIdu7Hw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.1.5.tgz",
+      "integrity": "sha512-KCfK3Vi2F+PH1klYauoQzg81GQ8/GGjQRKYY6tRnpQUPKTs/1gBZSRWtTEd7jGdSn1LZL7gpAmJT+BcS55k2XQ==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6",
@@ -22478,9 +22461,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -23004,9 +22987,9 @@
       },
       "dependencies": {
         "cacache": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
-          "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+          "version": "15.0.6",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.6.tgz",
+          "integrity": "sha512-g1WYDMct/jzW+JdWEyjaX2zoBkZ6ZT9VpOyp2I/VMtDsNLffNat3kqPFfi1eDRSK9/SuKGyORDHcQMcPF8sQ/w==",
           "dev": true,
           "requires": {
             "@npmcli/move-file": "^1.0.1",
@@ -23023,7 +23006,7 @@
             "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^3.0.2",
-            "ssri": "^8.0.0",
+            "ssri": "^8.0.1",
             "tar": "^6.0.2",
             "unique-filename": "^1.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@storybook/theming": "^5.3.21",
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "@stylelint/postcss-markdown": "^0.36.1",
-    "@types/jasmine": "^3.6.6",
+    "@types/jasmine": "^3.6.9",
     "@types/jasminewd2": "^2.0.8",
     "@types/node": "^14.14.37",
     "autoprefixer": "^10.2.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@angular-devkit/build-angular": "^0.1002.0",
     "@angular/cli": "^11.2.5",
     "@angular/compiler-cli": "^11.1.0",
-    "@angular/language-service": "^11.1.0",
+    "@angular/language-service": "^11.2.9",
     "@babel/core": "^7.13.13",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-angular": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.1002.0",
-    "@angular/cli": "^11.2.5",
+    "@angular/cli": "^11.2.8",
     "@angular/compiler-cli": "^11.1.0",
     "@angular/language-service": "^11.2.9",
     "@babel/core": "^7.13.13",

--- a/projects/canopy/src/lib/canopy.module.ts
+++ b/projects/canopy/src/lib/canopy.module.ts
@@ -24,6 +24,7 @@ import { LgPrefixModule } from './prefix/prefix.module';
 import { LgPromoCardModule } from './promo-card/promo-card.module';
 import { LgQuickActionModule } from './quick-action/quick-action.module';
 import { LgSeparatorModule } from './separator/separator.module';
+import { LgSideNavModule } from './side-nav/side-nav.module';
 import { LgSpacingModule } from './spacing/spacing.module';
 import { LgSpinnerModule } from './spinner/spinner.module';
 import { LgSuffixModule } from './suffix/suffix.module';
@@ -55,6 +56,7 @@ const modules = [
   LgPromoCardModule,
   LgQuickActionModule,
   LgSeparatorModule,
+  LgSideNavModule,
   LgSpacingModule,
   LgSpinnerModule,
   LgSuffixModule,

--- a/projects/canopy/src/lib/side-nav/index.ts
+++ b/projects/canopy/src/lib/side-nav/index.ts
@@ -1,0 +1,4 @@
+export * from './side-nav-content/side-nav-content.component';
+export * from './side-nav-bar/side-nav-bar.component';
+export * from './side-nav.component';
+export * from './side-nav.module';

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-footer/side-nav-bar-footer.component.html
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-footer/side-nav-bar-footer.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-footer/side-nav-bar-footer.component.spec.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-footer/side-nav-bar-footer.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LgSideNavBarFooterComponent } from './side-nav-bar-footer.component';
+
+describe('LgSideNavBarFooterComponent', () => {
+  let component: LgSideNavBarFooterComponent;
+  let fixture: ComponentFixture<LgSideNavBarFooterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LgSideNavBarFooterComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgSideNavBarFooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain(
+      'lg-side-nav-bar-footer',
+    );
+  });
+});

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-footer/side-nav-bar-footer.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-footer/side-nav-bar-footer.component.ts
@@ -1,0 +1,16 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  ViewEncapsulation,
+} from '@angular/core';
+
+@Component({
+  selector: 'lg-side-nav-bar-footer',
+  templateUrl: './side-nav-bar-footer.component.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LgSideNavBarFooterComponent {
+  @HostBinding('class.lg-side-nav-bar-footer') class = true;
+}

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.html
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.html
@@ -1,0 +1,9 @@
+<div class="lg-side-nav-bar-item__container">
+  <div class="lg-side-nav-bar-item__title lg-font-size-1--strong">{{ title }}</div>
+  <div *ngIf="description" class="lg-side-nav-bar-item__description lg-font-size-0-8">
+    {{ description }}
+  </div>
+</div>
+<div class="lg-side-nav-bar-item__icon-container">
+  <lg-icon name="chevron-right" class="lg-font-size-0-8"></lg-icon>
+</div>

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.scss
@@ -1,0 +1,28 @@
+@import '../../../styles/mixins';
+
+.lg-side-nav-bar-item {
+  display: flex;
+  justify-content: space-between;
+
+  .lg-side-nav-bar-item__icon-container {
+    position: relative;
+    padding-right: var(--space-sm);
+
+    @include lg-breakpoint('md') {
+      padding-right: var(--space-sm);
+    }
+
+    @include lg-breakpoint('lg') {
+      padding-right: var(--space-xs);
+    }
+  }
+
+  &__description {
+    padding-top: var(--space-xxxs);
+  }
+
+  .lg-icon {
+    position: absolute;
+    left: calc(-1 * var(--space-xxs));
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.spec.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LgSideNavBarItemComponent } from './side-nav-bar-item.component';
+
+describe('LgSideNavBarItemComponent', () => {
+  let component: LgSideNavBarItemComponent;
+  let fixture: ComponentFixture<LgSideNavBarItemComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LgSideNavBarItemComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgSideNavBarItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-side-nav-bar-item');
+  });
+
+  it('should contain the description if appropriate data is present', () => {
+    component.description = 'test';
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const innerEl: HTMLElement = el.querySelector('.lg-side-nav-bar-item__description');
+
+    expect(innerEl).not.toBeNull();
+    expect(innerEl.textContent).toContain(`test`);
+  });
+
+  it('should not contain the description if appropriate data is not present', () => {
+    component.description = '';
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const innerEl: HTMLElement = el.querySelector('.lg-side-nav-bar-item__description');
+
+    expect(innerEl).toBeNull();
+  });
+});

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.ts
@@ -1,0 +1,14 @@
+import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'lg-side-nav-bar-item',
+  templateUrl: './side-nav-bar-item.component.html',
+  styleUrls: ['./side-nav-bar-item.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class LgSideNavBarItemComponent {
+  @HostBinding('class.lg-side-nav-bar-item') class = true;
+
+  @Input() title: string;
+  @Input() description: string;
+}

--- a/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.html
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.scss
@@ -1,0 +1,55 @@
+@import '../../../styles/mixins';
+
+.lg-side-nav-bar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  padding: 0;
+  margin: var(--space-sm) 0 0 0;
+  font-size: var(--text-base-size);
+  font-weight: var(--tabs-list-item-font-weight);
+
+  @include lg-breakpoint('md') {
+    margin: var(--space-sm) 0 0 0;
+  }
+
+  @include lg-breakpoint('lg') {
+    max-width: calc(33%);
+    padding: 0 var(--space-xl) 0 0;
+    border-right: var(--border-width) solid var(--color-platinum);
+  }
+
+  .lg-tab-nav-bar-link {
+    border-bottom: var(--border-width) solid var(--color-platinum);
+    color: var(--color-charcoal);
+    padding: var(--space-sm);
+    text-decoration: none;
+
+    @include lg-breakpoint('md') {
+      padding: var(--space-sm);
+    }
+
+    @include lg-breakpoint('lg') {
+      padding: var(--space-sm) var(--space-xs);
+    }
+
+    &:hover {
+      cursor: pointer;
+      color: var(--color-midnight-blue);
+      border-bottom: var(--side-nav-bar-item-border-width-lg) solid
+        var(--color-midnight-blue);
+      padding-bottom: var(--space-xs);
+    }
+  }
+
+  .lg-tab-nav-bar-link--selected {
+    color: var(--color-super-blue);
+    border-bottom: var(--side-nav-bar-item-border-width-md) solid var(--color-super-blue);
+    padding-bottom: calc(var(--space-sm) - var(--side-nav-bar-item-border-width-md));
+
+    &:hover {
+      padding-bottom: calc(var(--space-xs) - var(--border-width));
+    }
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.spec.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LgSideNavBarComponent } from './side-nav-bar.component';
+
+describe('LgSideNavBarComponent', () => {
+  let component: LgSideNavBarComponent;
+  let fixture: ComponentFixture<LgSideNavBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LgSideNavBarComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgSideNavBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-side-nav-bar');
+  });
+});

--- a/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar/side-nav-bar.component.ts
@@ -1,0 +1,116 @@
+import {
+  AfterContentChecked,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  forwardRef,
+  HostBinding,
+  HostListener,
+  Input,
+  OnDestroy,
+  QueryList,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { merge, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { isKeyDown, isKeyLeft, isKeyRight, isKeyUp } from '../../utils/keyboard-keys';
+import { LgTabNavBarLinkDirective } from '../../tabs';
+
+@Component({
+  selector: 'lg-side-nav-bar',
+  templateUrl: './side-nav-bar.component.html',
+  styleUrls: ['./side-nav-bar.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LgSideNavBarComponent implements AfterContentChecked, OnDestroy {
+  selectedIndex = 0;
+  navs: Array<LgTabNavBarLinkDirective>;
+  private ngUnsubscribe: Subject<void> = new Subject<void>();
+
+  @Input() label = 'Nav';
+  @ContentChildren(forwardRef(() => LgTabNavBarLinkDirective), {
+    descendants: true,
+  })
+  navQueryList: QueryList<LgTabNavBarLinkDirective>;
+
+  @HostBinding('class.lg-side-nav-bar') class = true;
+  @HostBinding('attr.role') ariaRole = 'tablist';
+  @HostBinding('attr.aria-label')
+  get ariaLabel() {
+    return this.label ? this.label : 'Nav';
+  }
+
+  @HostListener('keyup', ['$event']) onKeyUp(event: KeyboardEvent): void {
+    const isPreviousKey = isKeyLeft(event) || isKeyUp(event);
+    const isNextKey = isKeyRight(event) || isKeyDown(event);
+
+    if (!isPreviousKey && !isNextKey) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const currentSelectedTabIndex = this.navs.findIndex((tab) => tab.isActive);
+
+    if (isPreviousKey) {
+      this.selectedIndex =
+        currentSelectedTabIndex === 0
+          ? this.navs.length - 1
+          : currentSelectedTabIndex - 1;
+    }
+
+    if (isNextKey) {
+      this.selectedIndex =
+        currentSelectedTabIndex === this.navs.length - 1
+          ? 0
+          : currentSelectedTabIndex + 1;
+    }
+
+    this.navs[this.selectedIndex].selectByKeyboard();
+  }
+
+  constructor(private cd: ChangeDetectorRef) {}
+
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+
+  ngAfterContentChecked() {
+    this.setTabs();
+
+    this.navQueryList.changes.pipe(takeUntil(this.ngUnsubscribe)).subscribe(() => {
+      this.setTabs();
+      this.cd.detectChanges();
+    });
+  }
+
+  setTabs() {
+    this.navs = this.navQueryList.toArray();
+
+    // Set the tab indexes and initial selected tab index
+    this.navs.forEach((nav, index: number) => {
+      nav.index = index;
+    });
+
+    // Update tab link active states when active tab changes
+    const navOutputs = this.navs.map((tab) => tab.selectedTabIndexChange);
+
+    merge(...navOutputs)
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe((nextSelectedIndex: number) =>
+        this.updateSelectedNav(nextSelectedIndex),
+      );
+  }
+
+  updateSelectedNav(index: number) {
+    this.navs.forEach((tab, i: number) => {
+      tab.isActive = i === index;
+    });
+    this.selectedIndex = index;
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.html
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.scss
@@ -1,0 +1,13 @@
+@import '../../../styles/mixins';
+
+.lg-side-nav-content {
+  margin: 0 0 var(--space-sm) 0;
+
+  @include lg-breakpoint('md') {
+    margin: 0 0 var(--space-sm) 0;
+  }
+
+  @include lg-breakpoint('lg') {
+    margin: 0 0 0 var(--space-xl);
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.spec.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LgSideNavContentComponent } from './side-nav-content.component';
+
+describe('LgSideNavContentComponent', () => {
+  let component: LgSideNavContentComponent;
+  let fixture: ComponentFixture<LgSideNavContentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LgSideNavContentComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgSideNavContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-side-nav-content');
+  });
+});

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.ts
@@ -1,0 +1,24 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  Input,
+  ViewEncapsulation,
+} from '@angular/core';
+
+@Component({
+  selector: 'lg-side-nav-content',
+  templateUrl: './side-nav-content.component.html',
+  styleUrls: ['./side-nav-content.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LgSideNavContentComponent {
+  @Input() selectedNavId: string;
+
+  @HostBinding('class.lg-side-nav-content') class = true;
+  @HostBinding('attr.aria-labelledby')
+  get labelledBy() {
+    return this.selectedNavId;
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav.component.html
+++ b/projects/canopy/src/lib/side-nav/side-nav.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/canopy/src/lib/side-nav/side-nav.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav.component.scss
@@ -1,0 +1,14 @@
+@import '../../styles/mixins';
+
+.lg-side-nav {
+  display: flex;
+  flex-direction: column-reverse;
+
+  @include lg-breakpoint('md') {
+    flex-direction: column-reverse;
+  }
+
+  @include lg-breakpoint('lg') {
+    flex-direction: row;
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav.component.spec.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LgSideNavComponent } from './side-nav.component';
+
+describe('LgSideNavComponent', () => {
+  let component: LgSideNavComponent;
+  let fixture: ComponentFixture<LgSideNavComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LgSideNavComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgSideNavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-side-nav');
+  });
+});

--- a/projects/canopy/src/lib/side-nav/side-nav.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav.component.ts
@@ -1,0 +1,17 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  ViewEncapsulation,
+} from '@angular/core';
+
+@Component({
+  selector: 'lg-side-nav',
+  templateUrl: './side-nav.component.html',
+  styleUrls: ['./side-nav.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LgSideNavComponent {
+  @HostBinding('class.lg-side-nav') class = true;
+}

--- a/projects/canopy/src/lib/side-nav/side-nav.interface.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav.interface.ts
@@ -1,0 +1,4 @@
+export interface SideNavBarItem {
+  title: string;
+  description?: string;
+}

--- a/projects/canopy/src/lib/side-nav/side-nav.module.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LgSideNavComponent } from './side-nav.component';
+import { LgSideNavContentComponent } from './side-nav-content/side-nav-content.component';
+import { LgSideNavBarComponent } from './side-nav-bar/side-nav-bar.component';
+import { LgSideNavBarItemComponent } from './side-nav-bar-item/side-nav-bar-item.component';
+import { LgSideNavBarFooterComponent } from './side-nav-bar-footer/side-nav-bar-footer.component';
+import { LgIconModule } from '../icon/icon.module';
+import { LgIconRegistry } from '../icon/icon.registry';
+import { lgIconChevronRight } from '../icon/icons.interface';
+import { LgTabNavBarLinkDirective } from '../tabs';
+
+const components = [
+  LgSideNavComponent,
+  LgSideNavContentComponent,
+  LgSideNavBarComponent,
+  LgTabNavBarLinkDirective,
+  LgSideNavBarItemComponent,
+  LgSideNavBarFooterComponent,
+];
+
+@NgModule({
+  imports: [CommonModule, LgIconModule],
+  declarations: [...components, LgTabNavBarLinkDirective],
+  exports: [...components],
+})
+export class LgSideNavModule {
+  constructor(private registry: LgIconRegistry) {
+    this.registry.registerIcons([lgIconChevronRight]);
+  }
+}

--- a/projects/canopy/src/lib/side-nav/side-nav.notes.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav.notes.ts
@@ -1,0 +1,30 @@
+export const notes = `
+# Side Nav Component
+
+## Purpose
+
+## Usage
+
+Import the component in your module:
+
+~~~js
+@NgModule({
+  ...
+  imports: [ ..., LgSideNavModule ],
+})
+~~~
+
+and in your HTML:
+
+~~~html
+<lg-side-nav></lg-side-nav>
+~~~
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+
+
+## Using only the SCSS files
+`;

--- a/projects/canopy/src/lib/side-nav/side-nav.stories.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav.stories.ts
@@ -1,0 +1,77 @@
+import { object, withKnobs } from '@storybook/addon-knobs';
+import { moduleMetadata } from '@storybook/angular';
+
+import { LgSideNavModule } from './side-nav.module';
+import { notes } from './side-nav.notes';
+import { LgButtonModule } from '../button';
+import { SideNavBarItem } from './side-nav.interface';
+import { LgMarginModule } from '../spacing';
+
+export default {
+  title: 'Components/Side Nav',
+  parameters: {
+    decorators: [
+      withKnobs,
+      moduleMetadata({
+        declarations: [],
+        imports: [LgSideNavModule, LgButtonModule, LgMarginModule],
+      }),
+    ],
+    notes: {
+      markdown: notes,
+    },
+  },
+};
+
+const getDefaultNavItems = (): Array<SideNavBarItem> => [
+  {
+    title: 'Overview',
+  },
+  {
+    title: 'Personal details',
+    description:
+      'Your name, date of birth, marital status and National Insurance Number.',
+  },
+  {
+    title: 'Contact details',
+    description: 'Your address, email and phone number.',
+  },
+  {
+    title: 'Login and security',
+    description: 'Reset your password and get a User ID reminder.',
+  },
+  {
+    title: 'Preferences',
+    description: 'How we send you documents and marketing.',
+  },
+];
+
+export const standard = () => ({
+  template: `
+    <lg-side-nav>
+      <lg-side-nav-bar label="Side Nav Demo">
+        <a *ngFor="let item of navItems; index as i"
+           id="side-nav-{{i}}"
+           [routerLink]=""
+           lgTabNavBarLink
+           href=""
+           (click)="onClick($event)"
+           [isActive]="i==selectedNavIndex"
+           >
+          <lg-side-nav-bar-item [title]="item.title" [description]="item.description"></lg-side-nav-bar-item>
+        </a>
+        <lg-side-nav-bar-footer>
+          <a lg-button lgMarginTop="xxl" variant="outline-primary" [fullWidth]="false" href="#">Logout</a>
+        </lg-side-nav-bar-footer>
+      </lg-side-nav-bar>
+      <lg-side-nav-content [selectedNavId]="'side-nav-' + selectedNavIndex">
+        <h1>Overview</h1>
+      </lg-side-nav-content>
+    </lg-side-nav>
+  `,
+  props: {
+    navItems: object('Navs', getDefaultNavItems()),
+    selectedNavIndex: 0,
+    onClick: (event: MouseEvent) => event.preventDefault(),
+  },
+});

--- a/projects/canopy/src/public-api.ts
+++ b/projects/canopy/src/public-api.ts
@@ -28,6 +28,7 @@ export * from './lib/prefix/index';
 export * from './lib/promo-card/index';
 export * from './lib/quick-action/index';
 export * from './lib/separator/index';
+export * from './lib/side-nav/index';
 export * from './lib/spacing/index';
 export * from './lib/spinner/index';
 export * from './lib/suffix/index';

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -64,7 +64,15 @@ $breakpoints: (
 */
 @mixin lg-breakpoint($breakpoint, $range: 'min-width') {
   @if map-has-key($breakpoints, $breakpoint) {
-    @media ($range: map-get($breakpoints, $breakpoint)) {
+    $value: map-get($breakpoints, $breakpoint);
+
+    @if $range == 'max-width' {
+      // Removes 1 pixel if using max-width so that there is no
+      // overlap when used with min-width.
+      $value: $value - 0.06rem;
+    }
+
+    @media ($range: $value) {
       @content;
     }
   } @else {

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -14,6 +14,7 @@
 @import 'variables/components/input';
 @import 'variables/components/page';
 @import 'variables/components/promo-card';
+@import 'variables/components/side-nav';
 @import 'variables/components/brand-icon';
 @import 'variables/components/quick-action';
 @import 'variables/components/select';

--- a/projects/canopy/src/styles/variables/components/_side-nav.scss
+++ b/projects/canopy/src/styles/variables/components/_side-nav.scss
@@ -1,0 +1,4 @@
+:root {
+  --side-nav-bar-item-border-width-md: 0.1875rem; // 3px
+  --side-nav-bar-item-border-width-lg: 0.3125rem; // 5px
+}


### PR DESCRIPTION
# Description

This is a draft PR of the side navigation component, which is an offshoot of the tab navigation component. The functionality is similar (still allows you to switch between sections), but the behaviour is a bit different as the nav menu is on the left of the content on desktop and below it on mobile. In contrast to regular tabs, side-nav tabs have a title and an optional description.

This draft PR lacks the following:

1. complete HTML in the story
2. complete code in the notes
3. functionality added to test app

## Requirements

Storybook link: https://deploy-preview-313--legal-and-general-canopy.netlify.app/?path=/story/components-side-nav--standard

Design: https://legalandgeneral.invisionapp.com/overview/Account-Details-cknlj6bn71jia01ym13rjlqh8/screens

Screenshots: 

### Desktop

<img width="1220" alt="Screenshot 2021-04-12 at 16 47 43" src="https://user-images.githubusercontent.com/4033816/114405169-13e09700-9baf-11eb-832a-115b9a197423.png">

### Tablet

<img width="859" alt="Screenshot 2021-04-12 at 16 51 13" src="https://user-images.githubusercontent.com/4033816/114405435-599d5f80-9baf-11eb-9a2d-a86d9ef057a5.png">

### Mobile phone

<img width="352" alt="Screenshot 2021-04-12 at 16 50 27" src="https://user-images.githubusercontent.com/4033816/114405306-3d99be00-9baf-11eb-9a80-48365fe71653.png">

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
