### PR TITLE
ci(master-push): use Node version 14 on release job

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -46,7 +46,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2.4.0
         with:
-          node-version: 12
+          node-version: 14
       - name: install dependencies
         run: npm ci
       - name: build


### PR DESCRIPTION
# Description

Latest push to master after the update to Semantic Release failed on `release` because now Node 14 is a requirement. 

This updates the job to run on Node v14.
