### PR TITLE
fix(button-group): remove margin bottom

### DIFF
--- a/projects/canopy/src/lib/button/button-group/button-group.component.scss
+++ b/projects/canopy/src/lib/button/button-group/button-group.component.scss
@@ -2,7 +2,6 @@
 
 .lg-btn-group {
   display: block;
-  margin-bottom: var(--component-margin);
 
   .lg-btn {
     margin-bottom: 0;


### PR DESCRIPTION
# Description

The margin button shouldn't be necessary as the buttons are usually always at the bottom of a page.

Before:
![Screenshot 2021-06-22 at 16 02 05](https://user-images.githubusercontent.com/8397116/122948984-36dbb400-d373-11eb-848d-47630a9c85a8.png)

After:
![Screenshot 2021-06-22 at 16 01 58](https://user-images.githubusercontent.com/8397116/122949155-58d53680-d373-11eb-9d27-7d0f4b2b7f28.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
