### PR TITLE
fix(side-nav): remove display property from lg-card mixin

### DIFF
--- a/projects/canopy/src/lib/card/card.component.scss
+++ b/projects/canopy/src/lib/card/card.component.scss
@@ -1,5 +1,6 @@
 @import '../../styles/mixins.scss';
 
 .lg-card {
+  display: block;
   @include lg-card;
 }

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.scss
@@ -3,6 +3,7 @@
 .lg-side-nav-content {
   @include lg-card;
 
+  display: block;
   width: 100%;
   margin: 0;
 

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -202,7 +202,6 @@ $breakpoints: (
 }
 
 @mixin lg-card {
-  display: block;
   background-color: var(--card-bg-color);
   border-radius: var(--border-radius-lg);
   margin-bottom: var(--grid-gutter);


### PR DESCRIPTION
# Description

Fixes an issue where the display property of the `lg-card` mixin was overriding and display property of an element that used the mixin.

Storybook link: (once netlify has deployed link provide a link to the component)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
