### PR TITLE
fix(links): update line height for the links

### DIFF
--- a/projects/canopy/src/styles/links.notes.ts
+++ b/projects/canopy/src/styles/links.notes.ts
@@ -1,0 +1,7 @@
+export const notes = `
+# Links
+
+The links styles are applied automatically when adding the global Canopy css.
+
+For custom components it's possible to override the style of a link by using the \`lg-unstyled-link\`.
+`;

--- a/projects/canopy/src/styles/links.stories.ts
+++ b/projects/canopy/src/styles/links.stories.ts
@@ -1,0 +1,33 @@
+import { withKnobs } from '@storybook/addon-knobs';
+import { moduleMetadata } from '@storybook/angular';
+
+import { notes } from './links.notes';
+import { LgAlertModule } from '../lib/alert';
+import { LgMarginModule } from '../lib/spacing';
+
+export default {
+  title: 'Links',
+  parameters: {
+    decorators: [
+      withKnobs,
+      moduleMetadata({
+        imports: [LgAlertModule, LgMarginModule],
+      }),
+    ],
+    notes: {
+      markdown: notes,
+    },
+  },
+};
+
+export const links = () => ({
+  template: `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit <a href="#">Inline link example</a> and <a href="#" style="display: inline-block">inline block link example</a>
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+    <lg-alert variant="generic" lgMarginTop="lg">Example of <a href="#">link text</a> within an alert.</lg-alert>
+    <lg-alert variant="info">Example of <a href="#">link text</a> within an alert.</lg-alert>
+    <lg-alert variant="success">Example of <a href="#">link text</a> within an alert.</lg-alert>
+    <lg-alert variant="error">Example of <a href="#">link text</a> within an alert.</lg-alert>
+`,
+});

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -24,10 +24,11 @@
 ) {
   $box-shadow-inset-width: -0.063rem;
 
-  color: $default-color;
-  text-decoration: none;
   border-bottom: 0.125rem solid $default-color;
+  color: $default-color;
+  line-height: initial;
   padding: 0 0.125rem;
+  text-decoration: none;
 
   &:hover,
   &:hover:visited {


### PR DESCRIPTION
# Description

Fix an issue where the inline block links had different line height than the inline ones.
Also the inline block links on hover were causing the below content to shift.

Behaviour before:

https://user-images.githubusercontent.com/8397116/124100493-6e72ec00-da56-11eb-9f1a-cbdb6278f703.mov



Behaviour after:

https://user-images.githubusercontent.com/8397116/124100090-0fad7280-da56-11eb-9638-3598df791685.mov

Storybook link: https://deploy-preview-442--legal-and-general-canopy.netlify.app/?path=/story/links--utils

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
