### PR TITLE
feat(footer): include ID in footer link model

### DIFF
--- a/projects/canopy/src/lib/footer/footer.component.html
+++ b/projects/canopy/src/lib/footer/footer.component.html
@@ -9,6 +9,7 @@
       <li *ngFor="let link of primaryLinks" class="lg-footer__primary-nav-item">
         <a
           (click)="handlePrimaryLinkClick($event)"
+          [attr.id]="link.id"
           [attr.href]="link.href"
           [attr.target]="link.target || '_blank'"
           class="lg-footer__nav-link"
@@ -29,6 +30,7 @@
       <li *ngFor="let link of secondaryLinks" class="lg-footer__secondary-nav-item">
         <a
           (click)="handleSecondaryLinkClick($event)"
+          [attr.id]="link.id"
           [attr.href]="link.href"
           [attr.target]="link.target || '_blank'"
           class="lg-footer__nav-link"

--- a/projects/canopy/src/lib/footer/footer.component.spec.ts
+++ b/projects/canopy/src/lib/footer/footer.component.spec.ts
@@ -11,9 +11,11 @@ describe('FooterComponent', () => {
   const logoAlt = 'logo alt';
   const text1 = 'test1';
   const href1 = 'https://a.b';
+  const id1 = 'test-1';
 
   const text2 = 'test2';
   const href2 = 'https://b.c';
+  const id2 = 'test-2';
 
   beforeEach(
     waitForAsync(() => {
@@ -26,8 +28,8 @@ describe('FooterComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LgFooterComponent);
     component = fixture.componentInstance;
-    component.primaryLinks = [{ text: text1, href: href1 }];
-    component.secondaryLinks = [{ text: text2, href: href2 }];
+    component.primaryLinks = [{ text: text1, href: href1, id: id1 }];
+    component.secondaryLinks = [{ text: text2, href: href2, id: id2 }];
     component.logo = logo;
 
     fixture.detectChanges();
@@ -76,6 +78,7 @@ describe('FooterComponent', () => {
       const link = fixture.debugElement.query(By.css(`[href="${href1}"]`));
       expect(link).toBeTruthy();
       expect(link.attributes.href).toBe(href1);
+      expect(link.attributes.id).toBe(id1);
     });
 
     it('does not throw an error when no links are provided', () => {
@@ -101,8 +104,9 @@ describe('FooterComponent', () => {
     it('emits an event when clicked', () => {
       let selectedHref: string;
       component.primaryLinkClicked.subscribe((event: Event) => {
-        selectedHref = (event.target as HTMLLinkElement).attributes.getNamedItem('href')
-          .value;
+        selectedHref = (event.target as HTMLLinkElement).attributes.getNamedItem(
+          'href',
+        ).value;
         event.preventDefault();
       });
 
@@ -117,6 +121,7 @@ describe('FooterComponent', () => {
       const link = fixture.debugElement.query(By.css(`[href="${href2}"]`));
       expect(link).toBeTruthy();
       expect(link.attributes.href).toBe(href2);
+      expect(link.attributes.id).toBe(id2);
     });
 
     it('does not throw an error when no links are provided', () => {
@@ -142,8 +147,9 @@ describe('FooterComponent', () => {
     it('emits an event when clicked', () => {
       let selectedHref: string;
       component.secondaryLinkClicked.subscribe((event: Event) => {
-        selectedHref = (event.target as HTMLLinkElement).attributes.getNamedItem('href')
-          .value;
+        selectedHref = (event.target as HTMLLinkElement).attributes.getNamedItem(
+          'href',
+        ).value;
         event.preventDefault();
       });
 

--- a/projects/canopy/src/lib/footer/footer.component.ts
+++ b/projects/canopy/src/lib/footer/footer.component.ts
@@ -7,11 +7,8 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-interface Link {
-  text: string;
-  href: string;
-  target?: string;
-}
+import { Link } from './footer.model';
+
 @Component({
   selector: '[lg-footer]',
   templateUrl: './footer.component.html',

--- a/projects/canopy/src/lib/footer/footer.model.ts
+++ b/projects/canopy/src/lib/footer/footer.model.ts
@@ -1,0 +1,6 @@
+export interface Link {
+  text: string;
+  href: string;
+  id?: string;
+  target?: string;
+}

--- a/projects/canopy/src/lib/footer/footer.notes.ts
+++ b/projects/canopy/src/lib/footer/footer.notes.ts
@@ -35,8 +35,8 @@ and in your HTML:
 | \`\`logo\`\` | A url link to the logo | string | null | Yes |
 | \`\`logoAlt\`\` | alt text to display alongside the logo | string | '2rem' | Yes |
 | \`\`copyright\`\` | Copyright text to display in footer | string | null | No |
-| \`\`primaryLinks\`\` | The primary footer links | \`[{ text: string, href: string }]\` | null | No |
-| \`\`secondaryLinks\`\` | The secondary footer links | \`[{ text: string, href: string }]\` | null | No |
+| \`\`primaryLinks\`\` | The primary footer links | \`[{ text: string, href: string, id?: string, target?: string }]\` | null | No |
+| \`\`secondaryLinks\`\` | The secondary footer links | \`[{ text: string, href: string, id?: string, target?: string }]\` | null | No |
 
 ## Outputs
 

--- a/projects/canopy/src/lib/footer/footer.stories.ts
+++ b/projects/canopy/src/lib/footer/footer.stories.ts
@@ -25,16 +25,28 @@ export default {
 };
 
 export const primaryLinks = [
-  { text: 'My account', href: 'https://app.somecompany.com' },
-  { text: 'My quotes', href: 'https://somecompany.com/quotes' },
-  { text: 'Support centre', href: 'https://somecompany.com/support' },
-  { text: 'Contact', href: 'https://somecompany.com/contact' },
+  { id: 'primary-link-1', text: 'My account', href: 'https://app.somecompany.com' },
+  { id: 'primary-link-2', text: 'My quotes', href: 'https://somecompany.com/quotes' },
+  {
+    id: 'primary-link-3',
+    text: 'Support centre',
+    href: 'https://somecompany.com/support',
+  },
+  { id: 'primary-link-4', text: 'Contact', href: 'https://somecompany.com/contact' },
 ];
 
 export const secondaryLinks = [
-  { text: 'Accessibility', href: 'https://somecompany.com/accessibility' },
-  { text: 'Security', href: 'https://somecompany.com/security' },
-  { text: 'Legal and regulatory', href: 'https://somecompany.com/legal' },
+  {
+    id: 'secondary-link-1',
+    text: 'Accessibility',
+    href: 'https://somecompany.com/accessibility',
+  },
+  { id: 'secondary-link-2', text: 'Security', href: 'https://somecompany.com/security' },
+  {
+    id: 'secondary-link-3',
+    text: 'Legal and regulatory',
+    href: 'https://somecompany.com/legal',
+  },
 ];
 
 const groupId = 'footer';


### PR DESCRIPTION

# Description


Updated the footer inputs for primary and secondary links, so that they can accept and render an ID
value

Storybook link: (once netlify has deployed link provide a link to the component)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
