### PR TITLE
Next: revert variants imports

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,9 +1,9 @@
 {
+  "branches": [
+    "master",
+    {"name": "next", "prerelease": true}
+  ],
   "plugins": [
-    "branches": [
-      "master",
-      {"name": "next", "channel": "next", "prerelease": "next"}
-    ],
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", {

--- a/projects/canopy/src/lib/alert/alert.component.scss
+++ b/projects/canopy/src/lib/alert/alert.component.scss
@@ -1,9 +1,4 @@
 @import '../../styles/mixins';
-/*
- The below import will be removed in the next breaking change. It is currently included to ensure
- the same scss entities are exported. @deprecated
-*/
-@import '../../styles/variants';
 
 .lg-alert {
   display: flex;

--- a/projects/canopy/src/lib/details/details.component.scss
+++ b/projects/canopy/src/lib/details/details.component.scss
@@ -1,9 +1,4 @@
 @import '../../styles/mixins';
-/*
- The below import will be removed in the next breaking change. It is currently included to ensure
- the same scss entities are exported. @deprecated
-*/
-@import '../../styles/variants';
 
 .lg-details {
   background: var(--details-bg-color);

--- a/projects/canopy/src/lib/forms/validation/validation.component.scss
+++ b/projects/canopy/src/lib/forms/validation/validation.component.scss
@@ -1,9 +1,4 @@
 @import '../../../styles/mixins';
-/*
- The below import will be removed in the next breaking change. It is currently included to ensure
- the same scss entities are exported. @deprecated
-*/
-@import '../../../styles/variants';
 
 .lg-validation {
   display: flex;

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -24,34 +24,34 @@
 ) {
   $box-shadow-inset-width: -0.063rem;
 
-  color: $default-color;
+  color: $default-color !important;
   text-decoration: none;
   border-bottom: 0.125rem solid $default-color;
   padding: 0 0.125rem;
 
   &:hover {
-    color: $hover-color;
+    color: $hover-color !important;
     border-bottom: 0;
     box-shadow: inset 0 $box-shadow-inset-width 0 0 $hover-color,
       0 0.188rem 0 0 $hover-color;
   }
 
   &:visited {
-    color: $visited-color;
+    color: $visited-color !important;
     border-color: $visited-color;
   }
 
   &:active {
-    background-color: $active-bg-color;
+    background-color: $active-bg-color !important;
     border-bottom-color: $active-color;
-    color: $active-color;
+    color: $active-color !important;
     outline: 0;
   }
 
   &:focus {
-    background-color: $focus-bg-color;
+    background-color: $focus-bg-color !important;
     border-bottom: 0;
-    color: $focus-color;
+    color: $focus-color !important;
     outline: 0.063rem solid $focus-bg-color;
     outline-offset: 0;
 
@@ -141,8 +141,8 @@ $breakpoints: (
 }
 
 @mixin lg-variant($variant: 'generic') {
-  background-color: var(--#{$variant}-bg-color);
-  color: var(--#{$variant}-color);
+  background-color: var(--#{$variant}-bg-color) !important;
+  color: var(--#{$variant}-color) !important;
 
   a {
     @include lg-link(


### PR DESCRIPTION
# Description
This PR updates the `next` branch with the latest master and in particular the last commit (8e86ab4) reverts the following commits:
- 86c2d774ffd39ab967c0f532532adfd630ce4447
- fb5c03ed204e2ca48d48e65bb71f1ec454ce9e6c
- 5f6f4b54b39611143caef1b4ae8fcfd7d46af291

BREAKING CHANGE: The following change removes the variants imports
from the alert, details and validation components.
If using the global scss modules, update your main scss file to
import `canopy/styles/variants`.

# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
