### PR TITLE
fix(quick-action): set background to white

### DIFF
--- a/projects/canopy/src/lib/quick-action/quick-action.component.scss
+++ b/projects/canopy/src/lib/quick-action/quick-action.component.scss
@@ -12,7 +12,7 @@
   transition: background-color var(--animation-duration) var(--animation-fn);
   cursor: pointer;
   border: 0;
-  background-color: transparent;
+  background-color: var(--quick-action-bg-color);
   appearance: none;
   color: var(--link-color);
 
@@ -39,6 +39,9 @@
   &:focus,
   &:focus:hover {
     @include lg-outer-focus-outline(var(--default-focus-color));
+
+    background-color: var(--quick-action-bg-color);
+    color: var(--link-color);
   }
 
   &:visited:hover {

--- a/projects/canopy/src/styles/variables/components/_quick-action.scss
+++ b/projects/canopy/src/styles/variables/components/_quick-action.scss
@@ -1,4 +1,5 @@
 :root {
+  --quick-action-bg-color: var(--color-white);
   --quick-action-hover-bg-color: var(--color-super-blue);
   --quick-action-hover-color: var(--color-white);
   --quick-action-active-bg-color: var(--color-super-blue-dark);


### PR DESCRIPTION
fix #469

# Description

Update quick action background to white to ensure the text is still visible against varying backgrounds

Fixes #469 

## Requirements

Ensure the text on the quick actions is visible against all backgrounds (storybook allows the background colour to be changed)

Storybook link: https://deploy-preview-470--legal-and-general-canopy.netlify.app/?path=/story/components-quick-action--link
https://deploy-preview-470--legal-and-general-canopy.netlify.app/?path=/story/components-quick-action--button

Screenshot: 

![Screenshot 2021-07-14 at 15 26 34](https://user-images.githubusercontent.com/7768665/125644305-bc401413-d47c-4dff-b0ff-8a9f606a7953.png)
![Screenshot 2021-07-14 at 15 14 32](https://user-images.githubusercontent.com/7768665/125644307-cf0d433a-e0f5-4f59-9b6a-efe4f5202cdf.png)
![Screenshot 2021-07-14 at 15 14 26](https://user-images.githubusercontent.com/7768665/125644310-19e66935-3df8-4bcd-a8a5-375d3ff58803.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
