### PR TITLE
fix(page): add max width to page to fix page scrolling at 200% zoom

### DIFF
--- a/projects/canopy/src/lib/page/page.component.scss
+++ b/projects/canopy/src/lib/page/page.component.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   background: var(--page-bg-color);
   min-height: 100%;
+  max-width: 100vw;
 }
 
 .lg-page__main {


### PR DESCRIPTION
On a low resolution device zoomed at 200%, page content scrolls horizontally. Setting the max-width
to 100vw solves this issue.

This was raised as an issue by our accessibility testers.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
