### PR TITLE
fix(primary-message): add style for when a heading is used

### DIFF
--- a/projects/canopy/src/lib/primary-message/primary-message-title/primary-message-title.component.scss
+++ b/projects/canopy/src/lib/primary-message/primary-message-title/primary-message-title.component.scss
@@ -1,11 +1,24 @@
 @import '../../../styles/mixins';
 
-.lg-primary-message-title {
+@mixin primary-message-title() {
   display: block;
   margin-top: var(--space-sm);
   @include lg-font-size('3');
 
   @include lg-breakpoint(md) {
     margin-top: var(--space-md);
+  }
+}
+
+.lg-primary-message-title {
+  @include primary-message-title;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @include primary-message-title;
   }
 }


### PR DESCRIPTION
# Description

This fixes the issue when using a heading within the title of the `primary-message` component where the styles of the title where not applied.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
