### PR TITLE
fix(variants): add outline primary button override

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -155,4 +155,10 @@ $breakpoints: (
       $focus-bg-color: var(--#{$variant}-link-focus-bg-color)
     );
   }
+
+  .lg-btn--outline-primary {
+    background-color: transparent !important;
+    border-color: var(--#{$variant}-color) !important;
+    color: var(--#{$variant}-color) !important;
+  }
 }


### PR DESCRIPTION
# Description

The variant styling for `.lg-btn--outline-primary` is missing in `next`, this adds them back in.

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Storybook link: https://deploy-preview-333--legal-and-general-canopy.netlify.app/?path=/story/directives--variant
Design link: n/a
Screenshot: 

**Before**
<img width="1186" alt="Screenshot 2021-04-26 at 14 10 23" src="https://user-images.githubusercontent.com/1943532/116089174-7b601180-a69a-11eb-9bcb-cd759f8a590e.png">

**After**
<img width="1178" alt="Screenshot 2021-04-26 at 14 10 09" src="https://user-images.githubusercontent.com/1943532/116089194-8024c580-a69a-11eb-8f9c-845e80cb8791.png">



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
