### PR TITLE
fix(links): reset color and background of unstyled link on hover

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -72,6 +72,8 @@
   &:hover {
     border-bottom: 0;
     box-shadow: none;
+    background-color: transparent;
+    color: inherit;
   }
 
   &:active,
@@ -81,7 +83,8 @@
     color: inherit;
   }
 
-  &:focus {
+  &:focus,
+  &:focus:hover {
     @include lg-outer-focus-outline;
   }
 }


### PR DESCRIPTION
# Description

Unstyled links still inherited the global link hover color and background, which need to be reset to avoid undesirable behaviour on hover.
# Checklist:

- [x The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
