### PR TITLE
build(dependabot): ignore all angular updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
       include: 'scope'
     versioning-strategy: increase
     ignore:
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@storybook/addon-a11y"
         versions: ["6.x"]
       - dependency-name: "@storybook/addon-actions"


### PR DESCRIPTION
# Description

As suggested in [this Dependabot PR](https://github.com/Legal-and-General/canopy/pull/366), this change should disable all Dependabot updates for Angular packages, as we do these manually at the same time.

Shout if you don't think this is the right thing to do.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
