### PR TITLE
docs(netlify): redirects master deployment to GitHub pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
   command = "npm run build-storybook"
   publish = "storybook-static"
+[[redirects]]
+  from = "https://legal-and-general-canopy.netlify.app/"
+  to = "https://legal-and-general.github.io/canopy/"
+  status = 301
+  force = true


### PR DESCRIPTION
# Description

Redirects the master branch deployment from netlify to GitHub pages. 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
