### PR TITLE
Fix some issues with the alert and the variants

### DIFF
--- a/projects/canopy/src/lib/alert/alert.component.scss
+++ b/projects/canopy/src/lib/alert/alert.component.scss
@@ -1,4 +1,9 @@
-@import '../../styles/mixins.scss';
+@import '../../styles/mixins';
+/*
+ The below import will be removed in the next breaking change. It is currently included to ensure
+ the same scss entities are exported. @deprecated
+*/
+@import '../../styles/variants';
 
 .lg-alert {
   display: flex;

--- a/projects/canopy/src/lib/alert/alert.component.scss
+++ b/projects/canopy/src/lib/alert/alert.component.scss
@@ -16,3 +16,7 @@
     line-height: var(--text-base-line-height);
   }
 }
+
+.lg-alert__icon {
+  margin-right: var(--space-xs);
+}

--- a/projects/canopy/src/lib/details/details.component.scss
+++ b/projects/canopy/src/lib/details/details.component.scss
@@ -1,4 +1,9 @@
 @import '../../styles/mixins';
+/*
+ The below import will be removed in the next breaking change. It is currently included to ensure
+ the same scss entities are exported. @deprecated
+*/
+@import '../../styles/variants';
 
 .lg-details {
   background: var(--details-bg-color);

--- a/projects/canopy/src/lib/forms/validation/validation.component.scss
+++ b/projects/canopy/src/lib/forms/validation/validation.component.scss
@@ -1,4 +1,9 @@
-@import '../../../styles/mixins.scss';
+@import '../../../styles/mixins';
+/*
+ The below import will be removed in the next breaking change. It is currently included to ensure
+ the same scss entities are exported. @deprecated
+*/
+@import '../../../styles/variants';
 
 .lg-validation {
   display: flex;


### PR DESCRIPTION
# Description

Add back the margin to the alert icon (removed by mistake https://github.com/Legal-and-General/canopy/commit/3f0e52c800e7f53e011fdc245b80653b47fd0094) and fixes the breaking change introduced in `5.8.0` where a new `variants.scss` was introduced which requires adding the import in every project using `scss` files. For the moment we will import the file in each component that uses it but flagged as deprecated. The breaking change will be addressed in the `next` branch.

Storybook link: https://deploy-preview-314--legal-and-general-canopy.netlify.app/

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
