### PR TITLE
feat(table): add stackedOnMobile option and long copy version of table

### DIFF
--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.html
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.html
@@ -9,9 +9,10 @@
 </span>
 <div
   #content
+  class="lg-table-cell__content"
   [ngClass]="{
     'lg-table-cell__content--align-end': align === alignOptions.End,
-    'lg-table-cell__content': showLabel
+    'lg-table-cell__content--hidden-label': !showLabel
   }"
 >
   <ng-content></ng-content>

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -5,6 +5,26 @@
   display: flex;
   align-items: center;
 
+  &--stacked {
+    flex-direction: column;
+    align-items: stretch;
+
+    .lg-table-cell__label {
+      margin-bottom: var(--space-xxs);
+    }
+
+    .lg-table-cell__content {
+      margin-left: 0;
+      margin-bottom: var(--space-md);
+    }
+
+    &:last-child {
+      .lg-table-cell__content {
+        margin-bottom: 0;
+      }
+    }
+  }
+
   &--toggle-cell {
     order: 1;
     padding: 0;
@@ -21,7 +41,10 @@
 
 .lg-table-cell__content {
   margin-left: auto;
-  white-space: nowrap;
+}
+
+.lg-table-cell__content--hidden-label {
+  margin-left: 0;
 }
 
 .lg-table-cell--expandable-content {
@@ -56,6 +79,7 @@
 
       &__content {
         @include lg-breakpoint($columns-breakpoint) {
+          margin-bottom: 0;
           text-align: left;
         }
 

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.spec.ts
@@ -75,6 +75,32 @@ describe('LgTableCellComponent', () => {
     });
   });
 
+  describe('when stack is set to true', () => {
+    beforeEach(() => {
+      component.stack = true;
+      fixture.detectChanges();
+    });
+
+    it('should set the lg-table-cell--stacked class', () => {
+      expect(fixture.nativeElement.getAttribute('class')).toContain(
+        'lg-table-cell--stacked',
+      );
+    });
+  });
+
+  describe('when stack is set to false', () => {
+    beforeEach(() => {
+      component.stack = false;
+      fixture.detectChanges();
+    });
+
+    it('should not set the lg-table-cell--stacked class', () => {
+      expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-cell--stacked',
+      );
+    });
+  });
+
   describe('when showLabel is set to true', () => {
     beforeEach(() => {
       component.showLabel = true;
@@ -107,9 +133,11 @@ describe('LgTableCellComponent', () => {
       );
     });
 
-    it('should not set the content class', () => {
-      const contentElement = debugElement.query(By.css('.lg-table-cell__content'));
-      expect(contentElement).toBe(null);
+    it('should set the hidden class on the content', () => {
+      const contentElement = debugElement.query(
+        By.css('.lg-table-cell__content--hidden-label'),
+      );
+      expect(contentElement).toBeDefined();
     });
   });
 

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.ts
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.ts
@@ -101,6 +101,10 @@ export class LgTableCellComponent {
     return this._showLabel;
   }
 
+  @HostBinding('class.lg-table-cell--stacked')
+  @Input()
+  stack = false;
+
   private _align: AlignmentOptions = AlignmentOptions.Start;
 
   private _showLabel = true;

--- a/projects/canopy/src/lib/table/table.notes.ts
+++ b/projects/canopy/src/lib/table/table.notes.ts
@@ -1,10 +1,10 @@
-// Document the lower components
-
 export const notes = `
 # Table Component
 
 ## Purpose
-The table component provides a way to present tabular data in a responsive format.
+The table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.
+
+There are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.
 
 ## Usage
 ~~~js
@@ -14,7 +14,35 @@ The table component provides a way to present tabular data in a responsive forma
 })
 ~~~
 
-and in your HTML:
+### Simple example
+
+~~~html
+<table lg-table>
+  <thead lg-table-head>
+    <tr lg-table-row>
+      <th lg-table-head-cell>Author</th>
+      <th lg-table-head-cell>Book</th>
+      <th lg-table-head-cell>Published</th>
+    </tr>
+  </thead>
+  <tbody lg-table-body>
+    <tr lg-table-row>
+      <td lg-table-cell>Orhan Pamuk</td>
+      <td lg-table-cell>Strangeness in my Mind</td>
+      <td lg-table-cell>2016</td>
+    </tr>
+    <tr lg-table-row>
+      <td lg-table-cell>Albert Camus</td>
+      <td lg-table-cell>The Plague</td>
+      <td lg-table-cell>1947</td>
+    </tr>
+  </tbody>
+</table>
+~~~
+
+### Table with expandable detail rows
+
+This table adds the \`\`LgTableRowToggleComponent\`\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href="/story/components-table--detail">Expandable Detail story</a>.
 
 ~~~html
 <table lg-table>
@@ -46,28 +74,47 @@ and in your HTML:
         </lg-table-expanded-detail>
       </td>
     </tr>
+  </tbody>
+</table>
+~~~
+
+### Table with long copy
+
+Sometimes a table can be used to display large amounts of copy, including buttons, links and headings.
+
+Note that each \`\`LgTableCellComponent\`\` has the \`\`stack\`\` Input set to \`\`true\`\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \`\`<colgroup>\`\` to control width of the columns on large screens. This can be seen on the <a href="/story/components-table--with-long-copy">Table With Long Copy story</a>.
+
+Also note the use of the \`\`LgMarginDirective\`\`, such as \`\`lgMarginBottom="xs"\`\`, to add extra space around content, making it more readable.
+
+~~~html
+<table lg-table>
+  <colgroup>
+    <col span="1" style="width: 65%;" />
+    <col span="1" style="width: 35%;" />
+  </colgroup>
+  <thead lg-table-head>
     <tr lg-table-row>
-      <td>
-        <lg-table-row-toggle
-        (click)="<function-to-handle-click>"
-        [isActive]="<logic-to-handle-toggle>"
-        >
-        </lg-table-row-toggle>
-      </td>
-      <td lg-table-cell>Albert Camus</td>
-      <td lg-table-cell>The Plague</td>
-      <td lg-table-cell>1947</td>
+      <th lg-table-head-cell>Item</th>
+      <th lg-table-head-cell>More information</th>
     </tr>
-    <tr lg-table-row [isHidden]="<logic-to-handle-row>">
-      <td lg-table-cell>
-        <lg-table-expanded-detail>
-          Detail content goes here
-        </lg-table-expanded-detail>
+  </thead>
+
+  <tbody lg-table-body>
+    <tr lg-table-row>
+      <td lg-table-cell [stack]="true">
+        <h3 lgMarginVertical="xs">Item one: Lorem ipsum dolor sit amet</h3>
+        <p lgMarginBottom="xs">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>
+      </td>
+      <td lg-table-cell [showLabel]="false" [stack]="true">
+        <p>Sed ut perspiciatis</p>
+        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <button lg-quick-action><lg-icon name="information-fill"></lg-icon>Find out more</button>
       </td>
     </tr>
   </tbody>
 </table>
 ~~~
+
 
 ## Inputs
 
@@ -88,6 +135,7 @@ A component that acts as a standard table cell.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| \`\`stack\`\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |
 | \`\`colspan\`\` | Sets the colspan attribute on the column when specified | number | undefined | No |
 
 ### LgTableExpandedDetailComponent
@@ -117,53 +165,4 @@ A component that creates a icon for toggling the expanded state.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`isActive\`\` | Determines if the toggle displays in the active state | boolean | false | No |
-
-## Using only the SCSS files
-
-Generate the markup as show in the example below.
-
-| Class | Description |
-|-------|-------------|
-| \`\`lg-table\`\` | Adds styles to the table styling |
-| \`\`lg-table-head'\`\` | Adds styles to the thead |
-| \`\`lg-table-row\`\` | Adds styles to the table row |
-| \`\`lg-table-row--active\`\` | Adds styles to the table row in the active state |
-| \`\`lg-table-head-cell'\`\` | Adds styles to the table header cell |
-| \`\`lg-table-body\`\` | Adds styles to the tbody |
-| \`\`lg-table-cell\`\` | Adds styles to the table cell |
-| \`\`lg-table-cell__content\`\` | Adds styles to the table cell content |
-| \`\`lg-table-cell__label\`\` | Adds styles to the table cell label for smaller screens |
-| \`\`lg-table-expanded-detail\`\` | Adds styles to the expandable detail section |
-| \`\`lg-table-row-toggle\`\` | Adds styles to the expandable detail section |
-| \`\`lg-table-row-toggle__btn\`\` | Adds styles to the expandable detail button |
-| \`\`lg-table-row-toggle__label\`\` | Adds styles to the expandable detail button label |
-| \`\`lg-table-row-toggle__heading-icon\`\` | Adds styles to the expandable detail button icon |
-
-
-### Examples:
-
-~~~html
-<table class="lg-table">
-  <thead class="lg-table-head">
-    <tr class="lg-table-row">
-      <th class="lg-table-head-cell">Author</th>
-      <th class="lg-table-head-cell">Book</th>
-      <th class="lg-table-head-cell">Published</th>
-    </tr>
-  </thead>
-
-  <tbody class="lg-table-body">
-    <tr class="lg-table-row">
-      <td class="lg-table-cell">Orhan Pamuk</td>
-      <td class="lg-table-cell">Strangeness in my Mind</td>
-      <td class="lg-table-cell">2016</td>
-    </tr>
-    <tr class="lg-table-row">
-      <td class="lg-table-cell">Albert Camus</td>
-      <td class="lg-table-cell">The Plague</td>
-      <td class="lg-table-cell">1947</td>
-    </tr>
-  </tbody>
-</table>
-~~~
 `;

--- a/projects/canopy/src/lib/table/table.stories.ts
+++ b/projects/canopy/src/lib/table/table.stories.ts
@@ -13,6 +13,14 @@ import { LgMarginModule } from '../spacing';
 import { LgSuffixModule } from '../suffix';
 import { LgTableModule } from './table.module';
 import { notes } from './table.notes';
+import { LgGridModule } from '../grid';
+import { LgQuickActionModule } from '../quick-action';
+import {
+  lgIconChevronRightCircle,
+  lgIconInformationFill,
+  LgIconModule,
+  LgIconRegistry,
+} from '../icon';
 
 interface TableStoryItem {
   author: string;
@@ -124,6 +132,7 @@ export class StoryTableDetailComponent {
   @Input() showAuthorLabel: boolean;
   @Input() columnBreakpoint: TableColumnLayoutBreakpoints;
   @Input() expandedRows: Array<number> = [];
+  @Input() stack: boolean;
 
   get colspan() {
     return Object.keys(this.books[0]).length + 1;
@@ -146,6 +155,111 @@ export class StoryTableDetailComponent {
   }
 }
 
+@Component({
+  selector: 'story-table-long-copy',
+  template: `
+    <div lgContainer>
+      <div lgRow>
+        <div lgCol="12">
+          <table lg-table [variant]="variant">
+            <colgroup>
+              <col span="1" style="width: 65%;" />
+              <col span="1" style="width: 35%;" />
+            </colgroup>
+            <thead lg-table-head>
+              <tr lg-table-row>
+                <th lg-table-head-cell [showLabel]="false">Item</th>
+                <th lg-table-head-cell>More information</th>
+              </tr>
+            </thead>
+
+            <tbody lg-table-body>
+              <tr lg-table-row>
+                <td lg-table-cell [stack]="stack">
+                  <h1 class="lg-font-size-1--strong" lgMarginVertical="xs">
+                    Item one: Lorem ipsum dolor sit amet
+                  </h1>
+                  <p lgMarginBottom="xs">
+                    consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                    <a href="#">labore et dolore magna</a> aliqua. Ut enim ad minim
+                    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+                    ea commodo consequat. Duis aute irure dolor in reprehenderit in
+                    voluptate velit esse cillum dolore eu. Excepteur sint occaecat
+                    cupidatat non proident.
+                  </p>
+                </td>
+                <td lg-table-cell [showLabel]="false" [stack]="stack">
+                  <p>Sed ut perspiciatis</p>
+                  <p>
+                    emo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
+                    fugit, sed quia consequuntur.
+                  </p>
+                  <button lg-quick-action>
+                    <lg-icon name="information-fill"></lg-icon>
+                    More information
+                  </button>
+                </td>
+              </tr>
+              <tr lg-table-row>
+                <td lg-table-cell [stack]="stack">
+                  <h1 class="lg-font-size-1--strong" lgMarginVertical="xs">
+                    Item two: At vero eos et accusamus
+                  </h1>
+                  <p>
+                    Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil.
+                  </p>
+                  <p lgMarginBottom="xs">
+                    Temporibus autem quibusdam et aut officiis debitis aut rerum
+                    necessitatibus saepe eveniet ut et voluptates repudiandae sint et
+                    molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente
+                    delectus, ut aut reiciendis voluptatibus maiores alias consequatur.
+                  </p>
+                </td>
+                <td lg-table-cell [stack]="stack">
+                  <p>
+                    Et harum quidem rerum facilis est et expedita distinctio. Nam libero
+                    tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo
+                    minus id quod.
+                  </p>
+                  <button lg-quick-action>
+                    <lg-icon name="chevron-right-circle"></lg-icon>
+                    Contact us
+                  </button>
+                </td>
+              </tr>
+              <tr lg-table-row>
+                <td lg-table-cell [stack]="stack">
+                  <h1 class="lg-font-size-1--strong" lgMarginVertical="xs">
+                    Item three: Ut enim ad minima veniam
+                  </h1>
+                  <p>Proportionate final payment: Applies</p>
+                  <p lgMarginBottom="xs">
+                    Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse
+                    quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo
+                    voluptas nulla pariatur. Tempora incidunt ut labore et dolore magnam
+                    aliquam quaerat voluptatem.
+                  </p>
+                </td>
+                <td lg-table-cell [stack]="stack">
+                  Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis
+                  voluptatibus maiores.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  `,
+})
+class StoryTableLongCopyComponent {
+  @Input() variant: TableVariant;
+  @Input() stack: boolean;
+  constructor(private registry: LgIconRegistry) {
+    this.registry.registerIcons([lgIconChevronRightCircle, lgIconInformationFill]);
+  }
+}
+
 export default {
   title: 'Components/Table',
   excludeStories: ['StoryTableDetailComponent'],
@@ -153,8 +267,16 @@ export default {
     decorators: [
       withKnobs,
       moduleMetadata({
-        imports: [LgTableModule, LgInputModule, LgSuffixModule, LgMarginModule],
-        declarations: [StoryTableDetailComponent],
+        imports: [
+          LgTableModule,
+          LgInputModule,
+          LgSuffixModule,
+          LgMarginModule,
+          LgGridModule,
+          LgQuickActionModule,
+          LgIconModule,
+        ],
+        declarations: [StoryTableDetailComponent, StoryTableLongCopyComponent],
       }),
     ],
     notes: {
@@ -176,9 +298,9 @@ export const standard = () => ({
 
       <tbody lg-table-body>
         <tr lg-table-row *ngFor="let book of books">
-          <td lg-table-cell>{{ book.author }}</td>
-          <td lg-table-cell>{{ book.title }}</td>
-          <td lg-table-cell>{{ book.published }}</td>
+          <td lg-table-cell [stack]="stack">{{ book.author }}</td>
+          <td lg-table-cell [stack]="stack">{{ book.title }}</td>
+          <td lg-table-cell [stack]="stack">{{ book.published }}</td>
         </tr>
       </tbody>
     </table>
@@ -210,14 +332,19 @@ export const standard = () => ({
       'Responsive options',
     ),
     showAuthorLabel: boolean(
-      'Display author label in non-columns view',
+      'Display author label in non-columns view (showLabel)',
+      false,
+      'Responsive options',
+    ),
+    stack: boolean(
+      'Stack label and content in non-columns view (stack)',
       false,
       'Responsive options',
     ),
   },
 });
 
-export const detail = () => ({
+export const expandableDetail = () => ({
   template: `<story-table-detail [books]="books" [variant]="variant" [alignPublishColumn]="alignPublishColumn" [showAuthorLabel]="showAuthorLabel" [columnBreakpoint]="columnBreakpoint"></story-table-detail>`,
 
   props: {
@@ -274,5 +401,22 @@ export const withInput = () => ({
   props: {
     books: object('Books', getDefaultTableContent(), 'Table data'),
     variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),
+  },
+});
+
+export const withLongCopy = () => ({
+  template: `
+    <story-table-long-copy
+      [variant]="variant"
+      [stack]="stack">
+    </story-table-long-copy>
+  `,
+  props: {
+    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),
+    stack: boolean(
+      'Stack label and content in non-columns view',
+      true,
+      'Responsive options',
+    ),
   },
 });

--- a/projects/canopy/src/lib/table/table/table.component.scss
+++ b/projects/canopy/src/lib/table/table/table.component.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   margin-bottom: var(--component-margin);
   border-spacing: 0;
+  border-top: solid var(--table-header-border-width) var(--table-header-border-color);
 
   &--striped:not(&--expandable) tr:nth-child(even) {
     background-color: var(--table-stripe-color);
@@ -41,6 +42,7 @@
 @each $columns-breakpoint in $columns-breakpoints {
   .lg-table--columns-#{$columns-breakpoint} {
     @include lg-breakpoint($columns-breakpoint) {
+      border-top: 0;
       display: table;
       table-layout: auto;
       width: 100%;

--- a/projects/canopy/src/lib/table/table/table.component.spec.ts
+++ b/projects/canopy/src/lib/table/table/table.component.spec.ts
@@ -202,12 +202,14 @@ describe('TableComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should add the lg-table-cell__content class to the table cell', () => {
+      it('should not add the lg-table-cell__content--hidden-label class to the table cell', () => {
         const [titleCell] = tableDebugElement.queryAll(
           By.directive(LgTableCellComponent),
         );
 
-        expect(titleCell.query(By.css('.lg-table-cell__content'))).toBeDefined();
+        expect(titleCell.query(By.css('.lg-table-cell__content--hidden-label'))).toBe(
+          null,
+        );
       });
 
       it('should not add the lg-visually-hidden class to the label', () => {
@@ -233,12 +235,14 @@ describe('TableComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should not add the lg-table-cell__content class to the table cell', () => {
+      it('should add the lg-table-cell__content--hidden-label class to the table cell', () => {
         const [titleCell] = tableDebugElement.queryAll(
           By.directive(LgTableCellComponent),
         );
 
-        expect(titleCell.query(By.css('.lg-table-cell__content'))).toBe(null);
+        expect(
+          titleCell.query(By.css('.lg-table-cell__content--hidden-label')),
+        ).toBeDefined();
       });
 
       it('should add the lg-visually-hidden class to the label', () => {


### PR DESCRIPTION
# Description

Adds new option to `lg-table-cell` called `stackSm`. If set, this option will stack the labels on top of the cell content, instead of side by side. E.g. 

```
<td lg-table-cell [stackSm]="true">
```

Also introduces a border to the top of the table.

A new story component is added to render a table with a large amount of copy in each cell, to catch these designs: https://legalandgeneral.invisionapp.com/console/share/JKZ6TDGSC4G/597020691/inspect

~Note this is still draft, will need to update notes and unit tests once the general approach is approved.~

Ready for full review 🙂 

## Screenshots

### stackedOnMobile set to false (default)
<img width="379" alt="Screenshot 2021-06-28 at 08 29 04" src="https://user-images.githubusercontent.com/1943532/123597238-fd7bcc00-d7ea-11eb-9e34-cc6d004fdd65.png">

### stackedOnMobile set to true
<img width="379" alt="Screenshot 2021-06-28 at 08 29 19" src="https://user-images.githubusercontent.com/1943532/123597258-02d91680-d7eb-11eb-8ee8-44aea8209788.png">

----

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: https://legalandgeneral.invisionapp.com/console/share/JKZ6TDGSC4G/597020691/inspect

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
