### PR TITLE
fix(side-nav): add correct zindex to side nav content for focus

### DIFF
--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.spec.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.spec.ts
@@ -25,4 +25,8 @@ describe('LgSideNavContentComponent', () => {
   it('should contain the default class', () => {
     expect(fixture.nativeElement.getAttribute('class')).toContain('lg-side-nav-content');
   });
+
+  it('should contain the tab index', () => {
+    expect(fixture.nativeElement.getAttribute('tabindex')).toEqual('-1');
+  });
 });

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.ts
@@ -14,5 +14,5 @@ import {
 })
 export class LgSideNavContentComponent {
   @HostBinding('class.lg-side-nav-content') class = true;
-  @HostBinding('tabindex') tabindex = 0;
+  @HostBinding('tabindex') tabindex = -1;
 }


### PR DESCRIPTION
# Description

Adds the correct tabindex of -1 to the content so that it can be focused without affecting the tab order of the page

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
