### PR TITLE
build(deps-dev): bump stylelint from 13.12.0 to 13.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28911,9 +28911,9 @@
       }
     },
     "stylelint-config-recommended": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
-      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
+      "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
       "dev": true
     },
     "stylelint-selector-bem-pattern": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "protractor": "^7.0.0",
     "semantic-release": "^17.4.2",
     "stylelint": "^13.13.1",
-    "stylelint-config-recommended": "^3.0.0",
+    "stylelint-config-recommended": "^5.0.0",
     "stylelint-selector-bem-pattern": "^2.1.0",
     "svg-to-ts": "^6.0.0",
     "svgo": "^2.3.0",

--- a/projects/canopy/src/styles/variables/_colors.scss
+++ b/projects/canopy/src/styles/variables/_colors.scss
@@ -35,7 +35,6 @@
   --color-poppy-red: #e22922;
 
   --color-poppy-red-dark: #b50005;
-  --color-earth-brown-darkest: #671210;
 
   --color-dandelion-yellow-lightest: #fdf8cd;
   --color-dandelion-yellow-light: #ffef67;


### PR DESCRIPTION
# Description

Bumps stylelint to 13.13.1 and also removes a duplicate variable which showed up after running the
updated version of stylelint

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
