### PR TITLE
fix(page): add href to skip link

### DIFF
--- a/projects/canopy/src/lib/page/page.component.html
+++ b/projects/canopy/src/lib/page/page.component.html
@@ -1,4 +1,6 @@
-<a (click)="skipToMain(target)" class="lg-page__skip-link"> Skip to main content </a>
+<a (click)="skipToMain(target)" class="lg-page__skip-link" href="#main">
+  Skip to main content
+</a>
 <ng-content select="[lg-header]"></ng-content>
 
 <main class="lg-page__main" id="main" role="main" #target>

--- a/projects/canopy/src/lib/page/page.component.ts
+++ b/projects/canopy/src/lib/page/page.component.ts
@@ -8,7 +8,7 @@ import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 export class LgPageComponent {
   @HostBinding('class.lg-page') class = true;
 
-  public skipToMain($element) {
+  public skipToMain($element: HTMLElement) {
     $element.focus();
   }
 }


### PR DESCRIPTION
It has been raised by both the Axe tool and by our external accessibility partner that the skip link
need to have an id reference. This PR adds that to the skip link.

Fixes #508

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
