### PR TITLE
fix(variants): add hover and active state style to variant buttons

### DIFF
--- a/projects/canopy/src/lib/heading/heading.component.spec.ts
+++ b/projects/canopy/src/lib/heading/heading.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 
 import { LgHeadingComponent } from './heading.component';
 
-fdescribe('LgHeadingComponent', () => {
+describe('LgHeadingComponent', () => {
   let component: LgHeadingComponent;
   let fixture: ComponentFixture<LgHeadingComponent>;
 

--- a/projects/canopy/src/lib/variant/variant.stories.ts
+++ b/projects/canopy/src/lib/variant/variant.stories.ts
@@ -64,9 +64,9 @@ export default {
         ],
       }),
     ],
-  },
-  notes: {
-    markdown: notes,
+    notes: {
+      markdown: notes,
+    },
   },
 };
 

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -160,5 +160,58 @@ $breakpoints: (
     background-color: transparent !important;
     border-color: var(--#{$variant}-color) !important;
     color: var(--#{$variant}-color) !important;
+
+    @if ($variant == 'generic') {
+      &:hover {
+        background-color: var(--color-taupe-grey) !important;
+        border-color: var(--color-taupe-grey) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-charcoal) !important;
+        color: var(--color-white) !important;
+      }
+    } @else if ($variant == 'info') {
+      &:hover {
+        background-color: var(--color-midnight-blue) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-super-blue-darkest) !important;
+        color: var(--color-white) !important;
+      }
+    } @else if ($variant == 'success') {
+      &:hover {
+        background-color: var(--color-mexican-green) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-leafy-green-dark) !important;
+        color: var(--color-white) !important;
+      }
+    } @else if ($variant == 'warning') {
+      &:hover {
+        background-color: var(--color-earth-brown-dark) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-earth-brown-darkest) !important;
+        color: var(--color-white) !important;
+      }
+    } @else if ($variant == 'error') {
+      &:hover {
+        background-color: var(--color-terracotta) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-earth-brown-darkest) !important;
+        color: var(--color-white) !important;
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

Add styles for hover and active state, to variant buttons.

Note FYI: After a discussion with Michelle from the design team, we decided on this temporary solution until we design and build the component that combines the current `Alert component`, the`Detail component`, the `Form Validation component` and the `Variant Directive` that is being modified here. Inside variants we may only use the `outline-primary` button.

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: [design link here](https://legalandgeneral.invisionapp.com/console/share/SB10JVR247UQ/613975239/play)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
