### PR TITLE
fix(button): ensure link styles don't override a link styled as button

### DIFF
--- a/projects/canopy/src/lib/button/button.stories.ts
+++ b/projects/canopy/src/lib/button/button.stories.ts
@@ -26,6 +26,7 @@ const contentGroupId = 'content';
 @Component({
   selector: 'lg-button-story',
   template: `
+    <p>Used on a <strong>button</strong> element</p>
     <button
       lg-button
       [disabled]="disabled"
@@ -36,9 +37,24 @@ const contentGroupId = 'content';
       [size]="size"
       [variant]="variant"
     >
-      <ng-content></ng-content>
+      {{ content }}
       <lg-icon *ngIf="showIcon || iconButton" [name]="icon"></lg-icon>
     </button>
+    <p>Used on a <strong>link</strong> element</p>
+    <a
+      lg-button
+      href="#"
+      [disabled]="disabled"
+      [fullWidth]="fullWidth"
+      [iconButton]="iconButton"
+      [iconPosition]="iconPosition"
+      [loading]="loading"
+      [size]="size"
+      [variant]="variant"
+    >
+      {{ content }}
+      <lg-icon *ngIf="showIcon || iconButton" [name]="icon"></lg-icon>
+    </a>
   `,
 })
 class ButtonStoryComponent {
@@ -51,6 +67,7 @@ class ButtonStoryComponent {
   @Input() showIcon: boolean;
   @Input() size: ButtonSize;
   @Input() variant: string;
+  @Input() content: string;
   icons = iconsArray;
   constructor(private registry: LgIconRegistry) {
     this.registry.registerIcons(this.icons);
@@ -95,8 +112,8 @@ const createBtnStory = (config: KnobsConfig) => ({
       [showIcon]="showIcon"
       [size]="size"
       [variant]="variant"
+      [content]="content"
       >
-      {{content}}
   </lg-button-story>
   `,
   props: {

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -24,34 +24,34 @@
 ) {
   $box-shadow-inset-width: -0.063rem;
 
-  color: $default-color !important;
+  color: $default-color;
   text-decoration: none;
   border-bottom: 0.125rem solid $default-color;
   padding: 0 0.125rem;
 
   &:hover {
-    color: $hover-color !important;
+    color: $hover-color;
     border-bottom: 0;
     box-shadow: inset 0 $box-shadow-inset-width 0 0 $hover-color,
       0 0.188rem 0 0 $hover-color;
   }
 
   &:visited {
-    color: $visited-color !important;
+    color: $visited-color;
     border-color: $visited-color;
   }
 
   &:active {
-    background-color: $active-bg-color !important;
+    background-color: $active-bg-color;
     border-bottom-color: $active-color;
-    color: $active-color !important;
+    color: $active-color;
     outline: 0;
   }
 
   &:focus {
-    background-color: $focus-bg-color !important;
+    background-color: $focus-bg-color;
     border-bottom: 0;
-    color: $focus-color !important;
+    color: $focus-color;
     outline: 0.063rem solid $focus-bg-color;
     outline-offset: 0;
 


### PR DESCRIPTION
# Description

~Th `lg-link` mixin used `!important` to apply colours to links inside
one of the `lg-variant` classes (such as info, success, error, etc).
However, this caused issues with the `lg-button` directive when used to
style a link as a button, because the global link styles use `lg-link`.
This is fixed by making `!important` an opt in paramter of the `lg-link`
mixin, so that the variant styles can still use it and apply `!important`,
but that won't affect any other uses of the `lg-link` mixin.~

**Edit:**

Following the discussion on the use of `!important` for the links inside `lg-variant`, we have decided to remove `!important` completely from the `lg-link` mixin.


This change also edits the button story, so that it displays both a normal button and a link styled as a button (separate commit).



Storybook link: https://deploy-preview-336--legal-and-general-canopy.netlify.app/?path=/story/components-button--primary-button

**Before:**
<img width="252" alt="Screenshot 2021-04-27 at 14 57 37" src="https://user-images.githubusercontent.com/1943532/116257202-bed68080-a76b-11eb-9e8c-14820a8bb8e4.png">



**After:**
<img width="247" alt="Screenshot 2021-04-27 at 14 57 04" src="https://user-images.githubusercontent.com/1943532/116256049-bf224c00-a76a-11eb-8082-b08314df766b.png">



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
