### PR TITLE
fix(side-nav): override side nav visited link styles

### DIFF
--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item-content/side-nav-bar-item-content.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item-content/side-nav-bar-item-content.component.scss
@@ -1,5 +1,5 @@
 .lg-side-nav-bar-item-content {
-  padding-top: var(--space-xxxs);
-  padding-right: var(--space-xxxs);
+  padding-top: var(--space-xxs);
   font-size: var(--text-fs--8-size);
+  line-height: var(--text-base-line-height);
 }

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.scss
@@ -8,6 +8,10 @@
 .lg-side-nav-bar-item__container {
   display: flex;
   flex-direction: column;
+
+  @include lg-breakpoint('md') {
+    padding-right: var(--space-sm);
+  }
 }
 
 .lg-side-nav-bar-item__icon-container {

--- a/projects/canopy/src/lib/side-nav/side-nav.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav.component.scss
@@ -17,7 +17,7 @@
 
   text-decoration: none;
   color: var(--side-nav-bar-link-color);
-  border-bottom: var(--border-width) solid var(--color-platinum);
+  border-bottom: var(--border-width) solid var(--side-nav-bar-link-border-color);
   display: block;
   padding: var(--space-sm);
   width: 100%;
@@ -32,6 +32,7 @@
 
   &:visited {
     color: var(--side-nav-bar-link-color);
+    border-bottom: var(--border-width) solid var(--side-nav-bar-link-border-color);
     text-decoration: none;
   }
 
@@ -51,5 +52,17 @@
 
   &:hover {
     padding-bottom: calc(var(--space-xs) - var(--border-width));
+  }
+
+  &:visited {
+    color: var(--side-nav-bar-link-active-color);
+    border-bottom: var(--side-nav-bar-link-border-width-md) solid
+      var(--side-nav-bar-link-active-color);
+  }
+
+  &:visited:hover {
+    color: var(--side-nav-bar-link-hover-color);
+    border-bottom: var(--side-nav-bar-link-border-width-lg) solid
+      var(--side-nav-bar-link-hover-color);
   }
 }

--- a/projects/canopy/src/styles/variables/components/_side-nav.scss
+++ b/projects/canopy/src/styles/variables/components/_side-nav.scss
@@ -4,4 +4,5 @@
   --side-nav-bar-link-color: var(--color-charcoal);
   --side-nav-bar-link-hover-color: var(--color-midnight-blue);
   --side-nav-bar-link-active-color: var(--color-super-blue);
+  --side-nav-bar-link-border-color: var(--color-platinum);
 }


### PR DESCRIPTION
# Description

The recent work to update the Canopy links caused some unwanted visited styles on the side nav. This PR fixes those to make them the desired states.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
