### PR TITLE
fix(spinner): add screen reader alert message

### DIFF
--- a/projects/canopy/src/lib/canopy.module.ts
+++ b/projects/canopy/src/lib/canopy.module.ts
@@ -48,6 +48,7 @@ import { LgTableModule } from './table/table.module';
 import { LgTabsModule } from './tabs/tabs.module';
 import { LgVariantModule } from './variant/variant.module';
 import { LgPrimaryMessageModule } from './primary-message/primary-message.module';
+import { LgSrAlertMessageModule } from './sr-alert-message';
 
 const modules = [
   LgAccordionModule,
@@ -82,6 +83,7 @@ const modules = [
   LgPrefixModule,
   LgPromoCardModule,
   LgQuickActionModule,
+  LgSrAlertMessageModule,
   LgSeparatorModule,
   LgShowAtModule,
   LgSideNavModule,

--- a/projects/canopy/src/lib/spinner/spinner.component.html
+++ b/projects/canopy/src/lib/spinner/spinner.component.html
@@ -5,7 +5,6 @@
     'lg-spinner__ring--light': variant === 'light',
     'lg-spinner__ring--inherit': variant === 'inherit'
   }"
-  role="alert"
   aria-busy="true"
 ></div>
 
@@ -16,7 +15,8 @@
     'lg-spinner__content--light': variant === 'light'
   }"
 >
-  {{ text }}
+  <span aria-hidden="true">{{ text }}</span>
+  <span class="lg-visually-hidden">{{ text }}</span>
 </p>
 
 <ng-template #defaultText>

--- a/projects/canopy/src/lib/spinner/spinner.component.spec.ts
+++ b/projects/canopy/src/lib/spinner/spinner.component.spec.ts
@@ -1,16 +1,30 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { ChangeDetectorRef } from '@angular/core';
+
+import { instance, mock } from 'ts-mockito';
 
 import { LgSpinnerComponent } from './spinner.component';
 
 describe('LgSpinnerComponent', () => {
   let component: LgSpinnerComponent;
   let fixture: ComponentFixture<LgSpinnerComponent>;
+  let cdrMock: ChangeDetectorRef;
 
   beforeEach(
     waitForAsync(() => {
+      cdrMock = mock(ChangeDetectorRef);
+
       TestBed.configureTestingModule({
         declarations: [LgSpinnerComponent],
+        providers: [{ provide: ChangeDetectorRef, useValue: instance(cdrMock) }],
       }).compileComponents();
     }),
   );
@@ -18,7 +32,6 @@ describe('LgSpinnerComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LgSpinnerComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -35,6 +48,7 @@ describe('LgSpinnerComponent', () => {
   });
 
   it('adds the small size variant to the component', () => {
+    fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.getAttribute('class')).not.toContain(
       'lg-spinner--sm',
     );
@@ -48,6 +62,7 @@ describe('LgSpinnerComponent', () => {
   describe('text input', () => {
     describe('when not specified', () => {
       it('should add a visually hidden element with default text', () => {
+        fixture.detectChanges();
         const hiddenEl = fixture.nativeElement.querySelector('.lg-visually-hidden');
         const textEl = fixture.nativeElement.querySelector('.lg-spinner__content');
 
@@ -63,12 +78,57 @@ describe('LgSpinnerComponent', () => {
         fixture.detectChanges();
 
         const hiddenEl = fixture.nativeElement.querySelector('.lg-visually-hidden');
-        const textEl = fixture.nativeElement.querySelector('.lg-spinner__content');
+        const textEl = fixture.nativeElement.querySelector(
+          '.lg-spinner__content > span[aria-hidden="true"]',
+        );
 
-        expect(hiddenEl).toBeNull();
+        expect(hiddenEl.innerText).not.toEqual('Loading...');
         expect(textEl).toBeDefined();
         expect(textEl.innerText).toBe('Test text');
       });
+    });
+  });
+
+  describe('readScreenReaderAlert', () => {
+    beforeEach(() => {
+      jasmine.clock().uninstall();
+      jasmine.clock().install();
+    });
+
+    it('should be toggled every few seconds', fakeAsync(() => {
+      component.ngOnInit();
+      expect(component.readScreenReaderAlert).toBe(true);
+
+      tick(1000);
+      expect(component.readScreenReaderAlert).toBe(true);
+      tick(1500);
+      expect(component.readScreenReaderAlert).toBe(false);
+      discardPeriodicTasks();
+    }));
+
+    describe('when set to false', () => {
+      it('should remove the role and aria-live attributes', fakeAsync(() => {
+        component.ngOnInit();
+        tick(2500);
+        fixture.detectChanges();
+
+        expect(component.readScreenReaderAlert).toBe(false);
+        expect(fixture.nativeElement.getAttribute('role')).toBeNull();
+        expect(fixture.nativeElement.getAttribute('aria-live')).toBeNull();
+        discardPeriodicTasks();
+      }));
+    });
+
+    describe('when set to true', () => {
+      it('should add the role and aria-live attributes', fakeAsync(() => {
+        tick(1000);
+        fixture.detectChanges();
+
+        expect(component.readScreenReaderAlert).toBe(true);
+        expect(fixture.nativeElement.getAttribute('role')).toBe('alert');
+        expect(fixture.nativeElement.getAttribute('aria-live')).toBe('assertive');
+        discardPeriodicTasks();
+      }));
     });
   });
 });

--- a/projects/canopy/src/lib/spinner/spinner.component.ts
+++ b/projects/canopy/src/lib/spinner/spinner.component.ts
@@ -1,14 +1,26 @@
-import { Component, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  HostBinding,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewEncapsulation,
+} from '@angular/core';
 
-import type { SpinnerVariant, SpinnerSize } from './spinner.interface';
+import { interval, Subscription } from 'rxjs';
+
+import type { SpinnerSize, SpinnerVariant } from './spinner.interface';
 
 @Component({
   selector: 'lg-spinner',
   templateUrl: './spinner.component.html',
   styleUrls: ['./spinner.component.scss'],
   encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgSpinnerComponent {
+export class LgSpinnerComponent implements OnInit, OnDestroy {
   @HostBinding('class.lg-spinner') class = true;
 
   @Input() variant: SpinnerVariant = 'dark';
@@ -23,4 +35,34 @@ export class LgSpinnerComponent {
    * https://github.com/angular/angular/issues/26083#issuecomment-425227938.
    */
   @Input() text: string;
+
+  readScreenReaderAlert = true;
+  private subscription: Subscription;
+
+  @HostBinding('attr.role') get role() {
+    if (this.readScreenReaderAlert) {
+      return 'alert';
+    }
+    return null;
+  }
+
+  @HostBinding('attr.aria-live') get ariaLive() {
+    if (this.readScreenReaderAlert) {
+      return 'assertive';
+    }
+    return null;
+  }
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit(): void {
+    this.subscription = interval(2500).subscribe(() => {
+      this.readScreenReaderAlert = !this.readScreenReaderAlert;
+      this.cdr.markForCheck();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
 }

--- a/projects/canopy/src/lib/spinner/spinner.module.ts
+++ b/projects/canopy/src/lib/spinner/spinner.module.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { LgSrAlertMessageModule } from '../sr-alert-message/sr-alert-message.module';
 import { LgSpinnerComponent } from './spinner.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, LgSrAlertMessageModule],
   declarations: [LgSpinnerComponent],
   exports: [LgSpinnerComponent],
 })

--- a/projects/canopy/src/lib/spinner/spinner.notes.ts
+++ b/projects/canopy/src/lib/spinner/spinner.notes.ts
@@ -8,7 +8,7 @@ They are normally used on form submissions or loading cards when the data retrie
 ## Usage
 Import the component in your application:
 
-~~~
+~~~js
 @NgModule({
   ...
   imports: [LgSpinnerModule],
@@ -17,9 +17,16 @@ Import the component in your application:
 
 and in your HTML:
 
+~~~html
+# Display a spinner while loading
+<lg-spinner *ngIf="!loaded"></lg-spinner>
+
+# Tell screen reader to read a message when loading is finished
+<p [lgSrAlertMessage]="loaded">Loading complete</p>
 ~~~
-<lg-spinner></lg-spinner>
-~~~
+
+As per the example above the spinner component should always be used together with the \`\`LgSrAlertMessageDirective\`\` as screen reader users should
+be notified when something has finished loading.
 
 ## Inputs
 

--- a/projects/canopy/src/lib/sr-alert-message/index.ts
+++ b/projects/canopy/src/lib/sr-alert-message/index.ts
@@ -1,0 +1,2 @@
+export * from './sr-alert-message.directive';
+export * from './sr-alert-message.module';

--- a/projects/canopy/src/lib/sr-alert-message/sr-alert-message.directive.spec.ts
+++ b/projects/canopy/src/lib/sr-alert-message/sr-alert-message.directive.spec.ts
@@ -1,0 +1,114 @@
+import { ChangeDetectorRef, Component, DebugElement, Input } from '@angular/core';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { instance, mock } from 'ts-mockito';
+
+import { LgSrAlertMessageDirective } from './sr-alert-message.directive';
+
+@Component({
+  template: ` <p [lgSrAlertMessage]="lgSrAlertMessage">Test feature</p> `,
+})
+class TestComponent {
+  @Input() lgSrAlertMessage;
+}
+
+describe('lgSrAlertMessage', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let directive: LgSrAlertMessageDirective;
+  let testElement: DebugElement;
+  let component: TestComponent;
+  let cdrMock: ChangeDetectorRef;
+
+  beforeEach(
+    waitForAsync(() => {
+      cdrMock = mock(ChangeDetectorRef);
+
+      TestBed.configureTestingModule({
+        declarations: [TestComponent, LgSrAlertMessageDirective],
+        providers: [{ provide: ChangeDetectorRef, useValue: instance(cdrMock) }],
+      }).compileComponents();
+    }),
+  );
+
+  beforeEach(
+    waitForAsync(() => {
+      fixture = TestBed.createComponent(TestComponent);
+      component = fixture.componentInstance;
+      testElement = fixture.debugElement.query(By.directive(LgSrAlertMessageDirective));
+      directive = testElement.injector.get(LgSrAlertMessageDirective);
+    }),
+  );
+
+  it('should have the class to visually hide the element', () => {
+    component.lgSrAlertMessage = true;
+    fixture.detectChanges();
+
+    expect(testElement.nativeElement.getAttribute('class')).toContain(
+      'lg-visually-hidden',
+    );
+  });
+
+  describe('when lgSrAlertMessage is set to false', () => {
+    beforeEach(() => {
+      component.lgSrAlertMessage = false;
+      fixture.detectChanges();
+    });
+
+    it('should have an aria-hidden attribute set to true', () => {
+      expect(testElement.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it("shouldn't have a role or aria-live attribute", () => {
+      expect(testElement.nativeElement.getAttribute('role')).toBeNull();
+      expect(testElement.nativeElement.getAttribute('aria-live')).toBeNull();
+    });
+  });
+
+  describe('when lgSrAlertMessage is set to true', () => {
+    beforeEach(() => {
+      component.lgSrAlertMessage = true;
+      fixture.detectChanges();
+    });
+
+    it('should have an aria-hidden attribute set to false', () => {
+      expect(testElement.nativeElement.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('should have a role and an aria-live attribute', () => {
+      expect(testElement.nativeElement.getAttribute('role')).toBe('alert');
+      expect(testElement.nativeElement.getAttribute('aria-live')).toBe('assertive');
+    });
+  });
+
+  describe('on init', () => {
+    it('should set lgSrAlertMessage to false after the default amount of time', fakeAsync(() => {
+      component.lgSrAlertMessage = true;
+      fixture.detectChanges();
+      tick(7000);
+
+      expect(directive.lgSrAlertMessage).toBe(true);
+      tick(8000);
+
+      expect(directive.lgSrAlertMessage).toBe(false);
+    }));
+
+    it('should set lgSrAlertMessage to false after the amount of time specified with the timer input', fakeAsync(() => {
+      component.lgSrAlertMessage = true;
+      directive.timer = 5000;
+      fixture.detectChanges();
+      tick(4000);
+
+      expect(directive.lgSrAlertMessage).toBe(true);
+      tick(5000);
+
+      expect(directive.lgSrAlertMessage).toBe(false);
+    }));
+  });
+});

--- a/projects/canopy/src/lib/sr-alert-message/sr-alert-message.directive.ts
+++ b/projects/canopy/src/lib/sr-alert-message/sr-alert-message.directive.ts
@@ -1,0 +1,52 @@
+import {
+  ChangeDetectorRef,
+  Directive,
+  HostBinding,
+  Input,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+
+import { Subscription, timer } from 'rxjs';
+
+@Directive({
+  selector: `[lgSrAlertMessage]`,
+})
+export class LgSrAlertMessageDirective implements OnInit, OnDestroy {
+  @Input() lgSrAlertMessage: boolean;
+  @Input() timer = 8000;
+  private subscription: Subscription;
+
+  @HostBinding('class.lg-visually-hidden') class = true;
+
+  @HostBinding('attr.aria-hidden') get ariaHidden() {
+    return !this.lgSrAlertMessage;
+  }
+
+  @HostBinding('attr.role') get role() {
+    if (this.lgSrAlertMessage) {
+      return 'alert';
+    }
+    return null;
+  }
+
+  @HostBinding('attr.aria-live') get ariaLive() {
+    if (this.lgSrAlertMessage) {
+      return 'assertive';
+    }
+    return null;
+  }
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit(): void {
+    this.subscription = timer(this.timer).subscribe(() => {
+      this.lgSrAlertMessage = false;
+      this.cdr.detectChanges();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/projects/canopy/src/lib/sr-alert-message/sr-alert-message.module.ts
+++ b/projects/canopy/src/lib/sr-alert-message/sr-alert-message.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { LgSrAlertMessageDirective } from './sr-alert-message.directive';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [LgSrAlertMessageDirective],
+  exports: [LgSrAlertMessageDirective],
+})
+export class LgSrAlertMessageModule {}

--- a/projects/canopy/src/lib/sr-alert-message/sr-alert-message.notes.ts
+++ b/projects/canopy/src/lib/sr-alert-message/sr-alert-message.notes.ts
@@ -1,0 +1,42 @@
+export const notes = `
+# Screen Reader Alert Message Directive
+
+## Purpose
+This directive allows for temporary visually hidden alert messages to be read out by screen readers. For example when something has finished loading.
+
+## Usage
+
+Import the module in your application:
+
+~~~js
+@NgModule({
+  ...
+  imports: [LgSrAlertMessageModule],
+})
+~~~
+
+In your HTML apply the directive to the relevant element.
+
+Pass in a boolean value to indicate when the message should be read out. When \`\`true\`\` the message will be read by the screen reader and will be removed after a set period (default is 8000ms).
+
+~~~html
+<p [lgSrAlertMessage]="true|false">Loading complete</p>
+~~~
+
+This directive can be used together with the \`\`LgSpinnerComponent\`\` to show a spinner while something is loading and then send a message to screen readers when it has finished loading.
+
+~~~html
+# Display a spinner while loading
+<lg-spinner *ngIf="!loaded"></lg-spinner>
+
+# Tell screen reader to read a message when loading is finished
+<p [lgSrAlertMessage]="loaded">Loading complete</p>
+~~~
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| \`\`lgSrAlertMessage\`\` | Whether the message should be read or not | \`\`boolean\`\` | null | Yes |
+| \`\`timer\`\` | The time (in ms) that needs to pass before the message become hidden to screen readers | \`\`number\`\` | 8000 | No |
+`;

--- a/projects/canopy/src/lib/sr-alert-message/sr-alert-message.stories.ts
+++ b/projects/canopy/src/lib/sr-alert-message/sr-alert-message.stories.ts
@@ -1,0 +1,29 @@
+import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/angular';
+
+import { notes } from './sr-alert-message.notes';
+import { LgSrAlertMessageDirective } from './sr-alert-message.directive';
+
+const stories = storiesOf('Directives', module);
+
+stories.addDecorator(withKnobs);
+
+stories.add(
+  'Screen reader alert message',
+  () => ({
+    moduleMetadata: {
+      declarations: [LgSrAlertMessageDirective],
+    },
+    template: `
+        <p [lgSrAlertMessage]="read">Loading complete</p>
+      `,
+    props: {
+      read: boolean('read message', false),
+    },
+  }),
+  {
+    notes: {
+      markdown: notes,
+    },
+  },
+);

--- a/projects/canopy/src/public-api.ts
+++ b/projects/canopy/src/public-api.ts
@@ -35,6 +35,7 @@ export * from './lib/shadow/index';
 export * from './lib/show-at/index';
 export * from './lib/side-nav/index';
 export * from './lib/skeleton/index';
+export * from './lib/sr-alert-message/index';
 export * from './lib/spacing/index';
 export * from './lib/spinner/index';
 export * from './lib/suffix/index';


### PR DESCRIPTION
# Description

Add functionality to the spinner so that screen readers users get updated every 6 seconds on the state.
This was raised during an accessibility audit.

https://user-images.githubusercontent.com/8397116/136986411-719ca045-7146-4fc5-b5db-f794815b3624.mov

Updated with loading complete:

https://user-images.githubusercontent.com/8397116/137956477-a4827d4b-b40e-482b-b94f-bde2713e3f74.mov

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
