### PR TITLE
Fix details heading and link style

### DIFF
--- a/projects/canopy/src/lib/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/card.stories.ts
@@ -158,7 +158,7 @@ export const standard = () => ({
         </lg-card-title>
       </lg-card-header>
       <lg-card-content>
-        {{cardContent}}
+        {{cardContent}} <a href="#">Test link</a>.
       </lg-card-content>
     </lg-card>
   `,

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
@@ -1,9 +1,17 @@
 @import '../../../styles/mixins';
 
 .lg-details-panel-heading {
-  font-size: var(--text-base-size);
-  font-weight: var(--font-weight-bold);
-  margin-bottom: 0;
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: var(--text-base-size);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--text-base-line-height);
+    margin-bottom: 0;
+  }
 
   &__toggle {
     background: transparent;

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -29,7 +29,8 @@
   border-bottom: 0.125rem solid $default-color;
   padding: 0 0.125rem;
 
-  &:hover {
+  &:hover,
+  &:hover:visited {
     color: $hover-color;
     border-bottom: 0;
     box-shadow: inset 0 $box-shadow-inset-width 0 0 $hover-color,


### PR DESCRIPTION
# Description

- Update details heading incorrect font size, caused by removal of the input class on `lg-heading`
- Update style of `:visited:hover` link

Storybook link: (once netlify has deployed link provide a link to the component)

**Details Screenshot**
Before
![Screenshot 2021-06-24 at 12 04 48](https://user-images.githubusercontent.com/7091410/123253463-67435f80-d4e5-11eb-804b-ecc914a7ec9c.png)

After
![image (4)](https://user-images.githubusercontent.com/7091410/123253407-5b579d80-d4e5-11eb-8b0c-00ef904c7809.png)

**Link screenshot**
Before
![Screenshot 2021-06-24 at 12 03 18](https://user-images.githubusercontent.com/7091410/123253526-7b875c80-d4e5-11eb-923a-8db95cbeec05.png)

After
![image (6)](https://user-images.githubusercontent.com/7091410/123253536-7f1ae380-d4e5-11eb-8977-54dae3bde32b.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
