### PR TITLE
fix(data-point): incorrect heading styles

### DIFF
--- a/projects/canopy/src/lib/data-point/data-point-label/data-point-label.component.html
+++ b/projects/canopy/src/lib/data-point/data-point-label/data-point-label.component.html
@@ -1,3 +1,3 @@
-<lg-heading [class]="'lg-data-point-label__heading-wrapper'" [level]="headingLevel">
+<lg-heading [level]="headingLevel">
   <ng-content></ng-content>
 </lg-heading>

--- a/projects/canopy/src/lib/data-point/data-point-label/data-point-label.component.scss
+++ b/projects/canopy/src/lib/data-point/data-point-label/data-point-label.component.scss
@@ -1,7 +1,12 @@
 .lg-data-point-label {
   margin-bottom: var(--space-xxxs);
 
-  &__heading-wrapper {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-size: var(--text-base-size);
     font-weight: var(--font-weight-bold);
     line-height: var(--text-fs--6-line-height);


### PR DESCRIPTION
# Description

Fixes issue where data point headings had the incorrect styling.


Storybook link: (once netlify has deployed link provide a link to the component)

Screenshot:

Before:
<img width="783" alt="Screenshot 2021-06-14 at 09 53 18" src="https://user-images.githubusercontent.com/1943532/121866118-8c222080-ccf6-11eb-8a89-e4cba89a8c96.png">


After:
<img width="791" alt="Screenshot 2021-06-14 at 09 54 17" src="https://user-images.githubusercontent.com/1943532/121866096-8593a900-ccf6-11eb-92ad-360320b87c9e.png">



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
