### PR TITLE
fix(tab-nav-bar): fix AxE Aria accessibility issue

### DIFF
--- a/projects/canopy/src/lib/tabs/tab-nav-content/tab-nav-content.component.spec.ts
+++ b/projects/canopy/src/lib/tabs/tab-nav-content/tab-nav-content.component.spec.ts
@@ -27,8 +27,9 @@ describe('LgTabNavBarComponent', () => {
       </lg-tab-nav-content>
     `);
     debugElement = fixture.debugElement;
-    component = debugElement.query(By.directive(LgTabNavContentComponent))
-      .componentInstance;
+    component = debugElement.query(
+      By.directive(LgTabNavContentComponent),
+    ).componentInstance;
     el = debugElement.query(By.directive(LgTabNavContentComponent)).nativeElement;
     fixture.detectChanges();
   });
@@ -39,6 +40,10 @@ describe('LgTabNavBarComponent', () => {
 
   it('should set default class', () => {
     expect(el.classList.contains('lg-tab-nav-content')).toBeTruthy();
+  });
+
+  it('should have the role `tabpanel`', () => {
+    expect(el.getAttribute('role')).toEqual('tabpanel');
   });
 
   it('should set the correct aria labelledby attribute', () => {

--- a/projects/canopy/src/lib/tabs/tab-nav-content/tab-nav-content.component.ts
+++ b/projects/canopy/src/lib/tabs/tab-nav-content/tab-nav-content.component.ts
@@ -10,6 +10,7 @@ export class LgTabNavContentComponent {
   @Input() selectedTabId: string;
 
   @HostBinding('class.lg-tab-nav-content') class = true;
+  @HostBinding('attr.role') ariaRole = 'tabpanel';
   @HostBinding('attr.aria-labelledby')
   get labelledBy() {
     return this.selectedTabId;


### PR DESCRIPTION
add missing role to tab-nav-content element and get rid of the AxE accessibility issue by doing that

# Description

AxE was flagging ARIA accessibility issue for the tab content. The fix was to add a role of `tabpanel` to it.

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: (link to design or delete if not required)
Screenshot: 
![Screenshot 2021-08-06 at 11 06 20](https://user-images.githubusercontent.com/68600084/128489413-b729b9ff-a170-477c-abcd-791cf259e18e.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
