### PR TITLE
feat(content-scroll): creates a scrollable region for long content

### DIFF
--- a/projects/canopy/src/lib/canopy.module.ts
+++ b/projects/canopy/src/lib/canopy.module.ts
@@ -8,6 +8,7 @@ import { LgBreadcrumbModule } from './breadcrumb/breadcrumb.module';
 import { LgButtonModule } from './button/button.module';
 import { LgCardModule } from './card/card.module';
 import { LgCarouselModule } from './carousel/carousel.module';
+import { LgContentScrollModule } from './content-scroll/content-scroll.module';
 import { LgDataPointModule } from './data-point/data-point.module';
 import { LgDetailsModule } from './details/details.module';
 import { LgFeatureToggleModule } from './feature-toggle/feature-toggle.module';
@@ -91,6 +92,7 @@ const modules = [
   LgTabsModule,
   LgVariantModule,
   LgCarouselModule,
+  LgContentScrollModule,
   LgModalModule,
   LgPrimaryMessageModule,
 ];

--- a/projects/canopy/src/lib/content-scroll/content-scroll.breakpoints.scss
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.breakpoints.scss
@@ -1,0 +1,1 @@
+$columns-breakpoints: 'sm', 'md', 'lg';

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.html
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.html
@@ -1,0 +1,12 @@
+<div
+  class="lg-content-scroll__content"
+  [ngClass]="{
+    'lg-content-scroll__content-min-width': mobileFullContent,
+    'lg-content-scroll__content-flat-list': listNoIndent
+  }"
+  [style.width]="getWidth()"
+  [style.height]="getHeight()"
+  tabindex="0"
+>
+  <ng-content></ng-content>
+</div>

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.html
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.html
@@ -1,11 +1,8 @@
 <div
   class="lg-content-scroll__content"
   [ngClass]="{
-    'lg-content-scroll__content-min-width': mobileFullContent,
     'lg-content-scroll__content-flat-list': listNoIndent
   }"
-  [style.width]="getWidth()"
-  [style.height]="getHeight()"
   tabindex="0"
 >
   <ng-content></ng-content>

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.scss
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.scss
@@ -1,0 +1,70 @@
+@import '../../styles/mixins';
+
+.lg-content-scroll {
+  .lg-content-scroll__content {
+    display: block;
+    position: relative;
+    margin: 0.5em;
+    padding: 0.5em;
+    overflow-x: hidden;
+    overflow-y: auto;
+    border: solid var(--border-width) var(--content-scroll-border-color);
+
+    p:first-child {
+      margin-top: 0;
+    }
+    @include lg-breakpoint('md', 'max-width') {
+      &.lg-content-scroll__content-min-width {
+        height: auto;
+        overflow-x: unset;
+        overflow-y: unset;
+        border: none;
+      }
+    }
+  }
+
+  .lg-content-scroll__content-flat-list {
+    ol {
+      counter-reset: item;
+      margin-left: 0;
+      padding-left: 0;
+    }
+
+    li {
+      padding-left: 3rem;
+      list-style-type: none;
+
+      &::before {
+        display: inline-block;
+        width: 3rem;
+        margin-left: -3rem;
+        padding-right: 0;
+        content: counters(item, '.') ' ';
+        counter-increment: item;
+      }
+
+      li {
+        margin-left: 0;
+        padding-left: 0;
+      }
+    }
+
+    ul {
+      li {
+        list-style-type: disc;
+
+        &::before {
+          display: block;
+          width: auto;
+          content: no-close-quote;
+          counter-increment: none;
+        }
+      }
+    }
+  }
+
+  li > ol,
+  li > ul {
+    margin-bottom: 0;
+  }
+}

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.scss
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.scss
@@ -1,27 +1,31 @@
 @import '../../styles/mixins';
+@import 'content-scroll.breakpoints';
 
-.lg-content-scroll {
-  .lg-content-scroll__content {
-    display: block;
-    position: relative;
-    margin: 0.5em;
-    padding: 0.5em;
-    overflow-x: hidden;
-    overflow-y: auto;
-    border: solid var(--border-width) var(--content-scroll-border-color);
+@mixin lg-content-scroll__breakpoint {
+  display: block;
+  position: relative;
+  margin: var(--component-margin);
+  padding: var(--component-padding);
+  overflow-x: hidden;
+  overflow-y: auto;
+  border: solid var(--border-width) var(--content-scroll-border-color);
 
-    p:first-child {
-      margin-top: 0;
-    }
-    @include lg-breakpoint('md', 'max-width') {
-      &.lg-content-scroll__content-min-width {
-        height: auto;
-        overflow-x: unset;
-        overflow-y: unset;
-        border: none;
-      }
+  p:first-child {
+    margin-top: 0;
+  }
+}
+
+@each $columns-breakpoint in $columns-breakpoints {
+  .lg-content-scroll__scroll-at-#{$columns-breakpoint} {
+    @include lg-breakpoint($columns-breakpoint) {
+      @include lg-content-scroll__breakpoint;
     }
   }
+}
+
+.lg-content-scroll {
+  height: auto;
+  width: auto;
 
   .lg-content-scroll__content-flat-list {
     ol {

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.spec.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { LgContentSrollComponent } from './content-scroll.component';
+import { ContentScrollBreakpoints } from './content-scroll.interface';
 
 describe('LgContentSrollComponent', () => {
   let component: LgContentSrollComponent;
   let fixture: ComponentFixture<LgContentSrollComponent>;
+  let scrollArea;
   let scrollContent;
 
   beforeEach(
@@ -18,6 +20,7 @@ describe('LgContentSrollComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LgContentSrollComponent);
     component = fixture.componentInstance;
+    scrollArea = fixture.debugElement.nativeElement;
     scrollContent = fixture.debugElement.nativeElement.querySelector(
       '.lg-content-scroll__content',
     );
@@ -28,64 +31,29 @@ describe('LgContentSrollComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('the contentWidth input', () => {
-    it('should show a value of auto input is not specified', () => {
+  describe('the scrollContentAt input', () => {
+    it('should show the default value if not specified', () => {
       fixture.detectChanges();
-      expect(scrollContent.style.width).toBe('auto');
-    });
-
-    it('should show a value of auto input is not valid', () => {
-      component.contentWidth = '4';
-      fixture.detectChanges();
-      expect(scrollContent.style.width).toBe('auto');
+      expect(scrollArea.classList.contains('lg-content-scroll__scroll-at-sm')).toBeTrue();
     });
 
     it('should show a value based on the input specified', () => {
-      component.contentWidth = '70vw';
+      component.scrollContentAt = ContentScrollBreakpoints.Medium;
       fixture.detectChanges();
-      expect(scrollContent.style.width).toBe('70vw');
+      expect(scrollArea.classList.contains('lg-content-scroll__scroll-at-md')).toBeTrue();
     });
   });
 
-  describe('the contentHeight input', () => {
-    it('should show a value of 40vh input is not specified', () => {
+  describe('the scrollHeight input', () => {
+    it('should show the default value if not specified', () => {
       fixture.detectChanges();
-      expect(scrollContent.style.height).toBe('40vh');
-    });
-
-    it('should show a value of 40vh input is not valid', () => {
-      component.contentHeight = '4';
-      fixture.detectChanges();
-      expect(scrollContent.style.height).toBe('40vh');
+      expect(scrollArea.style.height).toBe('40vh');
     });
 
     it('should show a value based on the input specified', () => {
-      component.contentHeight = '70vh';
+      component.scrollHeight = '70vh';
       fixture.detectChanges();
-      expect(scrollContent.style.height).toBe('70vh');
-    });
-  });
-
-  describe('the mobileFullContent input', () => {
-    it('should add the relevant class if input is not specified', () => {
-      fixture.detectChanges();
-      expect(
-        scrollContent.classList.contains('lg-content-scroll__content-min-width'),
-      ).toBeTrue();
-    });
-    it('should add the relevant class if input is true', () => {
-      component.mobileFullContent = true;
-      fixture.detectChanges();
-      expect(
-        scrollContent.classList.contains('lg-content-scroll__content-min-width'),
-      ).toBeTrue();
-    });
-    it('should not add the relevant class if input is false', () => {
-      component.mobileFullContent = false;
-      fixture.detectChanges();
-      expect(
-        scrollContent.classList.contains('lg-content-scroll__content-min-width'),
-      ).not.toBeTrue();
+      expect(scrollArea.style.height).toBe('70vh');
     });
   });
 

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.spec.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.spec.ts
@@ -1,0 +1,116 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LgContentSrollComponent } from './content-scroll.component';
+
+describe('LgContentSrollComponent', () => {
+  let component: LgContentSrollComponent;
+  let fixture: ComponentFixture<LgContentSrollComponent>;
+  let scrollContent;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [LgContentSrollComponent],
+      }).compileComponents();
+    }),
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgContentSrollComponent);
+    component = fixture.componentInstance;
+    scrollContent = fixture.debugElement.nativeElement.querySelector(
+      '.lg-content-scroll__content',
+    );
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('the contentWidth input', () => {
+    it('should show a value of auto input is not specified', () => {
+      fixture.detectChanges();
+      expect(scrollContent.style.width).toBe('auto');
+    });
+
+    it('should show a value of auto input is not valid', () => {
+      component.contentWidth = '4';
+      fixture.detectChanges();
+      expect(scrollContent.style.width).toBe('auto');
+    });
+
+    it('should show a value based on the input specified', () => {
+      component.contentWidth = '70vw';
+      fixture.detectChanges();
+      expect(scrollContent.style.width).toBe('70vw');
+    });
+  });
+
+  describe('the contentHeight input', () => {
+    it('should show a value of 40vh input is not specified', () => {
+      fixture.detectChanges();
+      expect(scrollContent.style.height).toBe('40vh');
+    });
+
+    it('should show a value of 40vh input is not valid', () => {
+      component.contentHeight = '4';
+      fixture.detectChanges();
+      expect(scrollContent.style.height).toBe('40vh');
+    });
+
+    it('should show a value based on the input specified', () => {
+      component.contentHeight = '70vh';
+      fixture.detectChanges();
+      expect(scrollContent.style.height).toBe('70vh');
+    });
+  });
+
+  describe('the mobileFullContent input', () => {
+    it('should add the relevant class if input is not specified', () => {
+      fixture.detectChanges();
+      expect(
+        scrollContent.classList.contains('lg-content-scroll__content-min-width'),
+      ).toBeTrue();
+    });
+    it('should add the relevant class if input is true', () => {
+      component.mobileFullContent = true;
+      fixture.detectChanges();
+      expect(
+        scrollContent.classList.contains('lg-content-scroll__content-min-width'),
+      ).toBeTrue();
+    });
+    it('should not add the relevant class if input is false', () => {
+      component.mobileFullContent = false;
+      fixture.detectChanges();
+      expect(
+        scrollContent.classList.contains('lg-content-scroll__content-min-width'),
+      ).not.toBeTrue();
+    });
+  });
+
+  describe('the listNoIndent input', () => {
+    it('should not add the relevant class if input is not specified', () => {
+      fixture.detectChanges();
+      expect(
+        scrollContent.classList.contains('lg-content-scroll__content-flat-list'),
+      ).not.toBeTrue();
+    });
+
+    it('should not add the relevant class if input is false', () => {
+      component.listNoIndent = false;
+      fixture.detectChanges();
+      expect(
+        scrollContent.classList.contains('lg-content-scroll__content-flat-list'),
+      ).not.toBeTrue();
+    });
+
+    it('should add the relevant class if input is true', () => {
+      component.listNoIndent = true;
+      fixture.detectChanges();
+      expect(
+        scrollContent.classList.contains('lg-content-scroll__content-flat-list'),
+      ).toBeTrue();
+    });
+  });
+});

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.ts
@@ -1,4 +1,13 @@
-import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+import {
+  Component,
+  HostBinding,
+  Input,
+  ViewEncapsulation,
+  ElementRef,
+  Renderer2,
+} from '@angular/core';
+
+import { ContentScrollBreakpoints } from './content-scroll.interface';
 
 @Component({
   selector: 'lg-content-scroll',
@@ -7,31 +16,60 @@ import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core'
   encapsulation: ViewEncapsulation.None,
 })
 export class LgContentSrollComponent {
-  @HostBinding('class.lg-content-scroll') class = true;
-  @Input() contentWidth: string = null;
-  @Input() contentHeight: string = null;
-  @Input() mobileFullContent = true;
+  @HostBinding('class') class = 'lg-content-scroll';
+
+  private _scrollContentAt: ContentScrollBreakpoints;
+  @Input()
+  set scrollContentAt(columnsBreakpoint: ContentScrollBreakpoints) {
+    if (columnsBreakpoint === null) {
+      columnsBreakpoint = this._scrollContentAt;
+    }
+
+    this.addContentScrollBreakpoint(columnsBreakpoint);
+    this._scrollContentAt = columnsBreakpoint;
+  }
+  get scrollContentAt(): ContentScrollBreakpoints {
+    return this._scrollContentAt;
+  }
+
+  private _scrollHeight: string;
+  @Input()
+  set scrollHeight(value: string) {
+    if (value === null || value === '') {
+      value = this._scrollHeight;
+    }
+    this.setHeight(value);
+    this._scrollHeight = value;
+  }
+  get scrollHeight(): string {
+    return this._scrollHeight;
+  }
+
   @Input() listNoIndent = false;
 
-  private defaultWidth = 'auto';
-  private defaultHeight = '40vh';
-  private unitWidthPattern = new RegExp(
-    '(^(auto|([0-9]+(em|px|%|px|cm|mm|in|pt|pc|ch|rem|vw|vmin|vmax)))$)',
-  );
-  private unitHeightPattern = new RegExp(
-    '(^(auto|([0-9]+(em|px|%|px|cm|mm|in|pt|pc|ch|rem|vh|vmin|vmax)))$)',
-  );
+  constructor(private renderer: Renderer2, private hostElement: ElementRef) {
+    this._scrollContentAt = ContentScrollBreakpoints.Small;
+    this._scrollHeight = '40vh';
 
-  getHeight() {
-    if (this.unitHeightPattern.test(this.contentHeight)) {
-      return this.contentHeight;
-    }
-    return this.defaultHeight;
+    this.addContentScrollBreakpoint(this._scrollContentAt);
+    this.setHeight(this._scrollHeight);
   }
-  getWidth() {
-    if (this.unitWidthPattern.test(this.contentWidth)) {
-      return this.contentWidth;
-    }
-    return this.defaultWidth;
+
+  private addContentScrollBreakpoint(columnsBreakpoint: ContentScrollBreakpoints) {
+    this.renderer.removeClass(
+      this.hostElement.nativeElement,
+      `lg-content-scroll__scroll-at-${this._scrollContentAt}`,
+    );
+
+    this.renderer.addClass(
+      this.hostElement.nativeElement,
+      `lg-content-scroll__scroll-at-${columnsBreakpoint}`,
+    );
+  }
+
+  private setHeight(value: string) {
+    this.renderer.removeStyle(this.hostElement.nativeElement, 'height');
+
+    this.renderer.setStyle(this.hostElement.nativeElement, 'height', value);
   }
 }

--- a/projects/canopy/src/lib/content-scroll/content-scroll.component.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.component.ts
@@ -1,0 +1,37 @@
+import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'lg-content-scroll',
+  styleUrls: ['./content-scroll.component.scss'],
+  templateUrl: './content-scroll.component.html',
+  encapsulation: ViewEncapsulation.None,
+})
+export class LgContentSrollComponent {
+  @HostBinding('class.lg-content-scroll') class = true;
+  @Input() contentWidth: string = null;
+  @Input() contentHeight: string = null;
+  @Input() mobileFullContent = true;
+  @Input() listNoIndent = false;
+
+  private defaultWidth = 'auto';
+  private defaultHeight = '40vh';
+  private unitWidthPattern = new RegExp(
+    '(^(auto|([0-9]+(em|px|%|px|cm|mm|in|pt|pc|ch|rem|vw|vmin|vmax)))$)',
+  );
+  private unitHeightPattern = new RegExp(
+    '(^(auto|([0-9]+(em|px|%|px|cm|mm|in|pt|pc|ch|rem|vh|vmin|vmax)))$)',
+  );
+
+  getHeight() {
+    if (this.unitHeightPattern.test(this.contentHeight)) {
+      return this.contentHeight;
+    }
+    return this.defaultHeight;
+  }
+  getWidth() {
+    if (this.unitWidthPattern.test(this.contentWidth)) {
+      return this.contentWidth;
+    }
+    return this.defaultWidth;
+  }
+}

--- a/projects/canopy/src/lib/content-scroll/content-scroll.interface.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.interface.ts
@@ -1,0 +1,5 @@
+export enum ContentScrollBreakpoints {
+  Small = 'sm',
+  Medium = 'md',
+  Large = 'lg',
+}

--- a/projects/canopy/src/lib/content-scroll/content-scroll.module.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { LgContentSrollComponent } from './content-scroll.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [LgContentSrollComponent],
+  exports: [LgContentSrollComponent],
+})
+export class LgContentScrollModule {}

--- a/projects/canopy/src/lib/content-scroll/content-scroll.notes.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.notes.ts
@@ -1,0 +1,40 @@
+export const notes = `
+# Content Scroll Component
+
+## Purpose
+Content Scroll allows you to place long content in a smaller scrollable region. On mobile devices, the scroll region is removed and the content is displayed in full.
+
+## Usage
+
+Import the component in your module:
+
+~~~js
+@NgModule({
+  ...
+  imports: [ ..., LgContentScrollModule ],
+})
+~~~
+
+and in your HTML:
+
+~~~html
+<lg-content-scroll
+  [contentWidth]="auto"
+  [contentHeight]="40vh"
+  [mobileFullContent]="true"
+  [listNoIndent]="false">
+
+  Content
+
+</lg-content-scroll>
+~~~
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| \`\`contentWidth\`\` | Set width of scroll region (takes auto, em, px, %, px, cm, mm, in, pt, pc, ch, rem, vw, vmin, vmax) | string | auto | No |
+| \`\`contentHeight\`\` | Set height of scroll region (takes auto, em, px, %, px, cm, mm, in, pt, pc, ch, rem, vh, vmin, vmax) | string | 40vh | No |
+| \`\`mobileFullContent\`\` | Remove scroll region on mobile devices | boolean | true | No |
+| \`\`listNoIndent\`\` | Remove indentation from ordered list structure | boolean | false | No |
+`;

--- a/projects/canopy/src/lib/content-scroll/content-scroll.notes.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.notes.ts
@@ -2,7 +2,7 @@ export const notes = `
 # Content Scroll Component
 
 ## Purpose
-Content Scroll allows you to place long content in a smaller scrollable region. On mobile devices, the scroll region is removed and the content is displayed in full.
+Content Scroll allows you to place long content in a smaller scrollable region. On small screens, the scroll region is removed and the content is displayed in full.
 
 ## Usage
 
@@ -19,9 +19,8 @@ and in your HTML:
 
 ~~~html
 <lg-content-scroll
-  [contentWidth]="auto"
-  [contentHeight]="40vh"
-  [mobileFullContent]="true"
+  [scrollContentAt]="sm"
+  [scrollHeight]="40vh"
   [listNoIndent]="false">
 
   Content
@@ -33,8 +32,7 @@ and in your HTML:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| \`\`contentWidth\`\` | Set width of scroll region (takes auto, em, px, %, px, cm, mm, in, pt, pc, ch, rem, vw, vmin, vmax) | string | auto | No |
-| \`\`contentHeight\`\` | Set height of scroll region (takes auto, em, px, %, px, cm, mm, in, pt, pc, ch, rem, vh, vmin, vmax) | string | 40vh | No |
-| \`\`mobileFullContent\`\` | Remove scroll region on mobile devices | boolean | true | No |
+| \`\`scrollContentAt\`\` | Set minimum width to show scroll region (sm, md, lg) | string | sm | No |
+| \`\`scrollHeight\`\` | Set height of scroll region | string | 40vh | No |
 | \`\`listNoIndent\`\` | Remove indentation from ordered list structure | boolean | false | No |
 `;

--- a/projects/canopy/src/lib/content-scroll/content-scroll.stories.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.stories.ts
@@ -1,0 +1,37 @@
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { moduleMetadata } from '@storybook/angular';
+
+import { LgContentSrollComponent } from './content-scroll.component';
+import { notes } from './content-scroll.notes';
+
+export default {
+  title: 'Components/Content Scroll',
+  parameters: {
+    decorators: [
+      withKnobs,
+      moduleMetadata({
+        declarations: [LgContentSrollComponent],
+      }),
+    ],
+    notes: {
+      markdown: notes,
+    },
+  },
+};
+
+export const standard = () => ({
+  template: `
+    <lg-content-scroll [contentWidth]="contentWidth" [contentHeight]="contentHeight" [mobileFullContent]="mobileFullContent" [listNoIndent]="listNoIndent">
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero. </p> \
+    <p>Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. </p> \
+    <ol><li>Nulla metus metus</li><li>Nllamcorper vel</li><li>Tincidunt sed<ol><li>Euismod in</li><li>Nibh</li><li>Quisque volutpat<ol><li>Ad litora</li><li>Torquent per</li></ol></li><li>Condimentum velit</li></ol></li><li>Class aptent</li><li>Taciti sociosqu<ul><li>Ad litora</li><li>Torquent per</li></ul></li><li>Conubia nostra</li></ol> \
+    <p>Suspendisse in justo eu magna luctus suscipit. Sed lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed non quam. In vel mi sit amet augue congue elementum. Morbi in ipsum sit amet pede facilisis laoreet. Donec lacus nunc, viverra nec, blandit vel, egestas et, augue. Vestibulum tincidunt malesuada tellus. Ut ultrices ultrices enim. Curabitur sit amet mauris. </p>
+    </lg-content-scroll>
+  `,
+  props: {
+    contentWidth: text('contentWidth', '50vw'),
+    contentHeight: text('contentHeight', '90vh'),
+    mobileFullContent: boolean('mobileFullContent', true),
+    listNoIndent: boolean('listNoIndent', false),
+  },
+});

--- a/projects/canopy/src/lib/content-scroll/content-scroll.stories.ts
+++ b/projects/canopy/src/lib/content-scroll/content-scroll.stories.ts
@@ -1,7 +1,9 @@
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, select, boolean, text } from '@storybook/addon-knobs';
 import { moduleMetadata } from '@storybook/angular';
 
 import { LgContentSrollComponent } from './content-scroll.component';
+import { ContentScrollBreakpoints } from './content-scroll.interface';
+
 import { notes } from './content-scroll.notes';
 
 export default {
@@ -21,7 +23,7 @@ export default {
 
 export const standard = () => ({
   template: `
-    <lg-content-scroll [contentWidth]="contentWidth" [contentHeight]="contentHeight" [mobileFullContent]="mobileFullContent" [listNoIndent]="listNoIndent">
+    <lg-content-scroll [scrollContentAt]="scrollContentAt" [scrollHeight]="scrollHeight" [listNoIndent]="listNoIndent">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero. </p> \
     <p>Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. </p> \
     <ol><li>Nulla metus metus</li><li>Nllamcorper vel</li><li>Tincidunt sed<ol><li>Euismod in</li><li>Nibh</li><li>Quisque volutpat<ol><li>Ad litora</li><li>Torquent per</li></ol></li><li>Condimentum velit</li></ol></li><li>Class aptent</li><li>Taciti sociosqu<ul><li>Ad litora</li><li>Torquent per</li></ul></li><li>Conubia nostra</li></ol> \
@@ -29,9 +31,17 @@ export const standard = () => ({
     </lg-content-scroll>
   `,
   props: {
-    contentWidth: text('contentWidth', '50vw'),
-    contentHeight: text('contentHeight', '90vh'),
-    mobileFullContent: boolean('mobileFullContent', true),
+    scrollContentAt: select(
+      'Minimum breakpoint where content is in scrolable region',
+      [
+        ContentScrollBreakpoints.Small,
+        ContentScrollBreakpoints.Medium,
+        ContentScrollBreakpoints.Large,
+      ],
+      ContentScrollBreakpoints.Medium,
+      'Responsive options',
+    ),
+    scrollHeight: text('scrollHeight', '90vh'),
     listNoIndent: boolean('listNoIndent', false),
   },
 });

--- a/projects/canopy/src/lib/content-scroll/index.ts
+++ b/projects/canopy/src/lib/content-scroll/index.ts
@@ -1,0 +1,2 @@
+export * from './content-scroll.component';
+export * from './content-scroll.module';

--- a/projects/canopy/src/public-api.ts
+++ b/projects/canopy/src/public-api.ts
@@ -41,4 +41,5 @@ export * from './lib/table/index';
 export * from './lib/tabs/index';
 export * from './lib/variant/index';
 export * from './lib/modal/index';
+export * from './lib/content-scroll/index';
 export * from './lib/primary-message/index';

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -5,6 +5,7 @@
 @import 'variables/components/button/main';
 @import 'variables/components/card';
 @import 'variables/components/carousel';
+@import 'variables/components/content-scroll';
 @import 'variables/components/radio';
 @import 'variables/components/data-point';
 @import 'variables/components/details';

--- a/projects/canopy/src/styles/variables/components/_content-scroll.scss
+++ b/projects/canopy/src/styles/variables/components/_content-scroll.scss
@@ -1,0 +1,3 @@
+:root {
+  --content-scroll-border-color: var(--color-platinum);
+}


### PR DESCRIPTION
# Description

Content Scroll allows you to place long content into a smaller scrollable region.
On mobile devices, the scroll region is removed and the content is displayed in full.

There are four modifiers -
  contentWidth: Set width of scroll region
  contentHeight: Set height of scroll region
  mobileFullContent: Remove scroll region on mobile devices
  listNoIndent: Remove indentation from ordered list structure

This makes it versatile enough to display general content or terms and conditions etc.

Storybook link: https://deploy-preview-496--legal-and-general-canopy.netlify.app/?path=/story/components-content-scroll--standard
