### PR TITLE
feat(grid): add breakpoint-specific alignment and order classes

### DIFF
--- a/projects/canopy/src/styles/grid.scss
+++ b/projects/canopy/src/styles/grid.scss
@@ -49,6 +49,53 @@ $columns: 12;
   max-width: 100%;
 }
 
+@mixin lg-grid-alignment($breakpoint) {
+  // Alignment and distribution
+
+  .lg-start-#{$breakpoint} {
+    justify-content: flex-start;
+    text-align: start;
+  }
+
+  .lg-center-#{$breakpoint} {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .lg-end-#{$breakpoint} {
+    justify-content: flex-end;
+    text-align: end;
+  }
+
+  .lg-top-#{$breakpoint} {
+    align-items: flex-start;
+  }
+
+  .lg-middle-#{$breakpoint} {
+    align-items: center;
+  }
+
+  .lg-bottom-#{$breakpoint} {
+    align-items: flex-end;
+  }
+
+  .lg-around-#{$breakpoint} {
+    justify-content: space-around;
+  }
+
+  .lg-between-#{$breakpoint} {
+    justify-content: space-between;
+  }
+
+  .lg-first-#{$breakpoint} {
+    order: -1;
+  }
+
+  .lg-last-#{$breakpoint} {
+    order: 1;
+  }
+}
+
 .lg-col-xs {
   @include col-style;
 
@@ -80,6 +127,8 @@ $columns: 12;
     margin-left: $width;
   }
 }
+
+@include lg-grid-alignment('xs');
 
 @include lg-breakpoint('sm') {
   .lg-col-sm {
@@ -113,6 +162,8 @@ $columns: 12;
       margin-left: $width;
     }
   }
+
+  @include lg-grid-alignment('sm');
 }
 
 @include lg-breakpoint('md') {
@@ -147,6 +198,8 @@ $columns: 12;
       margin-left: $width;
     }
   }
+
+  @include lg-grid-alignment('md');
 }
 
 @include lg-breakpoint('lg') {
@@ -181,4 +234,6 @@ $columns: 12;
       margin-left: $width;
     }
   }
+
+  @include lg-grid-alignment('lg');
 }

--- a/projects/canopy/src/styles/grid.stories.ts
+++ b/projects/canopy/src/styles/grid.stories.ts
@@ -15,8 +15,8 @@ export const grid = () => ({
       <div class="lg-container">
         <div class="lg-row">
           <div class="lg-col-xs-12">
-            <h2>Responsive</h2>
-            <p>Responsive modifiers enable specifying different column sizes, offsets, alignment and distribution at xs, sm, md & lg viewport widths.</p>
+            <h2>Responsive sizing and offsets</h2>
+            <p>Responsive modifiers enable specifying different column sizes and offsets at xs, sm, md & lg viewport widths.</p>
           </div>
         </div>
         <div class="lg-row">
@@ -46,6 +46,24 @@ export const grid = () => ({
           </div>
           <div class="lg-col-xs-2 lg-col-sm-6 lg-col-md-4 lg-col-lg-2">
             <div class="box"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="lg-container">
+        <div class="lg-row">
+          <div class="lg-col-xs-12">
+            <h2>Responsive alignment and distribution</h2>
+            <p>Responsive modifiers enable specifying different alignment and distribution at xs, sm, md & lg viewport widths.</p>
+            <p>Here the sidebar is displayed first below the md viewport size, and second beyond that.</p>
+          </div>
+        </div>
+        <div class="lg-row">
+          <div class="lg-col-xs-9 lg-last-xs lg-first-md">
+            <div class="box">Main content</div>
+          </div>
+          <div class="lg-col-xs-3 lg-first-xs lg-last-md">
+            <div class="box">Sidebar</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Description

Ports over various grid classes from the original http://flexboxgrid.com/ styles. Allows ordering and alignment at different viewport sizes.

## Requirements

Storybook link: (once netlify has deployed link provide a link to the component)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided a story in storybook to document the changes
