### PR TITLE
Export link model and set z order for skip link

### DIFF
--- a/projects/canopy/src/lib/footer/index.ts
+++ b/projects/canopy/src/lib/footer/index.ts
@@ -1,2 +1,3 @@
 export * from './footer.component';
 export * from './footer.module';
+export * from './footer.model';

--- a/projects/canopy/src/lib/page/page.component.scss
+++ b/projects/canopy/src/lib/page/page.component.scss
@@ -28,5 +28,6 @@
     clip: auto !important;
     width: auto !important;
     height: auto !important;
+    z-index: var(--z-index-skip-link);
   }
 }

--- a/projects/canopy/src/styles/variables/_main.scss
+++ b/projects/canopy/src/styles/variables/_main.scss
@@ -13,6 +13,7 @@
   --z-index-modal-overlay: 1000;
   --z-index-modal: 1010;
   --z-index-carousel-autoplay: 1;
+  --z-index-skip-link: 1020;
 
   /* Animation */
   --animation-duration: 0.25s;


### PR DESCRIPTION
# Description

This PR adds the z-order for `skip to main content` link also export the footer model.

Storybook link: (once netlify has deployed link provide a link to the component)
Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
