### PR TITLE
fix(typography): enable lyon font path setting

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -117,7 +117,7 @@ Canopy consists of two fonts; Roboto and Lyon. Roboto is included in the distrib
 
 Due to commercial licensing agreements the Lyon font is not included in the distributed package. You will need to manually add it to the **assets** directory of your application. Canopy does provide the css to work with the font and no additional code should be required. You will  need to ensure the font is in the directory specified by Canopy.
 
-Canopy's path for Lyon is **/assets/fonts/lyon/**, therefore you need to put the font files in the following location:
+Canopy's default path for Lyon is **/assets/fonts/lyon/**, therefore you need to put the font files in the following location:
 
 ```bash
 my-app/
@@ -134,6 +134,15 @@ my-app/
 > This will result in the font being served in your app like this: <br>http://my-app.landg.com/assets/fonts/lyon/LyonDisplay-Regular-Web.woff2
 
 When you include the canopy.css file in your project, it will try to load the font from that exact path. If your font files are in the wrong location, or have a typo in the filename, the Lyon font won't load correctly.
+
+If required, it is possible to set another path for Lyon by adding the following in your project's scss entry file:
+
+projects/canopy-test-app/src/styles.scss:
+
+```scss
+$fonts-path-lyon: 'path/to/lyon/fonts';
+@import 'dist/canopy/styles/styles';
+```
 
 Please ensure you have the correct licensing agreement in place before using the Lyon font in your application.
 

--- a/projects/canopy/src/styles/typography.scss
+++ b/projects/canopy/src/styles/typography.scss
@@ -1,6 +1,6 @@
 @import '../styles/mixins.scss';
 $fonts-path: '../assets/fonts' !default;
-$fonts-path-lyon: '/assets/fonts';
+$fonts-path-lyon: '/assets/fonts' !default;
 
 /*
   Lyon - font path is not transformed by the build, see USAGE.md for details


### PR DESCRIPTION
409

# Description

The current settings in typography.scss assume a directory structure that some projects do not have (i.e. /assets/fonts). This causes webpack builds to fail as it is difficult/impossible to store the Lyon fonts in a location that can be found.

Fixes #409