### PR TITLE
fix(page): fix contrast issue with skip link

### DIFF
--- a/projects/canopy/src/lib/page/page.component.scss
+++ b/projects/canopy/src/lib/page/page.component.scss
@@ -19,6 +19,7 @@
 }
 
 .lg-page__skip-link {
+  background: var(--color-white);
   @include lg-visually-hidden;
 
   &:focus,


### PR DESCRIPTION
Adding an explicit bg color of white ensures that there is sufficient contrast when implmeented by
consuming apps with background colors other than white

Fixes #431

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
