### PR TITLE
docs(deployments): updates netlify/gh-pages deployment docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,15 +14,11 @@ Running `npm start` will run storybook locally, this will hot reload any changes
 
 ### Netlify Deployments
 
-Pull requests are automatically deployed via [Netlify](https://netlify.com), a status check will be added to any pull request with a link to the deployment which will run the storybook application. [Netlify config](./netlify.toml) is checked into the project
+Pull requests are automatically deployed via [Netlify](https://netlify.com), a status check will be added to any pull request with a link to the deployment which will run the storybook application. [Netlify config](../netlify.toml) is checked into the project
 
-The master branch is also deployed to netlify, this currently provides the most up to date documentation for the latest version.
+The master branch is also deployed to [GitHub Pages](https://pages.github.com/), this currently provides the most up to date documentation for the latest version. This deployment is handled by a custom [GitHub action](../.github/actions/gh-pages-storybook)
 
-https://legal-and-general-canopy.netlify.app/
-
-When seeking QA approval for your work please provide a link on the PR to the specific component in question, e.g.
-
-https://legal-and-general-canopy.netlify.app/?path=/story/components-button--primary-button
+https://legal-and-general.github.io/canopy
 
 ## Build
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -163,7 +163,7 @@ import cssVars from 'css-vars-ponyfill';
 
 ## Using the components
 
-Each components is individually documented on Storybook, refer to the latest version which is available at https://legal-and-general-canopy.netlify.app/
+Each components is individually documented on Storybook, refer to the latest version which is available at https://legal-and-general.github.io/canopy/
 
 The `notes` tab explains the usage of each component. The `story` tab displays the code required to render that particular documentation page, and is a useful reference point.
 


### PR DESCRIPTION
This content is true at the time of writing but will be subject to change. I have left the Netlify docs in there for the moment.



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
