### PR TITLE
docs(usage): improves breaking change docs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -173,6 +173,8 @@ Canopy uses [semantic versioning](https://semver.org/) and a new version is depl
 
 The [releases section](https://github.com/Legal-and-General/canopy/releases) on GitHub documents the changes between releases. Keep an eye out for anything labelled as a `BREAKING CHANGE` as this may require some code changes in your application.
 
+We have provided a [guide which outlines our definition of a breaking change](./BREAKING_CHANGES.md). We avoid making too many breaking changes, and we tend to group them together into a larger release where possible. We keep an issued pinned to the top of the [issues list](https://github.com/Legal-and-General/canopy/issues) which contains upcoming breaking changes. If you notice an unintentional breaking change please do make us aware by raising an issue. 
+
 ## Logging issues
 
 If you encounter a bug or have any issue with anything to do with Canopy please do not hesitate to raise a [github issue](https://github.com/Legal-and-General/canopy/issues/new).


### PR DESCRIPTION
# Description

I noticed we didn't link to the breaking change docs from the usage guide. I created the link and updated a few extra details.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
