### PR TITLE
fix(side-nav): remove global link styling from side nav links

### DIFF
--- a/projects/canopy/src/lib/side-nav/side-nav.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav.component.scss
@@ -13,6 +13,8 @@
 }
 
 .lg-side-nav-bar-link {
+  @include lg-unstyled-link();
+
   text-decoration: none;
   color: var(--side-nav-bar-link-color);
   border-bottom: var(--border-width) solid var(--color-platinum);


### PR DESCRIPTION
# Description

Fixes an issue where global link styling was affecting the side nav links

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
