### PR TITLE
fix(variants): add hover and active state style to variant buttons

### DIFF
--- a/projects/canopy/src/lib/variant/variant.stories.ts
+++ b/projects/canopy/src/lib/variant/variant.stories.ts
@@ -62,9 +62,9 @@ export default {
         ],
       }),
     ],
-  },
-  notes: {
-    markdown: notes,
+    notes: {
+      markdown: notes,
+    },
   },
 };
 

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -113,6 +113,17 @@ $breakpoints: (
       background-color: transparent !important;
       border-color: var(--generic-color) !important;
       color: var(--generic-color) !important;
+
+      &:hover {
+        background-color: var(--color-taupe-grey) !important;
+        border-color: var(--color-taupe-grey) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-charcoal) !important;
+        color: var(--color-white) !important;
+      }
     }
   } @else if ($variant == 'info') {
     background-color: var(--info-bg-color) !important;
@@ -134,6 +145,16 @@ $breakpoints: (
       background-color: transparent !important;
       border-color: var(--info-color) !important;
       color: var(--info-color) !important;
+
+      &:hover {
+        background-color: var(--info-link-hover-color) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-super-blue-darkest) !important;
+        color: var(--color-white) !important;
+      }
     }
   } @else if ($variant == 'success') {
     background-color: var(--success-bg-color) !important;
@@ -155,6 +176,16 @@ $breakpoints: (
       background-color: transparent !important;
       border-color: var(--success-color) !important;
       color: var(--success-color) !important;
+
+      &:hover {
+        background-color: var(--success-link-hover-color) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-leafy-green-dark) !important;
+        color: var(--color-white) !important;
+      }
     }
   } @else if ($variant == 'warning') {
     background-color: var(--warning-bg-color) !important;
@@ -176,6 +207,16 @@ $breakpoints: (
       background-color: transparent !important;
       border-color: var(--warning-color) !important;
       color: var(--warning-color) !important;
+
+      &:hover {
+        background-color: var(--warning-link-hover-color) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-earth-brown-darkest) !important;
+        color: var(--color-white) !important;
+      }
     }
   } @else if ($variant == 'error') {
     background-color: var(--error-bg-color) !important;
@@ -197,6 +238,16 @@ $breakpoints: (
       background-color: transparent !important;
       border-color: var(--error-color) !important;
       color: var(--error-color) !important;
+
+      &:hover {
+        background-color: var(--error-link-hover-color) !important;
+        color: var(--color-white) !important;
+      }
+
+      &:active {
+        background-color: var(--color-earth-brown-darkest) !important;
+        color: var(--color-white) !important;
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

Add styles for hover and active state, to variant buttons.

Note FYI: After a discussion with Michelle from the design team, we decided on this temporary solution until we design and build the component that combines the current Alert component, theDetail component, the Form Validation component and the Variant Directive that is being modified here. Inside variants we may only use the outline-primary button.

Implementation for pre-release branch( next ): [PR here](https://github.com/Legal-and-General/canopy/pull/350)

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: [design link](https://legalandgeneral.invisionapp.com/console/share/SB10JVR247UQ/613975239/play)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
