### PR TITLE
fix(sort-code): changes the size of the sort code fields

### DIFF
--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.scss
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.scss
@@ -10,7 +10,7 @@
 .lg-sort-code__input {
   flex-direction: column;
   margin-right: var(--space-sm);
-  width: 3.75rem; // 60px
+  width: 3.4375rem; // 55px
 
   & .lg-input-field .lg-input-field__inputs {
     width: 100%;


### PR DESCRIPTION
The sort code fields are slightly larger than they should be.  This change addresses that.

#483

Please note that the original size of the sort code input fields was originally intended to be about 60px.  However, through padding and other css it ended up being about 55px.  The update from #464 forced the input to resize correctly, which has led to this discrepancy.  The width for the individual sort code input boxes has been set to 55px (3.4375rem), rather than the original 60px (3.75rem).  

Netlify link: https://deploy-preview-484--legal-and-general-canopy.netlify.app/?path=/story/components-form-sort-code--standard