### PR TITLE
fix(date-field): corrects date display on IE11

### DIFF
--- a/projects/canopy/src/lib/forms/date/date-field.component.scss
+++ b/projects/canopy/src/lib/forms/date/date-field.component.scss
@@ -16,6 +16,10 @@
 
   & .lg-input-field .lg-input-field__inputs {
     width: 100%;
+
+    & .lg-input {
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
This explicitly set width to 100% which fix this issue

# Description

The date fields don't display properly on IE11. This change corrects the
issue

Fixes 
set width to 100% on actual input element. Parent element width doesn't reflect on IE11


Storybook link: 
https://deploy-preview-495--legal-and-general-canopy.netlify.app/?path=/story/components-form-date-input--standard

Screenshot: 
Before fix
![Screenshot 2021-07-27 at 15 23 50](https://user-images.githubusercontent.com/8222267/127172319-d579fca4-342a-4a75-905e-eff528455bd9.png)

After Fix
![Screenshot 2021-07-27 at 15 32 26](https://user-images.githubusercontent.com/8222267/127172873-3a163222-2248-4918-8fa4-536a33a5ac90.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
