### PR TITLE
GitHub pages deploy

### DIFF
--- a/.github/actions/gh-pages-storybook/README.md
+++ b/.github/actions/gh-pages-storybook/README.md
@@ -1,0 +1,15 @@
+# GitHub Pages Storybook action
+
+This action will:
+- run the storybook static build
+- commit and push the resultant directory to the `gh-pages` branch
+
+The node_modules are not checked in and there is currently no separate build process for the action. For this reason we need to install the node_modules ahead of time.
+
+## Example usage
+```
+- name: install action dependencies
+  run: ci .github/actions/gh-pages-storybook && npm ci
+- name: deploy to gh-pages
+  uses: ./.github/actions/gh-pages-storybook
+```

--- a/.github/actions/gh-pages-storybook/action.yml
+++ b/.github/actions/gh-pages-storybook/action.yml
@@ -1,0 +1,6 @@
+name: '@legal-and-general/gh-pages-storybook'
+description: 'Deploy Storybook to GitHub Pages'
+runs:
+  using: 'node12'
+  main: 'index.js'
+

--- a/.github/actions/gh-pages-storybook/index.js
+++ b/.github/actions/gh-pages-storybook/index.js
@@ -1,0 +1,44 @@
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+async function run () {
+  try {
+    if (core.isDebug()) {
+      core.startGroup('Debug: context');
+      core.debug(core.context);
+      core.endGroup();
+    }
+
+    const buildPath = 'storybook-static';
+    
+    core.info('[INFO]: commencing storybook gh-pages deploy')
+
+    core.info('[INFO]: running storybook build')
+    await exec.exec('npm', ['run', 'build-storybook']);
+
+    core.info('[INFO]: configuring git')
+    await exec.exec('git', ['config', '--global', 'user.email', 'github-actions[bot]@users.noreply.github.com']);
+    await exec.exec('git', ['config', '--global', 'user.name', 'github-actions[bot]']);
+
+    core.info('[INFO]: checking out gh-pages branch')
+    // -B: don't error if the branch already exists
+    await exec.exec('git', ['checkout', '-B', 'gh-pages']);
+
+    core.info('[INFO]: adding storybook static files')
+    // --force: override .gitignore
+    await exec.exec('git', ['add', '--force', buildPath]);
+
+    core.info('[INFO]: committing changes');
+    // TODO: retrieve latest release and put it in the commit msg, token does not have privileges
+    await exec.exec('git', ['commit', '-m', 'docs(gh-pages): latest storybook build']);
+
+    core.info('[INFO]: pushing to gh-pages');
+    await exec.exec('git', ['push', '-f', '--set-upstream', 'origin', 'gh-pages']);
+
+
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+(async () => { await run() })();

--- a/.github/actions/gh-pages-storybook/package-lock.json
+++ b/.github/actions/gh-pages-storybook/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "@legal-and-general/gh-pages-storybook",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@legal-and-general/gh-pages-storybook",
+      "devDependencies": {
+        "@actions/core": "^1.4.0",
+        "@actions/exec": "^1.1.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg==",
+      "dev": true
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "dev": true,
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg==",
+      "dev": true
+    },
+    "@actions/exec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
+      "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+      "dev": true,
+      "requires": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "@actions/io": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA==",
+      "dev": true
+    }
+  }
+}

--- a/.github/actions/gh-pages-storybook/package.json
+++ b/.github/actions/gh-pages-storybook/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@legal-and-general/gh-pages-storybook",
+  "private": true,
+  "description": "A github action to deploy storybook to gh-pages",
+  "devDependencies": {
+    "@actions/core": "^1.4.0",
+    "@actions/exec": "^1.1.0"
+  }
+}

--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to gh-pages
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14
+      - name: install dependencies
+        run: npm ci
+      - name: install action dependencies
+        run: cd .github/actions/gh-pages-storybook && npm ci
+      - name: deploy to pages
+        uses: ./.github/actions/gh-pages-storybook


### PR DESCRIPTION
# Description

This PR will enable deployment of the master branch to GitHub pages. It works by executing the necessary commands to run the storybook static build and commit them to the gh-pages branch.

I decided to roll this manually as we have been wary of using actions from unknown sources, at least for the time being. We could fork an action and host it within our org but this would require quite a lot of extra work

There are some hopefully workable compromises.
1. The commit message in the gh-pages branch does not have the latest release version. This can be determined using Git but I was hoping to get this part working first.  
2. The default token doesn't have the ability to setup Github Pages, it can commit to the branch, but can't create the static site. This will have to be done manually.
3. There are no unit tests for the action. Given it only executes commands and there is no logic, all we could do is assert that the commands are run.
4. The node modules have to be manually installed before the action is run, before deciding this I tried the following.
  - Committing the node modules, just felt too wrong.
  - Generating a built version via a Husky commit hook and https://github.com/vercel/ncc, too complex

Once deployed we will have to start to redirect traffic to the new URL.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
