### PR TITLE
fix(sort-code): update logic to return requiredField

### DIFF
--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.spec.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.spec.ts
@@ -270,30 +270,16 @@ describe('SortCodeComponent', () => {
       });
     });
 
-    it('adds a required field validation rule if first input field is empty', () => {
+    it('adds a required field validation rule if all the input fields are empty', () => {
       sortCodeFieldInstance.first.markAsDirty();
-      sortCodeFieldInstance.first.setValue('');
-      fixture.detectChanges();
-      expect(fixture.componentInstance.form.controls.sortCode.errors).toEqual({
-        invalidField: true,
-      });
-    });
-
-    it('adds an invalid field validation rule if the second input field is empty', () => {
       sortCodeFieldInstance.second.markAsDirty();
-      sortCodeFieldInstance.second.setValue('');
-      fixture.detectChanges();
-      expect(fixture.componentInstance.form.controls.sortCode.errors).toEqual({
-        invalidField: true,
-      });
-    });
-
-    it('adds an invalid field validation rule if the third input field is empty', () => {
       sortCodeFieldInstance.third.markAsDirty();
+      sortCodeFieldInstance.first.setValue('');
+      sortCodeFieldInstance.second.setValue('');
       sortCodeFieldInstance.third.setValue('');
       fixture.detectChanges();
       expect(fixture.componentInstance.form.controls.sortCode.errors).toEqual({
-        invalidField: true,
+        requiredField: true,
       });
     });
   });

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
@@ -158,18 +158,30 @@ export class LgSortCodeComponent implements OnInit, ControlValueAccessor {
   }
 
   validate(): ValidationErrors {
-    const errors: ValidationErrors = {};
+    const invalidFields: Array<string> = [];
     Object.keys(this.sortCodeFormGroup.controls).forEach((fieldName) => {
       if (
         this.sortCodeFormGroup.controls[fieldName].invalid &&
         (this.sortCodeFormGroup.controls[fieldName].dirty ||
           (this.formGroupDirective && this.formGroupDirective.submitted))
       ) {
-        errors.invalidField = true;
+        invalidFields.push(fieldName);
       }
     });
-    if (Object.keys(errors).length) {
-      return errors;
+
+    const requiredFields = invalidFields.filter((fieldName) =>
+      this.sortCodeFormGroup.controls[fieldName].hasError('required'),
+    );
+
+    const error: ValidationErrors = {};
+    if (requiredFields.length === 3) {
+      error.requiredField = true;
+    } else if (invalidFields.length) {
+      error.invalidField = true;
+    }
+
+    if (Object.keys(error).length) {
+      return error;
     }
     return null;
   }

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
@@ -44,4 +44,6 @@ and in your HTML:
 
 All three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.
 
+The form will return \`requiredField\` when all of the inputs are left empty and \`invalidField\` when any of the inputs are invalid.
+
 `;

--- a/projects/canopy/src/lib/forms/validation/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/form.stories.ts
@@ -193,7 +193,12 @@ function invalidValidator(): ValidatorFn {
         Sort Code
         <lg-hint>Must be 6 digits long</lg-hint>
         <lg-validation *ngIf="isControlInvalid(sortCode, validationForm)">
-          Your sort code should be a 6 digit number
+          <ng-container *ngIf="sortCode.hasError('requiredField')">
+            Enter a sort code
+          </ng-container>
+          <ng-container *ngIf="sortCode.hasError('invalidField')">
+            Enter a valid sort code
+          </ng-container>
         </lg-validation>
       </lg-sort-code>
 


### PR DESCRIPTION
# Description

This PR fixes an issue where the sort code form field was not returning any specific error if any of the inputs where triggering the `required` error. Now the error returned is `requiredField` so that validation can be customised a bit more. 

## Requirements

Being able to return a different error message when the field is required.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
