### PR TITLE
fix(page): accessibility audit fixes to the skip link

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/projects/canopy/src/lib/page/page.component.html
+++ b/projects/canopy/src/lib/page/page.component.html
@@ -1,4 +1,6 @@
-<a (click)="skipToMain(target)" class="lg-page__skip-link"> Skip to main content </a>
+<a (click)="skipToMain($event, target)" class="lg-page__skip-link" href="main">
+  Skip to main content
+</a>
 <ng-content select="[lg-header]"></ng-content>
 
 <main class="lg-page__main" id="main" role="main" #target>

--- a/projects/canopy/src/lib/page/page.component.ts
+++ b/projects/canopy/src/lib/page/page.component.ts
@@ -8,7 +8,8 @@ import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 export class LgPageComponent {
   @HostBinding('class.lg-page') class = true;
 
-  public skipToMain($element) {
+  public skipToMain(event: Event, $element: HTMLElement) {
+    event.preventDefault();
     $element.focus();
   }
 }


### PR DESCRIPTION
# Description

The skip link does not link to an id via an href which has caused issues to be raised in the Axe tool and by our external accessibility testing partner. This PR adds in the missing href, but prevents the default event and continues to handle the skipping by using an event handler the way it previously did, avoiding a breaking change.

Fixes #508

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
