### PR TITLE
fix(links): remove white text on focus with .lg-unstyled-link

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -74,6 +74,7 @@
   &:active,
   &:focus {
     background-color: transparent;
+    color: inherit;
   }
 
   &:focus {


### PR DESCRIPTION
# Description

The `.lg-unstyled-link` class is used for turning off the global Canopy link styling, but the focus
state was still getting the focus colour of white.

## Requirements

Add the `.lg-unstyled-link` class to a link and apply `:focus`.

Storybook link: (once netlify has deployed link provide a link to the component)

**Before**
![Screenshot 2021-06-04 at 09 20 38](https://user-images.githubusercontent.com/1943532/120771264-f1b42700-c516-11eb-95c8-044d364fd1d1.png)

**After**
![Screenshot 2021-06-04 at 09 23 48](https://user-images.githubusercontent.com/1943532/120771277-f678db00-c516-11eb-990b-3e41a3fcf8d9.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
