### PR TITLE
fix(footer-component): removes extra space from underline on link hover

### DIFF
--- a/projects/canopy/src/lib/footer/footer.component.html
+++ b/projects/canopy/src/lib/footer/footer.component.html
@@ -14,8 +14,8 @@
           [attr.target]="link.target || '_blank'"
           class="lg-footer__nav-link"
           rel="noopener"
+          [innerHTML]="link.text"
         >
-          {{ link.text }}
         </a>
       </li>
     </ul>
@@ -35,8 +35,8 @@
           [attr.target]="link.target || '_blank'"
           class="lg-footer__nav-link"
           rel="noopener"
+          [innerHTML]="link.text"
         >
-          {{ link.text }}
         </a>
       </li>
     </ul>


### PR DESCRIPTION
# Description
Removes extra space from underline on link hover

Please briefly outline any requirements for the work which may aid the testing and review process.

Storybook link: (once netlify has deployed link provide a link to the component)
Screenshot: 
Before the fix, we were able to see some spaces when we hover on the link
![image](https://user-images.githubusercontent.com/11988774/132523639-bab4a535-6eb4-4df6-b398-b623969b11a3.png)

After this change it looks like this:

![image](https://user-images.githubusercontent.com/11988774/132523610-d2d87a9d-7896-43d6-9629-f74a8dd13eb2.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)

