### PR TITLE
fix(page): sets tabindex on skip link to 0

### DIFF
--- a/projects/canopy/src/lib/page/page.component.html
+++ b/projects/canopy/src/lib/page/page.component.html
@@ -1,4 +1,9 @@
-<a (click)="skipToMain($event, target)" class="lg-page__skip-link" href="#main">
+<a
+  (click)="skipToMain($event, target)"
+  class="lg-page__skip-link"
+  href="#main"
+  tabindex="0"
+>
   Skip to main content
 </a>
 <ng-content select="[lg-header]"></ng-content>


### PR DESCRIPTION
The skip link needs a tab index of 0 so that it can be focused before all other focusable elements

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
