### PR TITLE
fix(details): remove flex from the status icon

### DIFF
--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
@@ -34,7 +34,6 @@
   }
 
   &__state-icon {
-    display: flex;
     margin-left: auto;
     margin-right: var(--space-xxs);
     padding-left: var(--space-xxs);


### PR DESCRIPTION
# Description

Remove the `display: flex` from the chevron icon on the right of the details component as it was causing an issue with the size of the icon itself.

Before:
<img width="938" alt="Screenshot 2021-08-25 at 12 10 55" src="https://user-images.githubusercontent.com/8397116/130773862-9cf695dc-6212-4431-b430-f41033ceecb9.png">

After:
<img width="944" alt="Screenshot 2021-08-25 at 12 12 19" src="https://user-images.githubusercontent.com/8397116/130773872-c6682834-cd96-4a05-9f2b-a91e95d2fd57.png">


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
