### PR TITLE
feat: carousel component added

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -566,6 +566,39 @@
                 </ng-container>
               </tbody>
             </table>
+
+            <lg-heading level="3">Carousel</lg-heading>
+
+            <lg-carousel [description]="'Example Carousel'" [headingLevel]="4" [slideDuration]="500">
+              <lg-carousel-item>
+                <h3>Carousel item 1</h3>
+                <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+                <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+              </lg-carousel-item>
+
+              <lg-carousel-item>
+                <h3>Carousel item 2</h3>
+                <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+                <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+              </lg-carousel-item>
+
+              <lg-carousel-item>
+                <h3>Carousel item 3</h3>
+                <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+                <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+              </lg-carousel-item>
+
+              <lg-carousel-item>
+                <h3>Carousel item 4</h3>
+                <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+                <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+                <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+              </lg-carousel-item>
+            </lg-carousel>
+
           </lg-card-content>
         </lg-card>
       </div>

--- a/projects/canopy/src/lib/canopy.module.ts
+++ b/projects/canopy/src/lib/canopy.module.ts
@@ -7,6 +7,7 @@ import { LgBrandIconModule } from './brand-icon/brand-icon.module';
 import { LgBreadcrumbModule } from './breadcrumb/breadcrumb.module';
 import { LgButtonModule } from './button/button.module';
 import { LgCardModule } from './card/card.module';
+import { LgCarouselModule } from './carousel/carousel.module';
 import { LgDataPointModule } from './data-point/data-point.module';
 import { LgDetailsModule } from './details/details.module';
 import { LgFeatureToggleModule } from './feature-toggle/feature-toggle.module';
@@ -67,6 +68,7 @@ const modules = [
   LgTableModule,
   LgTabsModule,
   LgVariantModule,
+  LgCarouselModule,
 ];
 
 @NgModule({

--- a/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.html
+++ b/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.scss
+++ b/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.scss
@@ -1,0 +1,3 @@
+.lg-carousel-item {
+  padding: var(--component-padding);
+}

--- a/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.spec.ts
+++ b/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LgCarouselItemComponent } from './carousel-item.component';
+
+describe('LgCarouselItemComponent', () => {
+  let component: LgCarouselItemComponent;
+  let fixture: ComponentFixture<LgCarouselItemComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [LgCarouselItemComponent],
+      }).compileComponents();
+    }),
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgCarouselItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should apply initial host binding classes and attributes', () => {
+    expect(component.element.nativeElement.classList.contains('lg-carousel-item')).toBe(
+      true,
+    );
+    expect(component.element.nativeElement.attributes['aria-selected'].nodeValue).toBe(
+      'false',
+    );
+    expect(component.element.nativeElement.attributes['role'].nodeValue).toBe(
+      'tab-panel',
+    );
+  });
+
+  it('should update the aria-selected attribute when selected', () => {
+    component.selected = true;
+    fixture.detectChanges();
+    expect(component.element.nativeElement.attributes['aria-selected'].nodeValue).toBe(
+      'true',
+    );
+  });
+});

--- a/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.ts
@@ -1,0 +1,26 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostBinding,
+  ViewEncapsulation,
+} from '@angular/core';
+
+@Component({
+  selector: 'lg-carousel-item',
+  templateUrl: './carousel-item.component.html',
+  styleUrls: ['./carousel-item.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LgCarouselItemComponent {
+  @HostBinding('class.lg-carousel-item') class = true;
+  @HostBinding('attr.role') role = 'tab-panel';
+  @HostBinding('attr.aria-selected') public selected = false;
+
+  constructor(public element: ElementRef) {}
+
+  get itemContent() {
+    return this.element.nativeElement.innerHTML;
+  }
+}

--- a/projects/canopy/src/lib/carousel/carousel.component.html
+++ b/projects/canopy/src/lib/carousel/carousel.component.html
@@ -1,0 +1,59 @@
+<section class="lg-carousel" [attr.aria-labelledby]="description">
+  <lg-heading [level]="headingLevel" class="lg-carousel__heading lg-visually-hidden">{{
+    description
+  }}</lg-heading>
+  <div
+    class="lg-carousel__active-content lg-visually-hidden"
+    aria-atomic="true"
+    aria-live="polite"
+    [innerHTML]="selectedItemContent"
+  ></div>
+  <div
+    class="lg-carousel__wrapper"
+    [style.width.%]="100 * carouselItemCount"
+    [style.left.%]="-100 * selectedItemIndex"
+    [style.transition]="'left ease ' + slideDuration / 1000 + 's'"
+  >
+    <ng-content></ng-content>
+  </div>
+
+  <div class="lg-carousel__navigation" role="tablist">
+    <button
+      role="tab"
+      class="lg-carousel__button"
+      (click)="previousCarouselItem()"
+      [disabled]="!loopMode && selectedItemIndex === 0"
+    >
+      <span class="lg-visually-hidden">Previous {{ description }} item</span>
+      <span class="lg-carousel__button__disk lg-carousel--centered">
+        <lg-icon name="chevron-left"></lg-icon>
+      </span>
+    </button>
+    <button
+      role="tab"
+      class="lg-carousel__button lg-carousel--centered"
+      (click)="selectCarouselItem(i)"
+      *ngFor="let item of carouselItems; let i = index"
+      [tabindex]="'0' ? i === selectedItemIndex : '-1'"
+      [attr.aria-selected]="i === selectedItemIndex"
+    >
+      <span class="lg-visually-hidden">{{ description }} {{ i + 1 }}</span>
+      <span class="lg-visually-hidden" *ngIf="i === selectedItemIndex">(selected)</span>
+      <span
+        class="lg-carousel__bullet"
+        [ngClass]="{ 'lg-carousel__bullet--active': i === selectedItemIndex }"
+      ></span>
+    </button>
+    <button
+      role="tab"
+      class="lg-carousel__button"
+      (click)="nextCarouselItem()"
+      [disabled]="!loopMode && selectedItemIndex === carouselItemCount - 1"
+    >
+      <span class="lg-visually-hidden">Next {{ description }} item</span>
+      <span class="lg-carousel__button__disk lg-carousel--centered">
+        <lg-icon name="chevron-right"></lg-icon>
+      </span>
+    </button>
+  </div>
+</section>

--- a/projects/canopy/src/lib/carousel/carousel.component.scss
+++ b/projects/canopy/src/lib/carousel/carousel.component.scss
@@ -1,0 +1,64 @@
+.lg-carousel {
+  overflow: hidden;
+
+  &__wrapper {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+  }
+
+  &__navigation {
+    padding-top: var(--space-sm);
+    display: flex;
+    justify-content: center;
+  }
+
+  &--centered {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__button {
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    margin: 0;
+    width: var(--space-xxl);
+    height: var(--space-xxl);
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: none;
+    }
+
+    &__disk {
+      width: var(--space-xxl);
+      height: var(--space-xxl);
+      border-radius: 100%;
+    }
+
+    &:hover:not([disabled]) .lg-carousel__button__disk {
+      background-color: var(--carousel-nav-background-color);
+    }
+
+    &[disabled] {
+      cursor: default;
+    }
+  }
+
+  &__bullet {
+    width: var(--space-xxs);
+    height: var(--space-xxs);
+    background-color: var(--carousel-bullet-color);
+    display: block;
+    border-radius: 100%;
+    transition: all var(--animation-fn) var(--animation-duration);
+
+    &--active {
+      width: var(--space-xs);
+      height: var(--space-xs);
+      background-color: var(--carousel-active-bullet-color);
+    }
+  }
+}

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -1,0 +1,65 @@
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
+  ContentChildren,
+  Input,
+  QueryList,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { HeadingLevel } from '../heading';
+import { LgCarouselItemComponent } from './carousel-item/carousel-item.component';
+
+@Component({
+  selector: 'lg-carousel',
+  templateUrl: './carousel.component.html',
+  styleUrls: ['./carousel.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LgCarouselComponent implements AfterContentInit {
+  @Input() description: string;
+  @Input() headingLevel: HeadingLevel;
+  @Input() loopMode = false;
+  @Input() slideDuration = 500;
+
+  @ContentChildren(LgCarouselItemComponent, { read: LgCarouselItemComponent })
+  carouselItems = new QueryList<LgCarouselItemComponent>();
+  selectedItem: LgCarouselItemComponent;
+  carouselItemCount: number;
+  selectedItemIndex: number;
+  selectedItemContent: string;
+
+  selectCarouselItem(index: number): void {
+    this.selectedItemIndex = index;
+    this.selectedItem = this.carouselItems.get(index);
+    this.selectedItemContent = this.selectedItem.itemContent;
+
+    this.carouselItems.forEach((carouselItem: LgCarouselItemComponent) => {
+      carouselItem.selected = false;
+    });
+    this.selectedItem.selected = true;
+  }
+
+  nextCarouselItem(): void {
+    if (this.selectedItemIndex === this.carouselItemCount - 1) {
+      this.selectCarouselItem(0);
+    } else {
+      this.selectCarouselItem(this.selectedItemIndex + 1);
+    }
+  }
+
+  previousCarouselItem(): void {
+    if (this.selectedItemIndex === 0) {
+      this.selectCarouselItem(this.carouselItemCount - 1);
+    } else {
+      this.selectCarouselItem(this.selectedItemIndex - 1);
+    }
+  }
+
+  ngAfterContentInit(): void {
+    this.carouselItemCount = this.carouselItems.length;
+    this.selectCarouselItem(0);
+  }
+}

--- a/projects/canopy/src/lib/carousel/carousel.module.ts
+++ b/projects/canopy/src/lib/carousel/carousel.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LgCarouselComponent } from './carousel.component';
+import { LgCarouselItemComponent } from './carousel-item/carousel-item.component';
+import { LgHeadingModule } from '../heading';
+import {
+  LgIconModule,
+  LgIconRegistry,
+  lgIconChevronLeft,
+  lgIconChevronRight,
+} from '../icon';
+
+const components = [LgCarouselItemComponent, LgCarouselComponent];
+
+@NgModule({
+  declarations: [...components],
+  imports: [CommonModule, LgHeadingModule, LgIconModule],
+  exports: [...components],
+})
+export class LgCarouselModule {
+  constructor(private iconRegistry: LgIconRegistry) {
+    this.iconRegistry.registerIcons([lgIconChevronLeft, lgIconChevronRight]);
+  }
+}

--- a/projects/canopy/src/lib/carousel/carousel.notes.ts
+++ b/projects/canopy/src/lib/carousel/carousel.notes.ts
@@ -1,0 +1,42 @@
+export const notes = `
+# Carousel Component
+
+## Purpose
+
+Carousels allow customers to quickly navigate through grouped sections of content.
+
+## Usage
+~~~js
+@NgModule({
+  ...
+  imports: [ ..., LgCarouselModule ],
+})
+~~~
+
+and in your HTML:
+
+~~~html
+<lg-carousel [description]="description" [headingLevel]="headingLevel" [loopMode]="true">
+  <lg-carousel-item>
+    Carousel item 1 content goes here
+  </lg-carousel-item>
+
+  <lg-carousel-item>
+    Carousel item 2 content goes here
+  </lg-carousel-item>
+
+  <lg-carousel-item>
+    Carousel item 3 content goes here
+  </lg-carousel-item>
+</lg-carousel>
+~~~
+
+## Carousel Inputs
+
+| Name                  | Description                                                                                              |  Type   |  Default  | Required |
+| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |
+| \`\`loopMode\`\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |
+| \`\`slideDuration\`\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |
+| \`\`description\`\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |
+| \`\`headingLevel\`\`  | The heading level of the description: \`\`1\`\`, \`\`2\`\`, \`\`3\`\`, \`\`4\`\`, \`\`5\`\`, \`\`6\`\`   | number  | undefined |   Yes    |
+`;

--- a/projects/canopy/src/lib/carousel/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/carousel.stories.ts
@@ -1,0 +1,77 @@
+import { CommonModule } from '@angular/common';
+
+import { withKnobs, select, text, number } from '@storybook/addon-knobs';
+import { moduleMetadata } from '@storybook/angular';
+
+import { LgButtonModule } from '../button';
+import { LgCarouselModule } from './carousel.module';
+import { notes } from './carousel.notes';
+
+export default {
+  title: 'Components/Carousel',
+  parameters: {
+    decorators: [
+      withKnobs,
+      moduleMetadata({
+        imports: [CommonModule, LgCarouselModule, LgButtonModule],
+      }),
+    ],
+    notes: {
+      markdown: notes,
+    },
+  },
+};
+
+const carouselItems = `
+<lg-carousel-item>
+  <h3>Carousel item 1</h3>
+  <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+  <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+</lg-carousel-item>
+
+<lg-carousel-item>
+  <h3>Carousel item 2</h3>
+  <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+  <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+</lg-carousel-item>
+
+<lg-carousel-item>
+  <h3>Carousel item 3</h3>
+  <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+  <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+</lg-carousel-item>
+
+<lg-carousel-item>
+  <h3>Carousel item 4</h3>
+  <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
+  <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+</lg-carousel-item>
+`;
+
+function props() {
+  const slideDurationOptions = {
+    range: true,
+    min: 0,
+    max: 5000,
+    step: 100,
+  };
+  return {
+    headingLevel: select('Heading Level', [1, 2, 3, 4, 5, 6], 3),
+    description: text('Description', 'Example carousel'),
+    slideDuration: number('Slide Duration', 500, slideDurationOptions),
+  };
+}
+
+export const standard = () => ({
+  template: `<lg-carousel [description]="description" [headingLevel]="headingLevel" [slideDuration]="slideDuration">${carouselItems}</lg-carousel>`,
+  props: props(),
+});
+
+export const loopModeEnabled = () => ({
+  template: `<lg-carousel [description]="description" [headingLevel]="headingLevel" [slideDuration]="slideDuration" [loopMode]="true">${carouselItems}</lg-carousel>`,
+  props: props(),
+});

--- a/projects/canopy/src/lib/carousel/index.ts
+++ b/projects/canopy/src/lib/carousel/index.ts
@@ -1,0 +1,3 @@
+export * from './carousel-item/carousel-item.component';
+export * from './carousel.component';
+export * from './carousel.module';

--- a/projects/canopy/src/public-api.ts
+++ b/projects/canopy/src/public-api.ts
@@ -10,6 +10,7 @@ export * from './lib/alert/index';
 export * from './lib/breadcrumb/index';
 export * from './lib/button/index';
 export * from './lib/card/index';
+export * from './lib/carousel/index';
 export * from './lib/data-point/index';
 export * from './lib/details/index';
 export * from './lib/feature-toggle/index';

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -4,6 +4,7 @@
 @import 'variables/components/breadcrumb';
 @import 'variables/components/button/main';
 @import 'variables/components/card';
+@import 'variables/components/carousel';
 @import 'variables/components/radio';
 @import 'variables/components/data-point';
 @import 'variables/components/details';

--- a/projects/canopy/src/styles/variables/components/_carousel.scss
+++ b/projects/canopy/src/styles/variables/components/_carousel.scss
@@ -1,0 +1,5 @@
+:root {
+  --carousel-bullet-color: var(--color-charcoal);
+  --carousel-active-bullet-color: var(--color-super-blue);
+  --carousel-nav-background-color: var(--color-white-smoke);
+}


### PR DESCRIPTION
# Description

This PR adds a new carousel component which will be used on OSS.  This MVP version currently only supports click / keyboard navigation.  Swipe gesture and autoplay support to be added in future sprints.

View on [Netlify](https://deploy-preview-386--legal-and-general-canopy.netlify.app/?path=/story/components-carousel--standard)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](https://deploy-preview-386--legal-and-general-canopy.netlify.app/?path=/story/components-carousel--standard)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
