### PR TITLE
fix(variants): prevent lg-link from overiding lg-btn styles

### DIFF
--- a/projects/canopy/src/lib/variant/variant.stories.ts
+++ b/projects/canopy/src/lib/variant/variant.stories.ts
@@ -25,9 +25,11 @@ const variants = ['generic', 'info', 'success', 'warning', 'error'];
           This card has the <strong>{{ variant }}</strong> variant applied. Here is some
           <a href="#">link text</a>.
         </p>
-        <button lg-button variant="outline-primary" lgMarginBottom="none">
-          Outline primary button
-        </button>
+        <button lg-button variant="outline-primary">Outline primary button</button>
+        <br />
+        <a href="#" lg-button variant="outline-primary" lgMarginBottom="none">
+          Outline primary link styled as button
+        </a>
       </lg-card-content>
     </lg-card>
     <lg-card>

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -144,7 +144,7 @@ $breakpoints: (
   background-color: var(--#{$variant}-bg-color) !important;
   color: var(--#{$variant}-color) !important;
 
-  a {
+  a:not(.lg-btn) {
     @include lg-link(
       $default-color: var(--#{$variant}-link-color),
       $hover-color: var(--#{$variant}-link-hover-color),


### PR DESCRIPTION
## Description

The `lg-link` mixin is used to style links inside the variant CSS (e.g. for success, error
variants). However it was causing layout issues as it was clashing with the `.lg-btn` styles. This
is because the links inside varaint CSS were gaining higher specifity. Adding `a:not(.lg-btn)`
prevents this from happening.

Storybook link: (once netlify has deployed link provide a link to the component)


**Before**
![Screenshot 2021-04-30 at 09 55 11](https://user-images.githubusercontent.com/1943532/117122584-f35ec380-ad8d-11eb-8362-20f891df2dad.png)


**After**
<img width="571" alt="Screenshot 2021-05-05 at 10 38 06" src="https://user-images.githubusercontent.com/1943532/117122684-070a2a00-ad8e-11eb-8984-d12ac61bddf9.png">


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
