### PR TITLE
feat(modal): format timer input

### DIFF
--- a/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.html
+++ b/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.html
@@ -1,1 +1,1 @@
-{{ timer }}
+{{ formattedTime }}

--- a/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.spec.ts
+++ b/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.spec.ts
@@ -27,8 +27,36 @@ describe('LgModalBodyTimerComponent', () => {
   });
 
   it('should return the input in the correct format', () => {
-    const time = [0, 15, 59, 60, 61, 599, 600, 601, 5999];
+    const time = [
+      0,
+      15,
+      59,
+      60,
+      61,
+      599,
+      600,
+      601,
+      5999,
+      '0',
+      '15',
+      '59',
+      '60',
+      '61',
+      '599',
+      '600',
+      '601',
+      '5999',
+    ];
     const result = [
+      '0:00',
+      '0:15',
+      '0:59',
+      '1:00',
+      '1:01',
+      '9:59',
+      '10:00',
+      '10:01',
+      '99:59',
       '0:00',
       '0:15',
       '0:59',
@@ -41,8 +69,8 @@ describe('LgModalBodyTimerComponent', () => {
     ];
     time.forEach((value, index) => {
       component.timer = time[index];
-      component.ngOnInit();
-      expect(component.formattedTime).toBe(result[index]);
+
+      expect(component.formattedTime).toContain(result[index]);
     });
   });
 });

--- a/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.spec.ts
+++ b/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.spec.ts
@@ -25,4 +25,24 @@ describe('LgModalBodyTimerComponent', () => {
   it('should have a class', () => {
     expect(fixture.nativeElement.getAttribute('class')).toContain('lg-modal-body__timer');
   });
+
+  it('should return the input in the correct format', () => {
+    const time = [0, 15, 59, 60, 61, 599, 600, 601, 5999];
+    const result = [
+      '0:00',
+      '0:15',
+      '0:59',
+      '1:00',
+      '1:01',
+      '9:59',
+      '10:00',
+      '10:01',
+      '99:59',
+    ];
+    time.forEach((value, index) => {
+      component.timer = time[index];
+      component.ngOnInit();
+      expect(component.formattedTime).toBe(result[index]);
+    });
+  });
 });

--- a/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.ts
+++ b/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   HostBinding,
   Input,
+  OnInit,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -13,8 +14,16 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgModalBodyTimerComponent {
-  @Input() timer: string;
+export class LgModalBodyTimerComponent implements OnInit {
+  @Input() timer: number;
+  formattedTime: string | number;
 
   @HostBinding('class.lg-modal-body__timer') class = true;
+
+  ngOnInit() {
+    this.formattedTime = `${Math.floor(this.timer / 60)}:${(
+      '0' +
+      (this.timer % 60)
+    ).slice(-2)}`;
+  }
 }

--- a/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.ts
+++ b/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   HostBinding,
   Input,
-  OnInit,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -14,16 +13,21 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgModalBodyTimerComponent implements OnInit {
-  @Input() timer: number;
-  formattedTime: string | number;
+export class LgModalBodyTimerComponent {
+  private _timer: number;
+  formattedTime: string;
 
   @HostBinding('class.lg-modal-body__timer') class = true;
 
-  ngOnInit() {
-    this.formattedTime = `${Math.floor(this.timer / 60)}:${(
+  @Input()
+  set timer(seconds: number | string) {
+    if (typeof seconds === 'string') {
+      seconds = parseInt(seconds, 10);
+    }
+    this._timer = seconds;
+    this.formattedTime = `${Math.floor(this._timer / 60)}:${(
       '0' +
-      (this.timer % 60)
+      (this._timer % 60)
     ).slice(-2)}`;
   }
 }

--- a/projects/canopy/src/lib/modal/modal.notes.ts
+++ b/projects/canopy/src/lib/modal/modal.notes.ts
@@ -87,7 +87,7 @@ and to close it:
 ### LgModalBodyTimerComponent
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| \`\`timer\`\` | The timer value to apply the styles to | string | n/a | Yes |
+| \`\`timer\`\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |
 
 ### LgModalTriggerDirective
 | Name | Description | Type | Default | Required |

--- a/projects/canopy/src/lib/modal/modal.stories.ts
+++ b/projects/canopy/src/lib/modal/modal.stories.ts
@@ -28,7 +28,7 @@ export const standard = () => ({
       <lg-modal-header [headingLevel]="headingLevel">Lorem ipsum</lg-modal-header>
       <lg-modal-body>
         Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        <lg-modal-body-timer timer="0:25"></lg-modal-body-timer>
+        <lg-modal-body-timer timer="90"></lg-modal-body-timer>
       </lg-modal-body>
       <lg-modal-footer>
         <lg-button-group>


### PR DESCRIPTION
# Description

Takes the input of the timer in seconds and converts it to a minutes/seconds format e.g. from 90 to "1:30"
![image](https://user-images.githubusercontent.com/7091410/125787365-8a0fd98d-2d0a-40c7-af84-a486e7367d68.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
