### PR TITLE
docs(gh-pages): corrects path for git add

### DIFF
--- a/.github/actions/gh-pages-storybook/index.js
+++ b/.github/actions/gh-pages-storybook/index.js
@@ -9,8 +9,6 @@ async function run () {
       core.endGroup();
     }
 
-    const buildPath = 'storybook-static';
-    
     core.info('[INFO]: commencing storybook gh-pages deploy')
 
     core.info('[INFO]: running storybook build')
@@ -27,7 +25,7 @@ async function run () {
 
     core.info('[INFO]: adding storybook static files')
     // --force: override .gitignore
-    await exec.exec('git', ['add', '--force', buildPath]);
+    await exec.exec('git', ['add', '.']);
 
     core.info('[INFO]: committing changes');
     // TODO: retrieve latest release and put it in the commit msg, token does not have privileges


### PR DESCRIPTION
# Description

This should be the last tweak the get the GitHub pages deploy working.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
