### PR TITLE
fix(utils): dont allow override of visually hidden styles

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -98,15 +98,15 @@
 }
 
 @mixin lg-visually-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: auto;
-  margin: 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 0.0625em;
-  white-space: nowrap;
+  border: 0 !important;
+  clip: rect(0 0 0 0) !important;
+  height: auto !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 0.0625em !important;
+  white-space: nowrap !important;
 }
 
 $breakpoints: (


### PR DESCRIPTION
# Description

The visually-hidden styles can be overridden if the element has another class applied to it. For example, an input's label has `width: 100%` which overrides visually hidden's 1px width on mobile, which was breaking my layout. Given the nature of the visually-hidden class, I feel all of its values should be `!important`.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
