### PR TITLE
fix(sort-code): sync validation with the parent form

### DIFF
--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.spec.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.spec.ts
@@ -18,7 +18,7 @@ import { By } from '@angular/platform-browser';
 
 import { MockComponents } from 'ng-mocks';
 import { instance, mock } from 'ts-mockito';
-import { skip } from 'rxjs/operators';
+import { skip, startWith } from 'rxjs/operators';
 
 import { LgHintComponent } from '../hint/hint.component';
 import { LgErrorStateMatcher } from '../validation/error-state-matcher';
@@ -290,6 +290,21 @@ describe('SortCodeComponent', () => {
       buttonDebugElement.nativeElement.click();
 
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should have the sort fields marked as dirty and touched', (done) => {
+      const buttonDebugElement = fixture.debugElement.query(
+        By.directive(LgButtonComponent),
+      );
+      buttonDebugElement.nativeElement.click();
+      fixture.detectChanges();
+      sortCodeComponent.formGroupDirective.form.statusChanges
+        .pipe(startWith('INVALID'))
+        .subscribe(() => {
+          expect(sortCodeComponent.sortCodeFormGroup.dirty).toBe(true);
+          expect(sortCodeComponent.sortCodeFormGroup.touched).toBe(true);
+          done();
+        });
     });
   });
 });

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
@@ -113,7 +113,8 @@ export class LgSortCodeComponent implements OnInit, ControlValueAccessor {
       this.ngControl.control.updateValueAndValidity();
     }
 
-    const sortCodeParentControl = this.parentFormGroupDirective.form.controls['sortCode'];
+    const sortCodeParentControl =
+      this.parentFormGroupDirective.form.controls[this.ngControl.name];
 
     // show the error message when the input is invalid
     sortCodeParentControl.statusChanges.pipe(take(1)).subscribe(() => {


### PR DESCRIPTION
This PR has the following changes: 

- sort.code.component.ts 
  Subscribed to the `statusChanges` observable of the parent control. Inside the subscribe, we mark the form as touched 
  and individually mark the sort code fields as dirty, in order to trigger the `lg-input--error` and we also use `.setErrors` to trigger the validation message.

This fix addresses this bug, for the sort-code: https://github.com/Legal-and-General/canopy/issues/184


# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
