### PR TITLE
feat(scss): add font type parameter to lg-font-size mixin

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -22,7 +22,7 @@
   outline: var(--link-focus-outline) solid $bg-color;
 }
 
-@mixin lg-font-size($size, $modifier: null) {
+@mixin lg-font-size($size, $modifier: null, $type: null) {
   font-size: var(--text-fs-#{$size}-size);
   line-height: var(--text-fs-#{$size}-line-height);
 
@@ -30,6 +30,10 @@
     font-weight: var(--text-fs-#{$size}-weight--#{$modifier});
   } @else {
     font-weight: var(--text-fs-#{$size}-weight);
+  }
+
+  @if $type == 'expressive' {
+    font-family: var(--font-family-#{$type});
   }
 }
 


### PR DESCRIPTION
# Description

Add ability to apply the expressive font when using the _@lg-font-size_ mixin by enhancing the mixin with the third parameter _type_ with the default value null. When no parameter provided for the type of font family there will be no overriding of the font family set from another class. If we provide _productive_ as the value for the type parameter it will override the font family with the productive (Roboto) font. If the _expressive_ value has been set as a type parameter, expressive (Lyon) font will be set.

Fixes #224 

## Requirements

No requirements are needed. If we don't provide type parameter to the lg-font-size mixin there will be no changes to the font-family.

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
