### PR TITLE
fix(buttons): update hover state of outline-primary

### DIFF
--- a/projects/canopy/src/styles/variables/components/button/_button-outline.scss
+++ b/projects/canopy/src/styles/variables/components/button/_button-outline.scss
@@ -5,8 +5,8 @@
   --btn-outline-primary-active-bg-color: var(--color-charcoal);
   --btn-outline-primary-active-border-color: var(--color-charcoal);
   --btn-outline-primary-active-color: var(--color-white);
-  --btn-outline-primary-hover-bg-color: var(--color-taupe-grey);
-  --btn-outline-primary-hover-border-color: var(--color-taupe-grey);
+  --btn-outline-primary-hover-bg-color: var(--color-battleship-grey);
+  --btn-outline-primary-hover-border-color: var(--color-battleship-grey);
   --btn-outline-primary-hover-color: var(--color-white);
 
   --btn-outline-secondary-bg-color: var(--color-charcoal);


### PR DESCRIPTION
# Description

The hover state colour of the `outline-primary` button was flagged by DIG as inaccessible.
This is a temporary solution (suggested by James) while the designers review all the buttons styles.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
