### PR TITLE
fix(hero): fix broken styling on hero card title

### DIFF
--- a/projects/canopy/src/lib/hero/hero-card-title/hero-card-title.component.scss
+++ b/projects/canopy/src/lib/hero/hero-card-title/hero-card-title.component.scss
@@ -5,7 +5,14 @@
 }
 
 .lg-hero-card-title__heading {
-  @include lg-font-size(6);
+  > h1,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6 {
+    @include lg-font-size(6);
 
-  margin-bottom: var(--space-sm);
+    margin-bottom: var(--space-sm);
+  }
 }


### PR DESCRIPTION
# Description

The Hero Card Title component relied on passing a class to the `lg-heading` component. This input was
recently removed, causing this styling to break. This change adopts the same approach as
`lg-accordion` whereby the headings are styled directly.


## Requirements

Storybook link: (once netlify has deployed link provide a link to the component)

**Before**
<img width="618" alt="Screenshot 2021-05-05 at 16 41 01" src="https://user-images.githubusercontent.com/1943532/117169130-bd870280-adc0-11eb-858f-b8f735cf78ff.png">

**After**
<img width="607" alt="Screenshot 2021-05-05 at 16 40 42" src="https://user-images.githubusercontent.com/1943532/117169284-e14a4880-adc0-11eb-9c0b-a968dbfef050.png">


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
