### PR TITLE
feat(feature-toggle): upgrade story to CSF format

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
   stories: [
     '../projects/canopy/src/lib/alert/alert.stories.ts',
+    '../projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts',
   ],
   addons: [
     '@storybook/addon-links',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,8 +27,9 @@ export const parameters = {
     expanded: true
   },
   backgrounds: {
+    default: 'Default',
     values: [
-      { name: 'Default', value: 'transparent', default: true },
+      { name: 'Default', value: 'transparent' },
       { name: 'Midnight Blue', value: '#005380' },
       { name: 'Charcoal', value: '#333' },
       { name: 'Super Blue', value: '#0076d6' },

--- a/documentation.json
+++ b/documentation.json
@@ -23743,151 +23743,7 @@
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-c3f914cc5ff5dceb09857f6f1cfd4180-1",
-            "file": "projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts",
-            "encapsulation": [],
-            "entryComponents": [],
-            "inputs": [],
-            "outputs": [],
-            "providers": [],
-            "selector": "lg-reactive-form",
-            "styleUrls": [],
-            "styles": [],
-            "template": "<form [formGroup]=\"form\">\n  <lg-filter-multiple-group formControlName=\"colors\">\n    {{ label }}\n    <lg-toggle value=\"red\">Red</lg-toggle>\n    <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n    <lg-toggle value=\"green\">Green</lg-toggle>\n    <lg-toggle value=\"blue\">Blue</lg-toggle>\n  </lg-filter-multiple-group>\n</form>\n",
-            "templateUrl": [],
-            "viewProviders": [],
-            "inputsClass": [
-                {
-                    "name": "disabled",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 28,
-                    "type": "boolean"
-                },
-                {
-                    "name": "label",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 26,
-                    "type": "string"
-                }
-            ],
-            "outputsClass": [
-                {
-                    "name": "checkboxChange",
-                    "defaultValue": "new EventEmitter()",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 39,
-                    "type": "EventEmitter<void>"
-                }
-            ],
-            "propertiesClass": [
-                {
-                    "name": "fb",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormBuilder",
-                    "optional": false,
-                    "description": "",
-                    "line": 43,
-                    "modifierKind": [
-                        123
-                    ]
-                },
-                {
-                    "name": "form",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormGroup",
-                    "optional": false,
-                    "description": "",
-                    "line": 41
-                }
-            ],
-            "methodsClass": [],
-            "deprecated": false,
-            "deprecationMessage": "",
-            "hostBindings": [],
-            "hostListeners": [],
-            "description": "",
-            "rawdescription": "\n",
-            "type": "component",
-            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { action } from '@storybook/addon-actions';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { moduleMetadata } from '@storybook/angular';\n\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './checkbox-group.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-filter-multiple-group formControlName=\"colors\">\n        {{ label }}\n        <lg-toggle value=\"red\">Red</lg-toggle>\n        <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n        <lg-toggle value=\"green\">Green</lg-toggle>\n        <lg-toggle value=\"blue\">Blue</lg-toggle>\n      </lg-filter-multiple-group>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() label: string;\n  @Input()\n  set disabled(isDisabled: boolean) {\n    if (isDisabled === true) {\n      this.form.controls.colors.disable();\n    } else {\n      this.form.controls.colors.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.colors.disabled;\n  }\n\n  @Output() checkboxChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({ colors: this.fb.control(['red']) });\n    this.form.valueChanges.subscribe((val) => this.checkboxChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Filter Buttons',\n  parameters: {\n    decorators: [\n      withKnobs,\n      moduleMetadata({\n        declarations: [ReactiveFormComponent],\n        imports: [ReactiveFormsModule, CanopyModule],\n      }),\n    ],\n    notes: {\n      markdown: notes('Filter', 'filter-multiple'),\n    },\n  },\n};\nexport const selectMultiple = () => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    label: text('label', 'Select colors'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n  },\n});\n",
-            "assetsDirs": [],
-            "styleUrlsData": "",
-            "stylesData": "",
-            "constructorObj": {
-                "name": "constructor",
-                "description": "",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "args": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": ""
-                    }
-                ],
-                "line": 41,
-                "jsdoctags": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "tagName": {
-                            "text": "param"
-                        }
-                    }
-                ]
-            },
-            "accessors": {
-                "disabled": {
-                    "name": "disabled",
-                    "setSignature": {
-                        "name": "disabled",
-                        "type": "void",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "args": [
-                            {
-                                "name": "isDisabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": ""
-                            }
-                        ],
-                        "returnType": "void",
-                        "line": 28,
-                        "jsdoctags": [
-                            {
-                                "name": "isDisabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": "",
-                                "tagName": {
-                                    "text": "param"
-                                }
-                            }
-                        ]
-                    },
-                    "getSignature": {
-                        "name": "disabled",
-                        "type": "boolean",
-                        "returnType": "boolean",
-                        "line": 35
-                    }
-                }
-            },
-            "isDuplicate": true,
-            "duplicateId": 1,
-            "duplicateName": "ReactiveFormComponent-1"
-        },
-        {
-            "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-2af65b95dd2fba2a15db16813f570923-2",
+            "id": "component-ReactiveFormComponent-2af65b95dd2fba2a15db16813f570923-1",
             "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -24045,6 +23901,150 @@
                         "type": "boolean",
                         "returnType": "boolean",
                         "line": 37
+                    }
+                }
+            },
+            "isDuplicate": true,
+            "duplicateId": 1,
+            "duplicateName": "ReactiveFormComponent-1"
+        },
+        {
+            "name": "ReactiveFormComponent",
+            "id": "component-ReactiveFormComponent-c3f914cc5ff5dceb09857f6f1cfd4180-2",
+            "file": "projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lg-reactive-form",
+            "styleUrls": [],
+            "styles": [],
+            "template": "<form [formGroup]=\"form\">\n  <lg-filter-multiple-group formControlName=\"colors\">\n    {{ label }}\n    <lg-toggle value=\"red\">Red</lg-toggle>\n    <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n    <lg-toggle value=\"green\">Green</lg-toggle>\n    <lg-toggle value=\"blue\">Blue</lg-toggle>\n  </lg-filter-multiple-group>\n</form>\n",
+            "templateUrl": [],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "disabled",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 28,
+                    "type": "boolean"
+                },
+                {
+                    "name": "label",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 26,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "checkboxChange",
+                    "defaultValue": "new EventEmitter()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 39,
+                    "type": "EventEmitter<void>"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "fb",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormBuilder",
+                    "optional": false,
+                    "description": "",
+                    "line": 43,
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "form",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormGroup",
+                    "optional": false,
+                    "description": "",
+                    "line": 41
+                }
+            ],
+            "methodsClass": [],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { action } from '@storybook/addon-actions';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { moduleMetadata } from '@storybook/angular';\n\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './checkbox-group.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-filter-multiple-group formControlName=\"colors\">\n        {{ label }}\n        <lg-toggle value=\"red\">Red</lg-toggle>\n        <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n        <lg-toggle value=\"green\">Green</lg-toggle>\n        <lg-toggle value=\"blue\">Blue</lg-toggle>\n      </lg-filter-multiple-group>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() label: string;\n  @Input()\n  set disabled(isDisabled: boolean) {\n    if (isDisabled === true) {\n      this.form.controls.colors.disable();\n    } else {\n      this.form.controls.colors.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.colors.disabled;\n  }\n\n  @Output() checkboxChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({ colors: this.fb.control(['red']) });\n    this.form.valueChanges.subscribe((val) => this.checkboxChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Filter Buttons',\n  parameters: {\n    decorators: [\n      withKnobs,\n      moduleMetadata({\n        declarations: [ReactiveFormComponent],\n        imports: [ReactiveFormsModule, CanopyModule],\n      }),\n    ],\n    notes: {\n      markdown: notes('Filter', 'filter-multiple'),\n    },\n  },\n};\nexport const selectMultiple = () => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    label: text('label', 'Select colors'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n  },\n});\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "args": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": ""
+                    }
+                ],
+                "line": 41,
+                "jsdoctags": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "accessors": {
+                "disabled": {
+                    "name": "disabled",
+                    "setSignature": {
+                        "name": "disabled",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "isDisabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 28,
+                        "jsdoctags": [
+                            {
+                                "name": "isDisabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "disabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 35
                     }
                 }
             },
@@ -24523,165 +24523,7 @@
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-50d7afa6e8971c1ef656db2a20f0daba-5",
-            "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-            "encapsulation": [],
-            "entryComponents": [],
-            "inputs": [],
-            "outputs": [],
-            "providers": [],
-            "selector": "lg-reactive-form",
-            "styleUrls": [],
-            "styles": [],
-            "template": "<form [formGroup]=\"form\">\n  <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n  </lg-sort-code>\n</form>\n",
-            "templateUrl": [],
-            "viewProviders": [],
-            "inputsClass": [
-                {
-                    "name": "disabled",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 29,
-                    "type": "boolean"
-                },
-                {
-                    "name": "focus",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 26,
-                    "type": "boolean"
-                },
-                {
-                    "name": "hint",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 24,
-                    "type": "string"
-                },
-                {
-                    "name": "label",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 25,
-                    "type": "string"
-                }
-            ],
-            "outputsClass": [
-                {
-                    "name": "inputChange",
-                    "defaultValue": "new EventEmitter<void>()",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 40,
-                    "type": "EventEmitter"
-                }
-            ],
-            "propertiesClass": [
-                {
-                    "name": "fb",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormBuilder",
-                    "optional": false,
-                    "description": "",
-                    "line": 44,
-                    "modifierKind": [
-                        123
-                    ]
-                },
-                {
-                    "name": "form",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormGroup",
-                    "optional": false,
-                    "description": "",
-                    "line": 42
-                }
-            ],
-            "methodsClass": [],
-            "deprecated": false,
-            "deprecationMessage": "",
-            "hostBindings": [],
-            "hostListeners": [],
-            "description": "",
-            "rawdescription": "\n",
-            "type": "component",
-            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata } from '@storybook/angular';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { action } from '@storybook/addon-actions';\n\nimport { LgSortCodeComponent } from './sort-code.component';\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './sort-code.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n      </lg-sort-code>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n  @Input() focus: boolean;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled) {\n      this.form.controls.sortCode.disable();\n    } else {\n      this.form.controls.sortCode.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.sortCode.disabled;\n  }\n\n  @Output() inputChange = new EventEmitter<void>();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      sortCode: [''],\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Sort Code',\n  component: LgSortCodeComponent,\n  decorators: [\n    withKnobs,\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, CanopyModule],\n    }),\n  ],\n  parameters: {\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n});\n",
-            "assetsDirs": [],
-            "styleUrlsData": "",
-            "stylesData": "",
-            "constructorObj": {
-                "name": "constructor",
-                "description": "",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "args": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": ""
-                    }
-                ],
-                "line": 42,
-                "jsdoctags": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "tagName": {
-                            "text": "param"
-                        }
-                    }
-                ]
-            },
-            "accessors": {
-                "disabled": {
-                    "name": "disabled",
-                    "setSignature": {
-                        "name": "disabled",
-                        "type": "void",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "args": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": ""
-                            }
-                        ],
-                        "returnType": "void",
-                        "line": 29,
-                        "jsdoctags": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": "",
-                                "tagName": {
-                                    "text": "param"
-                                }
-                            }
-                        ]
-                    },
-                    "getSignature": {
-                        "name": "disabled",
-                        "type": "boolean",
-                        "returnType": "boolean",
-                        "line": 36
-                    }
-                }
-            },
-            "isDuplicate": true,
-            "duplicateId": 5,
-            "duplicateName": "ReactiveFormComponent-5"
-        },
-        {
-            "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-58c496c2e7f18b071e4677d85e360314-6",
+            "id": "component-ReactiveFormComponent-58c496c2e7f18b071e4677d85e360314-5",
             "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -24941,6 +24783,164 @@
                         "type": "",
                         "returnType": "",
                         "line": 246
+                    }
+                }
+            },
+            "isDuplicate": true,
+            "duplicateId": 5,
+            "duplicateName": "ReactiveFormComponent-5"
+        },
+        {
+            "name": "ReactiveFormComponent",
+            "id": "component-ReactiveFormComponent-50d7afa6e8971c1ef656db2a20f0daba-6",
+            "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lg-reactive-form",
+            "styleUrls": [],
+            "styles": [],
+            "template": "<form [formGroup]=\"form\">\n  <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n  </lg-sort-code>\n</form>\n",
+            "templateUrl": [],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "disabled",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 29,
+                    "type": "boolean"
+                },
+                {
+                    "name": "focus",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 26,
+                    "type": "boolean"
+                },
+                {
+                    "name": "hint",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 24,
+                    "type": "string"
+                },
+                {
+                    "name": "label",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 25,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "inputChange",
+                    "defaultValue": "new EventEmitter<void>()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 40,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "fb",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormBuilder",
+                    "optional": false,
+                    "description": "",
+                    "line": 44,
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "form",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormGroup",
+                    "optional": false,
+                    "description": "",
+                    "line": 42
+                }
+            ],
+            "methodsClass": [],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata } from '@storybook/angular';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { action } from '@storybook/addon-actions';\n\nimport { LgSortCodeComponent } from './sort-code.component';\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './sort-code.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n      </lg-sort-code>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n  @Input() focus: boolean;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled) {\n      this.form.controls.sortCode.disable();\n    } else {\n      this.form.controls.sortCode.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.sortCode.disabled;\n  }\n\n  @Output() inputChange = new EventEmitter<void>();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      sortCode: [''],\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Sort Code',\n  component: LgSortCodeComponent,\n  decorators: [\n    withKnobs,\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, CanopyModule],\n    }),\n  ],\n  parameters: {\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n});\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "args": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": ""
+                    }
+                ],
+                "line": 42,
+                "jsdoctags": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "accessors": {
+                "disabled": {
+                    "name": "disabled",
+                    "setSignature": {
+                        "name": "disabled",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 29,
+                        "jsdoctags": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "disabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 36
                     }
                 }
             },
@@ -29795,21 +29795,21 @@
                 "name": "components",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/carousel/carousel.module.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "[]",
-                "defaultValue": "[LgCarouselItemComponent, LgCarouselComponent, LgAutoplayComponent]"
-            },
-            {
-                "name": "components",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/card/card.module.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
                 "defaultValue": "[\n  LgCardComponent,\n  LgCardHeaderComponent,\n  LgCardTitleComponent,\n  LgCardFooterComponent,\n  LgCardSubtitleComponent,\n  LgCardPrincipleDataPointComponent,\n  LgCardPrincipleDataPointLabelComponent,\n  LgCardPrincipleDataPointValueComponent,\n  LgCardPrincipleDataPointDateComponent,\n  LgCardContentComponent,\n]"
+            },
+            {
+                "name": "components",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/carousel/carousel.module.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "[]",
+                "defaultValue": "[LgCarouselItemComponent, LgCarouselComponent, LgAutoplayComponent]"
             },
             {
                 "name": "components",
@@ -29825,21 +29825,21 @@
                 "name": "components",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/primary-message/primary-message.module.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "[]",
-                "defaultValue": "[\n  LgPrimaryMessageComponent,\n  LgPrimaryMessageTitleComponent,\n  LgPrimaryMessageDescriptionComponent,\n]"
-            },
-            {
-                "name": "components",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/promo-card/promo-card.module.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
                 "defaultValue": "[\n  LgPromoCardComponent,\n  LgPromoCardListComponent,\n  LgPromoCardTitleComponent,\n  LgPromoCardFooterComponent,\n  LgPromoCardContentComponent,\n  LgPromoCardImageComponent,\n  LgPromoCardListTitleComponent,\n]"
+            },
+            {
+                "name": "components",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/primary-message/primary-message.module.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "[]",
+                "defaultValue": "[\n  LgPrimaryMessageComponent,\n  LgPrimaryMessageTitleComponent,\n  LgPrimaryMessageDescriptionComponent,\n]"
             },
             {
                 "name": "components",
@@ -29895,7 +29895,7 @@
                 "name": "context",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/test.ts",
+                "file": "projects/canopy-test-app/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -29905,7 +29905,7 @@
                 "name": "context",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy-test-app/src/test.ts",
+                "file": "projects/canopy/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -30032,6 +30032,26 @@
                 "defaultValue": "() => ({\n  template: `<story-table-detail [books]=\"books\" [variant]=\"variant\" [alignPublishColumn]=\"alignPublishColumn\" [showAuthorLabel]=\"showAuthorLabel\" [columnBreakpoint]=\"columnBreakpoint\"></story-table-detail>`,\n\n  props: {\n    books: object('Books', getDefaultTableContent(), 'Table data'),\n    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),\n    alignPublishColumn: select(\n      'Align Publish column',\n      [AlignmentOptions.Start, AlignmentOptions.End],\n      AlignmentOptions.End,\n      'Alignment',\n    ),\n    columnBreakpoint: select(\n      'Minimum breakpoint where column layout is used',\n      [\n        TableColumnLayoutBreakpoints.Small,\n        TableColumnLayoutBreakpoints.Medium,\n        TableColumnLayoutBreakpoints.Large,\n      ],\n      TableColumnLayoutBreakpoints.Medium,\n      'Responsive options',\n    ),\n    showAuthorLabel: boolean(\n      'Display author label in non-columns view',\n      false,\n      'Responsive options',\n    ),\n  },\n})"
             },
             {
+                "name": "featureToggle",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "featureToggleTemplate.bind({})"
+            },
+            {
+                "name": "featureToggleTemplate",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story<LgFeatureToggleDirective>",
+                "defaultValue": "(args: LgFeatureToggleDirective) => ({\n  component: LgFeatureToggleDirective,\n  props: args,\n  template,\n})"
+            },
+            {
                 "name": "firstColGroupId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -30135,21 +30155,21 @@
                 "name": "groupId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/header/header.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "string",
-                "defaultValue": "'header'"
-            },
-            {
-                "name": "groupId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/heading/heading.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "string",
                 "defaultValue": "'lg-heading'"
+            },
+            {
+                "name": "groupId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/header/header.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "string",
+                "defaultValue": "'header'"
             },
             {
                 "name": "groupId",
@@ -33275,7 +33295,7 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
+                "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33285,7 +33305,7 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
+                "file": "projects/canopy/src/lib/forms/label/label.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33305,7 +33325,7 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/label/label.component.ts",
+                "file": "projects/canopy/src/lib/forms/toggle/toggle.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33335,27 +33355,27 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/toggle/toggle.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33385,16 +33405,6 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/styles/grid.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Grid\n\n## Purpose\nProvides responsive grid system.\n\nThe grid system is useful for responsive page layouts, we recommend that it is used sparingly, for the majority of cases you may be better off just using using flexbox.\n\nThe grid system is based on a subset of the excellent [flexboxgrid](http://flexboxgrid.com/) by [kristoferjoseph](http://github.com/kristoferjoseph).\nThe code is a direct port with some additional modifications to:\n\n- Add 'lg-' prefixes to reduce risk of clash with existing libraries\n- Modify spacing variables to match our own spacing system\n- Force all containers to be fluid width\n- Remove parts of the grid which we may not need\n\n## Usage\nImport the css into the angular.json file of your application, the grid classes should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\nA set of [Angular directives](/?path=/story/directives--grid) are also supplied which can be used to add grid classes to native HTML and Canopy elements.\n\nThere are also two utility directives available which allow you to show/hide components at different breakpoints:\n- [LgShowAt](/?path=/story/directives--show-at)\n- [LgHideAt](/?path=/story/directives--hide-at)\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/styles/links.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -33410,6 +33420,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Mixins\n\n## Purpose\nProvides available mixins\n\n## Mixins\n### lg-inner-focus-outline($bg-color, $color: var(--color-white))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\n\\`\\`$color\\`\\`: colour of the outline.\n\nSets the focus outline inside the element, by using multiple box shadows.\n\n### lg-outer-focus-outline($bg-color: var(--default-focus-color))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\nSets the focus outline outside the element, by using box shadows.\n\n### lg-link($default-color, $hover-color, $visited-color, $active-color, $active-bg-color, $focus-color, $focus-bg-color)\n\\`\\`$default-color\\`\\`: the default color of the element (default value: \\`\\`var(--link-color)\\`\\`).\n\n\\`\\`$hover-color\\`\\`: the hover color of the element (default value: \\`\\`var(--link-hover-color)\\`\\`).\n\n\\`\\`$visited-color\\`\\`: the visited color of the element (default value: \\`\\`var(--link-visited-color)\\`\\`).\n\n\\`\\`$active-color\\`\\`: the active color of the element (default value: \\`\\`var(--link-active-color)\\`\\`).\n\n\\`\\`$active-bg-color\\`\\`: the active background color of the element (default value: \\`\\`var(--link-active-bg-color)\\`\\`).\n\n\\`\\`$focus-color\\`\\`: the focus color color of the element (default value: \\`\\`var(--link-focus-color)\\`\\`).\n\n\\`\\`$focus-bg-color\\`\\`: the focus background color of the element (default value: \\`\\`var(--link-focus-bg-color)\\`\\`).\n\nStyles elements with the link style.\n\n### lg-unstyled-link\nRevert the links styles added with \\`\\`lg-link\\`\\`.\n\n### lg-font-size($size)\n\\`\\`$size\\`\\`: The font size, '7' | '6' | '5' | '4' | '3' | '2' | '1' | '-8' | '-6' | .\n\nStyles text to one of the predefined font sizes. '-8' and '-6' are the sub body font sizes.\n\n### lg-visually-hidden()\nProvides styles to hide information intended only for screen readers from the layout of the rendered page.\n\n### lg-breakpoint($breakpoint)\n\\`\\`$breakpoint\\`\\`: string value for the breakpoint screen size.\n\nAllows breakpoints to be added to css blocks.\n\n### lg-variant($variant: 'generic')\n\\`\\`$variant\\`\\`: The variant type, 'generic' | 'info' | 'success' | 'warning' | 'error'.\n\nStyles components and native child elements to the specified variant.\n\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/styles/grid.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Grid\n\n## Purpose\nProvides responsive grid system.\n\nThe grid system is useful for responsive page layouts, we recommend that it is used sparingly, for the majority of cases you may be better off just using using flexbox.\n\nThe grid system is based on a subset of the excellent [flexboxgrid](http://flexboxgrid.com/) by [kristoferjoseph](http://github.com/kristoferjoseph).\nThe code is a direct port with some additional modifications to:\n\n- Add 'lg-' prefixes to reduce risk of clash with existing libraries\n- Modify spacing variables to match our own spacing system\n- Force all containers to be fluid width\n- Remove parts of the grid which we may not need\n\n## Usage\nImport the css into the angular.json file of your application, the grid classes should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\nA set of [Angular directives](/?path=/story/directives--grid) are also supplied which can be used to add grid classes to native HTML and Canopy elements.\n\nThere are also two utility directives available which allow you to show/hide components at different breakpoints:\n- [LgShowAt](/?path=/story/directives--show-at)\n- [LgHideAt](/?path=/story/directives--hide-at)\n`"
             },
             {
                 "name": "notes",
@@ -33455,11 +33475,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/alert/alert.notes.ts",
+                "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
+                "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
             },
             {
                 "name": "notes",
@@ -33475,16 +33495,6 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/button/button.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -33495,11 +33505,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
+                "file": "projects/canopy/src/lib/alert/alert.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
+                "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -33515,11 +33525,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
+                "file": "projects/canopy/src/lib/footer/footer.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
+                "defaultValue": "`\n# Footer Component\n\n## Purpose\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<footer\n  lg-footer\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  copyright=\"© Some Company plc 2018\">\n</footer>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`copyright\\`\\` | Copyright text to display in footer | string | null | No |\n| \\`\\`primaryLinks\\`\\` | The primary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n| \\`\\`secondaryLinks\\`\\` | The secondary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`primaryLinkClicked\\`\\` | Event emitted when a primary link is clicked | EventEmitter<any> | n/a | No |\n| \\`\\`secondaryLinkClicked\\`\\` | Event emitted when a secondary link is clicked | EventEmitter<any> | n/a | No |\n`"
             },
             {
                 "name": "notes",
@@ -33530,6 +33540,26 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Details Component\n\n\n## Purpose\nThe Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgDetailsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-details [isActive]=\"expand\">\n  <lg-details-panel-heading [headingLevel]=\"5\">\n    How do I change my payment details?\n  </lg-details-panel-heading>\n  Give us a call on 0800 123 4567 and we'll be happy to help you change\n  your payment details\n</lg-details>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Expand the details | boolean | false | no |\n| \\`\\`headingLevel\\`\\` | The level of the details heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n|\\`\\`variant\\`\\`| Applies colour treatment and ARIA role if applicable: \\`\\`generic\\`\\`, \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'generic' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display on the warning, error or success variants | boolean | true | No |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the details are opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the details are closed | EventEmitter<void> | n/a | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
             },
             {
                 "name": "notes",
@@ -33555,31 +33585,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/footer/footer.notes.ts",
+                "file": "projects/canopy/src/lib/hero/hero.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Footer Component\n\n## Purpose\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<footer\n  lg-footer\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  copyright=\"© Some Company plc 2018\">\n</footer>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`copyright\\`\\` | Copyright text to display in footer | string | null | No |\n| \\`\\`primaryLinks\\`\\` | The primary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n| \\`\\`secondaryLinks\\`\\` | The secondary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`primaryLinkClicked\\`\\` | Event emitted when a primary link is clicked | EventEmitter<any> | n/a | No |\n| \\`\\`secondaryLinkClicked\\`\\` | Event emitted when a secondary link is clicked | EventEmitter<any> | n/a | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/grid/grid.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/header/header.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Header Component\n\n## Purpose\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<header\n  lg-header\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  logoHref=\"http://company.com\">\n</header>\n~~~\n\n## Inputs\n\n### LgHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`logoHref\\`\\` | Url link if the logo is clickable | string | null | No |\n`"
+                "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -33595,21 +33605,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/hero/hero.notes.ts",
+                "file": "projects/canopy/src/lib/header/header.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
+                "defaultValue": "`\n# Header Component\n\n## Purpose\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<header\n  lg-header\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  logoHref=\"http://company.com\">\n</header>\n~~~\n\n## Inputs\n\n### LgHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`logoHref\\`\\` | Url link if the logo is clickable | string | null | No |\n`"
             },
             {
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/hide-at/hide-at.notes.ts",
+                "file": "projects/canopy/src/lib/grid/grid.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Hide At Directive\n\n## Purpose\nThis directive allows for media quieries to be added to components, so they can be hidden at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to hide a component on wider viewports, such as desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgShowAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHideAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgHideAt=\"sm\">\n  <lg-card-content>\n    I get hidden at \"sm\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgHideAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
+                "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
             },
             {
                 "name": "notes",
@@ -33625,31 +33635,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/hide-at/hide-at.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Hide At Directive\n\n## Purpose\nThis directive allows for media quieries to be added to components, so they can be hidden at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to hide a component on wider viewports, such as desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgShowAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHideAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgHideAt=\"sm\">\n  <lg-card-content>\n    I get hidden at \"sm\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgHideAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/modal/modal.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Modal Component\n\n\n## Purpose\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Lorem ipsum</lg-modal-header>\n  <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nfor a timout modal you can use the following structure:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Logout</lg-modal-header>\n  <lg-modal-body>\n    For your security, we'll log yuo out in:\n    <lg-modal-body-timer timer=\"0:58\"></lg-modal-body-timer>\n  </lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nOpening and closing the modal is also possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/page/page.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/primary-message/primary-message.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Primary Message Component\n\n\n## Purpose\nThe Primary Message is used to communicate key information to the user.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPrimaryMessageModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-primary-message>\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title>\n      This is a primary message\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">Call to action</button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`hasRole\\`\\` | If false, removes the role \\`\\`alert\\`\\` from the component | boolean | true | No |\n\n`"
             },
             {
                 "name": "notes",
@@ -33675,21 +33675,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/separator/separator.notes.ts",
+                "file": "projects/canopy/src/lib/page/page.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Separator Component\n\n\n## Purpose\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-separator></lg-separator>\n\n<lg-separator variant='dotted'></lg-separator>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of separator: \\`\\`solid\\`\\`, \\`\\`dotted\\`\\` | SeparatorVariant | 'solid' | No |\n| \\`\\`hasRole\\`\\` | If true, adds a role of \\`\\`separator\\`\\` to the component | boolean | false | No |\n`"
+                "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
             },
             {
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/shadow/shadow.notes.ts",
+                "file": "projects/canopy/src/lib/primary-message/primary-message.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Shadow Directive\n\n## Purpose\nThis directive adds a box shadow to a component.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShadowModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShadow>\n  <lg-card-content>\n    This card has a shadow\n  </lg-card-content>\n</lg-card>\n~~~\n\n`"
+                "defaultValue": "`\n# Primary Message Component\n\n\n## Purpose\nThe Primary Message is used to communicate key information to the user.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPrimaryMessageModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-primary-message>\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title>\n      This is a primary message\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">Call to action</button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`hasRole\\`\\` | If false, removes the role \\`\\`alert\\`\\` from the component | boolean | true | No |\n\n`"
             },
             {
                 "name": "notes",
@@ -33705,21 +33705,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
+                "file": "projects/canopy/src/lib/separator/separator.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Show At Directive\n\n## Purpose\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShowAt=\"md\">\n  <lg-card-content>\n    I get dispalayed at the \"md\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgShowAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
+                "defaultValue": "`\n# Separator Component\n\n\n## Purpose\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-separator></lg-separator>\n\n<lg-separator variant='dotted'></lg-separator>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of separator: \\`\\`solid\\`\\`, \\`\\`dotted\\`\\` | SeparatorVariant | 'solid' | No |\n| \\`\\`hasRole\\`\\` | If true, adds a role of \\`\\`separator\\`\\` to the component | boolean | false | No |\n`"
             },
             {
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/skeleton/skeleton.notes.ts",
+                "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Skeleton Loading Directive\n\n## Purpose\nThe skeleton directive adds a skeleton loading state to a component or element.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSkeletonModule],\n})\n~~~\n\nThe directive works on components that output text or projected content. On composite components that\nare made up of other child components, it is best to add the skeleton loading directive to the child\ncomponents or even wrap the projected content inside another element. E.g. In the example,\nthe \\`lg-data-point-label\\` projects the content into an \\`lg-heading\\` component,\nso the directive is added to a span wrapping the content. However, the \\`lg-data-point-value\\` component\nsimply projects the content only so the directive can be applied to the component itself.\n\n~~~html\n<lg-data-point>\n  <lg-data-point-label [headingLevel]=\"4\">\n    <span lgSkeleton lgSkeletonWidth=\"10\">{{ data?.label }}</span>\n  </lg-data-point-label>\n  <lg-data-point-value lgSkeleton lgSkeletonWidth=\"8\">\n    {{ data?.value }}\n  </lg-data-point-value>\n</lg-data-point>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgSkeletonWidth\\`\\` | Override the default width with the desired value in ems | string | 100% | No |\n| \\`\\`lgSkeletonHeight\\`\\` | Override the default height with the desired value in ems | string | auto | No |\n\n`"
+                "defaultValue": "`\n# Show At Directive\n\n## Purpose\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShowAt=\"md\">\n  <lg-card-content>\n    I get dispalayed at the \"md\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgShowAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
             },
             {
                 "name": "notes",
@@ -33735,6 +33735,26 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/shadow/shadow.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Shadow Directive\n\n## Purpose\nThis directive adds a box shadow to a component.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShadowModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShadow>\n  <lg-card-content>\n    This card has a shadow\n  </lg-card-content>\n</lg-card>\n~~~\n\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/skeleton/skeleton.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Skeleton Loading Directive\n\n## Purpose\nThe skeleton directive adds a skeleton loading state to a component or element.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSkeletonModule],\n})\n~~~\n\nThe directive works on components that output text or projected content. On composite components that\nare made up of other child components, it is best to add the skeleton loading directive to the child\ncomponents or even wrap the projected content inside another element. E.g. In the example,\nthe \\`lg-data-point-label\\` projects the content into an \\`lg-heading\\` component,\nso the directive is added to a span wrapping the content. However, the \\`lg-data-point-value\\` component\nsimply projects the content only so the directive can be applied to the component itself.\n\n~~~html\n<lg-data-point>\n  <lg-data-point-label [headingLevel]=\"4\">\n    <span lgSkeleton lgSkeletonWidth=\"10\">{{ data?.label }}</span>\n  </lg-data-point-label>\n  <lg-data-point-value lgSkeleton lgSkeletonWidth=\"8\">\n    {{ data?.value }}\n  </lg-data-point-value>\n</lg-data-point>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgSkeletonWidth\\`\\` | Override the default width with the desired value in ems | string | 100% | No |\n| \\`\\`lgSkeletonHeight\\`\\` | Override the default height with the desired value in ems | string | auto | No |\n\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/table/table.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -33745,21 +33765,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/variant/variant.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
             },
             {
                 "name": "notes",
@@ -33805,31 +33825,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Sort Code Component\n\n## Purpose\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/toggle/toggle.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "(name: string) => `\n# ${name} Component\n\n## Purpose\nProvides a ${name} component for boolean form controls. The ${name} component is a variant of the Toggle component.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgToggleModule ],\n})\n~~~\n\nand in your HTML for a regular *checkbox*:\n\n~~~html\n<lg-toggle formControlName=\"confirm\" value=\"yes\" variant=\"${name.toLowerCase()}\">Do you agree?</lg-toggle>\n~~~\n\nor\n\n~~~html\n<lg-${name.toLowerCase()} formControlName=\"confirm\" value=\"yes\">Do you agree?</lg-${name.toLowerCase()}>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`value\\`\\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`variant\\`\\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |\n| \\`\\`focus\\`\\` | Set the focus on the input field | boolean | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
             },
             {
                 "name": "notes",
@@ -33855,11 +33865,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
+                "defaultValue": "`\n# Sort Code Component\n\n## Purpose\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
             },
             {
                 "name": "notes",
@@ -33875,11 +33885,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
+                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+                "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -33890,6 +33900,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
             },
             {
                 "name": "offsets",
@@ -33919,7 +33939,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "LgFeatureToggleOptions",
-                "defaultValue": "{\n  // disable undefined feature e.g. Feature 4 in the following story\n  defaultHide: true,\n}"
+                "defaultValue": "{\n  // disable undefined feature e.g. Feature 2 in the following story\n  defaultHide: true,\n}"
             },
             {
                 "name": "outlinePrimary",
@@ -34055,7 +34075,7 @@
                 "name": "require",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/test.ts",
+                "file": "projects/canopy-test-app/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "literal type"
@@ -34064,7 +34084,7 @@
                 "name": "require",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy-test-app/src/test.ts",
+                "file": "projects/canopy/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "literal type"
@@ -34203,7 +34223,7 @@
                 "name": "spaces",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
@@ -34213,7 +34233,7 @@
                 "name": "spaces",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
@@ -34263,31 +34283,11 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/carousel/carousel.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [slideDuration]=\"slideDuration\">${carouselItems}</lg-carousel>`,\n  props: props(),\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/card/card.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "() => ({\n  template: `\n    <lg-card>\n      <lg-card-header>\n        <lg-card-title headingLevel=\"4\">\n          {{title}}\n        </lg-card-title>\n      </lg-card-header>\n      <lg-card-content>\n        {{cardContent}} <a href=\"#\">Test link</a>.\n      </lg-card-content>\n    </lg-card>\n  `,\n  props: {\n    title: text('title', 'Card title'),\n    cardContent: text(\n      'cardContent',\n      `Leverage agile frameworks to provide a robust synopsis for high level\n    overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall\n    value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity\n    and empowerment.`,\n    ),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/details/details.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-details\n      [isActive]=\"expand\"\n      [variant]=\"variant\"\n      [showIcon]=\"showIcon\"\n      (opened)=\"toggle('Detail opened')\"\n      (closed)=\"toggle('Detail closed')\">\n      <lg-details-panel-heading [headingLevel]=\"headingLevel\">{{ header }}</lg-details-panel-heading>\n      Give us a call on <a href=\"tel:08001234567\">0800 123 4567</a> and we'll be happy to help you change your\n      payment details\n    </lg-details>\n  `,\n  props: {\n    header: text('Header', 'How do I change my payment details?'),\n    expand: boolean('Default expand', false),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 5),\n    toggle: action('Details active state change'),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'generic',\n    ),\n    showIcon: boolean('Show icon (warning, success & error variants only)', true),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -34303,11 +34303,21 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/header/header.stories.ts",
+                "file": "projects/canopy/src/lib/details/details.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n  `,\n  props: {\n    logo: text('logo', 'legal-and-general-logo.svg', groupId),\n    logoAlt: text('logoAlt', 'Company name', groupId),\n    logoHref: text('logoHref', 'https://storybook.js.org', groupId),\n  },\n})"
+                "defaultValue": "() => ({\n  template: `\n    <lg-details\n      [isActive]=\"expand\"\n      [variant]=\"variant\"\n      [showIcon]=\"showIcon\"\n      (opened)=\"toggle('Detail opened')\"\n      (closed)=\"toggle('Detail closed')\">\n      <lg-details-panel-heading [headingLevel]=\"headingLevel\">{{ header }}</lg-details-panel-heading>\n      Give us a call on <a href=\"tel:08001234567\">0800 123 4567</a> and we'll be happy to help you change your\n      payment details\n    </lg-details>\n  `,\n  props: {\n    header: text('Header', 'How do I change my payment details?'),\n    expand: boolean('Default expand', false),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 5),\n    toggle: action('Details active state change'),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'generic',\n    ),\n    showIcon: boolean('Show icon (warning, success & error variants only)', true),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/carousel/carousel.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [slideDuration]=\"slideDuration\">${carouselItems}</lg-carousel>`,\n  props: props(),\n})"
             },
             {
                 "name": "standard",
@@ -34318,6 +34328,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "() => ({\n  template: `\n    <lg-heading\n      [level]=\"level\">\n      {{content}}\n    </lg-heading>\n  `,\n  props: {\n    content: text('text', 'Heading', groupId),\n    level: select('level', [1, 2, 3, 4, 5, 6], 1, groupId),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/header/header.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n  `,\n  props: {\n    logo: text('logo', 'legal-and-general-logo.svg', groupId),\n    logoAlt: text('logoAlt', 'Company name', groupId),\n    logoHref: text('logoHref', 'https://storybook.js.org', groupId),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -34353,21 +34373,21 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/separator/separator.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-separator [variant]=\"variant\" [hasRole]=\"hasRole\"></lg-separator>\n  `,\n  props: {\n    variant: select('variant', ['solid', 'dotted'], 'solid', ''),\n    hasRole: boolean('hasRole', false),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/side-nav/side-nav.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "() => ({\n  template: '<story-side-nav [navItems]=\"navItems\"></story-side-nav>',\n  props: {\n    navItems: object('Navs', getDefaultNavItems()),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/separator/separator.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <lg-separator [variant]=\"variant\" [hasRole]=\"hasRole\"></lg-separator>\n  `,\n  props: {\n    variant: select('variant', ['solid', 'dotted'], 'solid', ''),\n    hasRole: boolean('hasRole', false),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -34443,16 +34463,6 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/radio/segment.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-segment\n    [stack]=\"stack === 'false' ? false : stack\"\n    [disabled]=\"disabled\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    [secondButtonLabel]=\"secondButtonLabel\"\n    (segmentChange)=\"segmentChange($event)\">\n  </lg-reactive-form-segment>\n  `,\n  props: {\n    label: text('label', 'Select a color'),\n    secondButtonLabel: text('secondButtonLabel', 'Yellow'),\n    segmentChange: action('segmentChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n    stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/radio/radio.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34463,21 +34473,11 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                "file": "projects/canopy/src/lib/forms/radio/segment.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
+                "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-segment\n    [stack]=\"stack === 'false' ? false : stack\"\n    [disabled]=\"disabled\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    [secondButtonLabel]=\"secondButtonLabel\"\n    (segmentChange)=\"segmentChange($event)\">\n  </lg-reactive-form-segment>\n  `,\n  props: {\n    label: text('label', 'Select a color'),\n    secondButtonLabel: text('secondButtonLabel', 'Yellow'),\n    segmentChange: action('segmentChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n    stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -34503,6 +34503,16 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34520,6 +34530,16 @@
                 "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
             },
             {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
+            },
+            {
                 "name": "standardAlert",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -34528,16 +34548,6 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "alertTemplate.bind({})"
-            },
-            {
-                "name": "stories",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "storiesOf('Directives', module)"
             },
             {
                 "name": "stories",
@@ -34573,16 +34583,6 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "storiesOf('Pipes', module)"
-            },
-            {
-                "name": "stories",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34593,7 +34593,17 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "storiesOf('Pipes', module)"
+            },
+            {
+                "name": "stories",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -34603,7 +34613,7 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -34638,6 +34648,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n<lg-alert\n  [showIcon]=\"showIcon\"\n  [variant]=\"variant\">\n  {{content}} Here is some <a href=\"#\"> link text</a>.\n</lg-alert>\n`"
+            },
+            {
+                "name": "template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n  <lg-card *lgFeatureToggle=\"'firstFeature'\"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>\n  <lg-card *lgFeatureToggle=\"'secondFeature'\"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>\n  <lg-card *lgFeatureToggle=\"'thirdFeature'\"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>\n  <lg-card *lgFeatureToggle=\"'fourthFeature'\"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>\n`"
             },
             {
                 "name": "textWithIcon",
@@ -36376,18 +36396,6 @@
                     "defaultValue": "[\n  LgAccordionComponent,\n  LgAccordionItemComponent,\n  LgAccordionPanelHeadingComponent,\n  LgAccordionItemContentDirective,\n]"
                 }
             ],
-            "projects/canopy/src/lib/carousel/carousel.module.ts": [
-                {
-                    "name": "components",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/carousel/carousel.module.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[LgCarouselItemComponent, LgCarouselComponent, LgAutoplayComponent]"
-                }
-            ],
             "projects/canopy/src/lib/card/card.module.ts": [
                 {
                     "name": "components",
@@ -36398,6 +36406,18 @@
                     "deprecationMessage": "",
                     "type": "[]",
                     "defaultValue": "[\n  LgCardComponent,\n  LgCardHeaderComponent,\n  LgCardTitleComponent,\n  LgCardFooterComponent,\n  LgCardSubtitleComponent,\n  LgCardPrincipleDataPointComponent,\n  LgCardPrincipleDataPointLabelComponent,\n  LgCardPrincipleDataPointValueComponent,\n  LgCardPrincipleDataPointDateComponent,\n  LgCardContentComponent,\n]"
+                }
+            ],
+            "projects/canopy/src/lib/carousel/carousel.module.ts": [
+                {
+                    "name": "components",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/carousel/carousel.module.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[LgCarouselItemComponent, LgCarouselComponent, LgAutoplayComponent]"
                 }
             ],
             "projects/canopy/src/lib/modal/modal.module.ts": [
@@ -36412,18 +36432,6 @@
                     "defaultValue": "[\n  LgModalComponent,\n  LgModalTriggerDirective,\n  LgModalHeaderComponent,\n  LgModalBodyComponent,\n  LgModalFooterComponent,\n  LgModalBodyTimerComponent,\n]"
                 }
             ],
-            "projects/canopy/src/lib/primary-message/primary-message.module.ts": [
-                {
-                    "name": "components",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/primary-message/primary-message.module.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[\n  LgPrimaryMessageComponent,\n  LgPrimaryMessageTitleComponent,\n  LgPrimaryMessageDescriptionComponent,\n]"
-                }
-            ],
             "projects/canopy/src/lib/promo-card/promo-card.module.ts": [
                 {
                     "name": "components",
@@ -36434,6 +36442,18 @@
                     "deprecationMessage": "",
                     "type": "[]",
                     "defaultValue": "[\n  LgPromoCardComponent,\n  LgPromoCardListComponent,\n  LgPromoCardTitleComponent,\n  LgPromoCardFooterComponent,\n  LgPromoCardContentComponent,\n  LgPromoCardImageComponent,\n  LgPromoCardListTitleComponent,\n]"
+                }
+            ],
+            "projects/canopy/src/lib/primary-message/primary-message.module.ts": [
+                {
+                    "name": "components",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/primary-message/primary-message.module.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[\n  LgPrimaryMessageComponent,\n  LgPrimaryMessageTitleComponent,\n  LgPrimaryMessageDescriptionComponent,\n]"
                 }
             ],
             "projects/canopy/src/lib/side-nav/side-nav.module.ts": [
@@ -36562,27 +36582,6 @@
                     "defaultValue": "() => ({\n  props: createProps(),\n  template: `\n    <lg-page>\n      ${header}\n      <div lgContainer>\n        <div lgRow>\n          <div lgCol=\"12\" lgColMd=\"8\" lgColLg=\"5\" lgColLgOffset=\"2\">\n            <lg-card lgMarginHorizontal=\"none\">\n              <lg-card-content>\n                {{card1Content}}\n                {{card3Content}}\n              </lg-card-content>\n            </lg-card>\n          </div>\n          <div lgCol=\"12\" lgColMd=\"4\" lgColLg=\"3\">\n            <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n            <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card3Content}}</lg-card-content></lg-card>\n          </div>\n        </div>\n      </div>\n      ${footer}\n    </lg-page>\n  `,\n})"
                 }
             ],
-            "projects/canopy/src/test.ts": [
-                {
-                    "name": "context",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/test.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
-                },
-                {
-                    "name": "require",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/test.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "literal type"
-                }
-            ],
             "projects/canopy-test-app/src/test.ts": [
                 {
                     "name": "context",
@@ -36599,6 +36598,27 @@
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy-test-app/src/test.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "literal type"
+                }
+            ],
+            "projects/canopy/src/test.ts": [
+                {
+                    "name": "context",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/test.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
+                },
+                {
+                    "name": "require",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/test.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "literal type"
@@ -36716,6 +36736,48 @@
                     "defaultValue": "() => ({\n  template: `\n    <story-table-long-copy\n      [variant]=\"variant\"\n      [stack]=\"stack\">\n    </story-table-long-copy>\n  `,\n  props: {\n    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),\n    stack: boolean(\n      'Stack label and content in non-columns view',\n      true,\n      'Responsive options',\n    ),\n  },\n})"
                 }
             ],
+            "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts": [
+                {
+                    "name": "featureToggle",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "featureToggleTemplate.bind({})"
+                },
+                {
+                    "name": "featureToggleTemplate",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story<LgFeatureToggleDirective>",
+                    "defaultValue": "(args: LgFeatureToggleDirective) => ({\n  component: LgFeatureToggleDirective,\n  props: args,\n  template,\n})"
+                },
+                {
+                    "name": "options",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "LgFeatureToggleOptions",
+                    "defaultValue": "{\n  // disable undefined feature e.g. Feature 2 in the following story\n  defaultHide: true,\n}"
+                },
+                {
+                    "name": "template",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n  <lg-card *lgFeatureToggle=\"'firstFeature'\"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>\n  <lg-card *lgFeatureToggle=\"'secondFeature'\"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>\n  <lg-card *lgFeatureToggle=\"'thirdFeature'\"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>\n  <lg-card *lgFeatureToggle=\"'fourthFeature'\"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>\n`"
+                }
+            ],
             "projects/canopy/src/lib/card/card.stories.ts": [
                 {
                     "name": "formJourney",
@@ -36804,28 +36866,6 @@
                     "defaultValue": "() => ({\n  template: `\n    <div>\n      <div class=\"lg-container\">\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12\">\n            <h2>Responsive sizing and offsets</h2>\n            <p>Responsive modifiers enable specifying different column sizes and offsets at xs, sm, md & lg viewport widths.</p>\n          </div>\n        </div>\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-6 lg-col-sm-6 lg-col-md-8 lg-col-lg-10\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-6 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n            <div class=\"box\"></div>\n          </div>\n        </div>\n\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-12 lg-col-sm-9 lg-col-md-10 lg-col-lg-11\">\n            <div class=\"box\"></div>\n          </div>\n        </div>\n\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-10 lg-col-sm-6 lg-col-md-8 lg-col-lg-10\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-2 lg-col-sm-6 lg-col-md-4 lg-col-lg-2\">\n            <div class=\"box\"></div>\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-container\">\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12\">\n            <h2>Responsive alignment and distribution</h2>\n            <p>Responsive modifiers enable specifying different alignment and distribution at xs, sm, md & lg viewport widths.</p>\n            <p>Here the sidebar is displayed first below the md viewport size, and second beyond that.</p>\n          </div>\n        </div>\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-9 lg-last-xs lg-first-md\">\n            <div class=\"box\">Main content</div>\n          </div>\n          <div class=\"lg-col-xs-3 lg-first-xs lg-last-md\">\n            <div class=\"box\">Sidebar</div>\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-container\">\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12\">\n            <h2>Fluid</h2>\n            <p>Percent based widths allow fluid resizing of columns and rows.</p>\n          </div>\n        </div>\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-3\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-9\">\n            <div class=\"box\">\n            </div>\n          </div>\n        </div>\n\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-4\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-8\">\n            <div class=\"box\">\n            </div>\n          </div>\n        </div>\n\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-5\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-7\">\n            <div class=\"box\">\n            </div>\n          </div>\n        </div>\n\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-6\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-6\">\n            <div class=\"box\">\n            </div>\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-container\">\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12\">\n            <h2>Offsets</h2>\n            <p>Offset a column</p>\n          </div>\n        </div>\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-offset-11 lg-col-xs-1\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-10 lg-col-xs-2\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-9 lg-col-xs-3\">\n              <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-8 lg-col-xs-4\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-7 lg-col-xs-5\">\n              <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-6 lg-col-xs-6\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-5 lg-col-xs-7\">\n              <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-4 lg-col-xs-8\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-3 lg-col-xs-9\">\n              <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-2 lg-col-xs-10\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs-offset-1 lg-col-xs-11\">\n            <div class=\"box\"></div>\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-container\">\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12\">\n            <h2>Auto Width</h2>\n            <p>Add any number of auto sizing columns to a row. Let the grid figure it out.</p>\n          </div>\n        </div>\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs\">\n            <div class=\"box\"></div>\n          </div>\n          <div class=\"lg-col-xs\">\n            <div class=\"box\"></div>\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-container\">\n        <div class=\"lg-row\">\n          <div class=\"lg-col-xs-12\">\n            <h2>Nested Grid</h2>\n            <p>Nest grids inside grids inside grids.</p>\n          </div>\n        </div>\n        <div class=\"lg-row nested\">\n          <div class=\"lg-col-xs-7\">\n            <div class=\"box\">\n              <div class=\"lg-row\">\n                <div class=\"lg-col-xs-9\">\n                  <div class=\"box\">\n                    <div class=\"lg-row\">\n                      <div class=\"lg-col-xs-4\">\n                        <div class=\"box\">\n                        </div>\n                      </div>\n                      <div class=\"lg-col-xs-8\">\n                        <div class=\"box\">\n                        </div>\n                      </div>\n                    </div>\n                  </div>\n                </div>\n                <div class=\"lg-col-xs-3\">\n                  <div class=\"box\">\n                    <div class=\"lg-row\">\n                      <div class=\"lg-col-xs\">\n                        <div class=\"box\">\n                        </div>\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n            </div>\n          </div>\n          <div class=\"lg-col-xs-5\">\n            <div class=\"box\">\n              <div class=\"lg-row\">\n                <div class=\"lg-col-xs-12\">\n                  <div class=\"box\">\n                    <div class=\"lg-row\">\n                      <div class=\"lg-col-xs-6\">\n                        <div class=\"box\">\n                        </div>\n                      </div>\n                      <div class=\"lg-col-xs-6\">\n                        <div class=\"box\">\n                        </div>\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n    `,\n  styles: [\n    `\n        .box {\n          background-color: var(--color-super-blue);\n          margin-bottom: var(--space-md);\n          height: var(--space-lg);\n        }\n\n        .nested .box {\n          background-color: var(--color-super-blue-lightest);\n          height: auto;\n          padding: var(--space-sm);\n          margin-bottom: var(--space-md);\n        }\n\n        .nested .box .box {\n          background-color: var(--color-super-blue-light);\n          margin-bottom: 0;\n        }\n\n        .nested .box .box .box {\n          background-color: var(--color-super-blue);\n        }\n\n        h2 {\n          margin-top: var(--space-xl);\n        }\n\n        p:last-child {\n          margin-bottom: var(--text-bottom-margin)\n        }\n      `,\n  ],\n})"
                 }
             ],
-            "projects/canopy/src/lib/header/header.stories.ts": [
-                {
-                    "name": "groupId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/header/header.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "string",
-                    "defaultValue": "'header'"
-                },
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/header/header.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n  `,\n  props: {\n    logo: text('logo', 'legal-and-general-logo.svg', groupId),\n    logoAlt: text('logoAlt', 'Company name', groupId),\n    logoHref: text('logoHref', 'https://storybook.js.org', groupId),\n  },\n})"
-                }
-            ],
             "projects/canopy/src/lib/heading/heading.stories.ts": [
                 {
                     "name": "groupId",
@@ -36846,6 +36886,28 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "() => ({\n  template: `\n    <lg-heading\n      [level]=\"level\">\n      {{content}}\n    </lg-heading>\n  `,\n  props: {\n    content: text('text', 'Heading', groupId),\n    level: select('level', [1, 2, 3, 4, 5, 6], 1, groupId),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/header/header.stories.ts": [
+                {
+                    "name": "groupId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/header/header.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "string",
+                    "defaultValue": "'header'"
+                },
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/header/header.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n    <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n  `,\n  props: {\n    logo: text('logo', 'legal-and-general-logo.svg', groupId),\n    logoAlt: text('logoAlt', 'Company name', groupId),\n    logoHref: text('logoHref', 'https://storybook.js.org', groupId),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/hide-at/hide-at.stories.ts": [
@@ -39926,24 +39988,24 @@
                     "defaultValue": "0"
                 }
             ],
-            "projects/canopy/src/lib/forms/input/input-field.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
             "projects/canopy/src/lib/forms/input/input.directive.ts": [
                 {
                     "name": "nextUniqueId",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/label/label.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/label/label.component.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -39962,12 +40024,12 @@
                     "defaultValue": "0"
                 }
             ],
-            "projects/canopy/src/lib/forms/label/label.component.ts": [
+            "projects/canopy/src/lib/forms/toggle/toggle.component.ts": [
                 {
                     "name": "nextUniqueId",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/label/label.component.ts",
+                    "file": "projects/canopy/src/lib/forms/toggle/toggle.component.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -39998,36 +40060,36 @@
                     "defaultValue": "0"
                 }
             ],
-            "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/toggle/toggle.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/toggle/toggle.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
             "projects/canopy/src/lib/forms/validation/validation.component.ts": [
                 {
                     "name": "nextUniqueId",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/input/input-field.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -40058,18 +40120,6 @@
                     "defaultValue": "`\n# Colours\n\n## Purpose\nProvides available brand colours and tints via CSS variables\n\n## Usage\nImport the css into the angular.json file of your application, the variables should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\n`"
                 }
             ],
-            "projects/canopy/src/styles/grid.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/grid.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Grid\n\n## Purpose\nProvides responsive grid system.\n\nThe grid system is useful for responsive page layouts, we recommend that it is used sparingly, for the majority of cases you may be better off just using using flexbox.\n\nThe grid system is based on a subset of the excellent [flexboxgrid](http://flexboxgrid.com/) by [kristoferjoseph](http://github.com/kristoferjoseph).\nThe code is a direct port with some additional modifications to:\n\n- Add 'lg-' prefixes to reduce risk of clash with existing libraries\n- Modify spacing variables to match our own spacing system\n- Force all containers to be fluid width\n- Remove parts of the grid which we may not need\n\n## Usage\nImport the css into the angular.json file of your application, the grid classes should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\nA set of [Angular directives](/?path=/story/directives--grid) are also supplied which can be used to add grid classes to native HTML and Canopy elements.\n\nThere are also two utility directives available which allow you to show/hide components at different breakpoints:\n- [LgShowAt](/?path=/story/directives--show-at)\n- [LgHideAt](/?path=/story/directives--hide-at)\n`"
-                }
-            ],
             "projects/canopy/src/styles/links.notes.ts": [
                 {
                     "name": "notes",
@@ -40092,6 +40142,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Mixins\n\n## Purpose\nProvides available mixins\n\n## Mixins\n### lg-inner-focus-outline($bg-color, $color: var(--color-white))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\n\\`\\`$color\\`\\`: colour of the outline.\n\nSets the focus outline inside the element, by using multiple box shadows.\n\n### lg-outer-focus-outline($bg-color: var(--default-focus-color))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\nSets the focus outline outside the element, by using box shadows.\n\n### lg-link($default-color, $hover-color, $visited-color, $active-color, $active-bg-color, $focus-color, $focus-bg-color)\n\\`\\`$default-color\\`\\`: the default color of the element (default value: \\`\\`var(--link-color)\\`\\`).\n\n\\`\\`$hover-color\\`\\`: the hover color of the element (default value: \\`\\`var(--link-hover-color)\\`\\`).\n\n\\`\\`$visited-color\\`\\`: the visited color of the element (default value: \\`\\`var(--link-visited-color)\\`\\`).\n\n\\`\\`$active-color\\`\\`: the active color of the element (default value: \\`\\`var(--link-active-color)\\`\\`).\n\n\\`\\`$active-bg-color\\`\\`: the active background color of the element (default value: \\`\\`var(--link-active-bg-color)\\`\\`).\n\n\\`\\`$focus-color\\`\\`: the focus color color of the element (default value: \\`\\`var(--link-focus-color)\\`\\`).\n\n\\`\\`$focus-bg-color\\`\\`: the focus background color of the element (default value: \\`\\`var(--link-focus-bg-color)\\`\\`).\n\nStyles elements with the link style.\n\n### lg-unstyled-link\nRevert the links styles added with \\`\\`lg-link\\`\\`.\n\n### lg-font-size($size)\n\\`\\`$size\\`\\`: The font size, '7' | '6' | '5' | '4' | '3' | '2' | '1' | '-8' | '-6' | .\n\nStyles text to one of the predefined font sizes. '-8' and '-6' are the sub body font sizes.\n\n### lg-visually-hidden()\nProvides styles to hide information intended only for screen readers from the layout of the rendered page.\n\n### lg-breakpoint($breakpoint)\n\\`\\`$breakpoint\\`\\`: string value for the breakpoint screen size.\n\nAllows breakpoints to be added to css blocks.\n\n### lg-variant($variant: 'generic')\n\\`\\`$variant\\`\\`: The variant type, 'generic' | 'info' | 'success' | 'warning' | 'error'.\n\nStyles components and native child elements to the specified variant.\n\n`"
+                }
+            ],
+            "projects/canopy/src/styles/grid.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/styles/grid.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Grid\n\n## Purpose\nProvides responsive grid system.\n\nThe grid system is useful for responsive page layouts, we recommend that it is used sparingly, for the majority of cases you may be better off just using using flexbox.\n\nThe grid system is based on a subset of the excellent [flexboxgrid](http://flexboxgrid.com/) by [kristoferjoseph](http://github.com/kristoferjoseph).\nThe code is a direct port with some additional modifications to:\n\n- Add 'lg-' prefixes to reduce risk of clash with existing libraries\n- Modify spacing variables to match our own spacing system\n- Force all containers to be fluid width\n- Remove parts of the grid which we may not need\n\n## Usage\nImport the css into the angular.json file of your application, the grid classes should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\nA set of [Angular directives](/?path=/story/directives--grid) are also supplied which can be used to add grid classes to native HTML and Canopy elements.\n\nThere are also two utility directives available which allow you to show/hide components at different breakpoints:\n- [LgShowAt](/?path=/story/directives--show-at)\n- [LgHideAt](/?path=/story/directives--hide-at)\n`"
                 }
             ],
             "projects/canopy/src/styles/spacing.notes.ts": [
@@ -40142,16 +40204,16 @@
                     "defaultValue": "`\n# Accordion Component\n\n## Purpose\nAccordions allow users to quickly expand and collapse grouped sections of content.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAccordionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-accordion [headingLevel]=\"2\">\n    <lg-accordion-item [isActive]=\"isActive\" (opened)=\"handleItemOpened()\" (closed)=\"handleItemClosed()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua.</p>\n    </lg-accordion-item>\n    <lg-accordion-item>\n      <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>\n      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\n        ut aliquip ex ea commodo consequat. Duis aute irure dolor in\n        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\n        pariatur.</p>\n      <button lg-button lgMarginTop=\"sm\" variant=\"solid-primary\">\n        Test primary button\n      </button>\n    </lg-accordion-item>\n    <lg-accordion-item (opened)=\"loadDynamicContent()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n\n      <ng-template lgAccordionItemContent>\n        <app-dynamic-component [content]=\"dynamicContentItems$ | async\">\n            An example component that loads data from the network when this panel is opened.\n        </app-dynamic-component>\n      </ng-template>\n    </lg-accordion-item>\n  </lg-accordion>\n~~~\n\n## Accordion Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`multi\\`\\` | Set false to only allow a single panel to be open at a time | boolean | true | No |\n| \\`\\`headingLevel\\`\\` | The level of the accordion headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n\n## Accordion Item Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | The active state of the accordion item | boolean | false | No |\n\n\n## Accordion Item Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the accordion item is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the accordion item is closed | EventEmitter<void> | n/a | No |\n\n\n## Lazy content initialisation\n\nWrap the panel content in a \\`ng-template\\` with the \\`lgAccordionContent\\` directive to only initialise and render\nthe panel when it is first opened.\n`"
                 }
             ],
-            "projects/canopy/src/lib/alert/alert.notes.ts": [
+            "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/alert/alert.notes.ts",
+                    "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
+                    "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts": [
@@ -40166,18 +40228,6 @@
                     "defaultValue": "`\n# Brand Icon Component\n\n## Purpose\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` and register your brand icons:\n\n~~~js\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n| \\`\\`size\\`\\` | the size of the icon | BrandIconSize | 'sm' | no |\n| \\`\\`colour\\`\\` | the specific colour of the icon (for global colours see the \"Branding\" section below) | css variable as a string | undefined | no |\n\n## Branding\nThe yellow fill colour of the brand icons can be changed by overriding the \\`--brand-icon-fill-primary\\` css variable.\n\nNote that changing that variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input (see details in the table above).\n`"
                 }
             ],
-            "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
-                }
-            ],
             "projects/canopy/src/lib/button/button.notes.ts": [
                 {
                     "name": "notes",
@@ -40190,16 +40240,16 @@
                     "defaultValue": "`\n# Button Component\n\n## Purpose\nProvides common styles and behaviours for buttons and links.\n\n## Usage\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgButtonModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n~~~\n\nor:\n\n~~~html\n<a lg-button href=\"#\" variant=\"primary\">Link</a>\n~~~\n\n## Button with icon with text\n\nIcons can be content projected into the button, the button component will then handle the styling of that icon.\nThe \\`ButtonIconPosition\\` property can be used to locate the icon on the left hand side of the text, the default is to the right hand side.\nContent projection is used as Canopy Icons need loading via the \\`iconRegistry\\` which enables tree shaking of icons.\n\n~~~html\n<button lg-button type=\"button\" iconPosition=\"left\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## Button with icon only\n\nButtons can be setup as icon only buttons, this is done in a similar way to a button with icon and text.\nYou will still need to include text content inside the button as this information is vital to screen readers.\nThe \\`iconButton\\` property is used to visually hide that text.\n\n~~~html\n<button lg-button type=\"button\" iconButton=\"true\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## ButtonComponent inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of button: \\`\\`solid-primary\\`\\`, \\`\\`solid-secondary\\`\\`, \\`\\`outline-primary\\`\\`, \\`\\`outline-secondary\\`\\`, \\`\\`reverse-primary\\`\\`, \\`\\`reverse-secondary\\`\\`, \\`\\`add-on\\`\\`; | string | solid-primary | No |\n| \\`\\`size\\`\\` | The size of the button | ButtonSize [\\`\\`sm\\`\\`, \\`\\`md\\`\\`] | \\`\\`md\\`\\` | No |\n| \\`\\`fullWidth\\`\\` | If the button has to span full width or not. For 'sm' and 'md' sized screens, the button will always be full width and this input has no affect | boolean | false | No |\n| \\`\\`disabled\\`\\` | Programmatically disable the button via this property | boolean | false | No |\n| \\`\\`loading\\`\\` | If the button shows a loading spinner and is also disabled | boolean | false | No |\n| \\`\\`iconPosition\\`\\` | The position of the icon in the button | string | right | No |\n| \\`\\`iconButton\\`\\` | The button displays an icon only | boolean | false | No |\n\n## Button group\n\nButtons can be grouped together by using the \\`\\`ButtonGroupComponent\\`\\`:\n\n~~~html\n<lg-button-group>\n  <button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n  <a lg-button href=\"#\" variant=\"outline-primary\">Link</a>\n</lg-button-group>\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/carousel/carousel.notes.ts": [
+            "projects/canopy/src/lib/alert/alert.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
+                    "file": "projects/canopy/src/lib/alert/alert.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
+                    "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/card/card.notes.ts": [
@@ -40214,16 +40264,16 @@
                     "defaultValue": "`\n# Card Component\n\n## Purpose\nProvides a generic card component for displaying content. Consists of various card components that are designed to create modular and flexible card layouts, from a basic card with a title, text and buttons to a single-page Form Journey card.\n\n## Usage\n\nFor a basic card, import the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgCardModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-card>\n  <lg-card-header>\n    Your title\n  </lg-card-header>\n  <lg-card-content>\n    Your content\n  </lg-card-content>\n</lg-card>\n~~~\n\n---\n\n### Other card types and templates\n\nYou can extend the basic card component and create specific card implementations.\n\n#### Product card\n\nThis component uses some extra card components, such as \\`LgCardPrincipleDataPoint\\` and \\`LgCardPrincipleDataPointValue\\` to display data points.\n\n~~~html\n<lg-card>\n  <lg-card-content>\n    <div lgRow>\n      <div lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-title headingLevel=\"4\">\n          <a href=\"#\">{{title}}</a>.\n        </lg-card-title>\n        <lg-card-subtitle>\n          Payroll Reference Number P23456\n        </lg-card-subtitle>\n      </div>\n      <lg-card-principle-data-point lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-principle-data-point-label>\n          Last payment (after tax and deductions)\n        </lg-card-principle-data-point-label>\n        <lg-card-principle-data-point-value>\n          <span><span class=\"lg-font-size-3\">£</span>230.20</span>\n        </lg-card-principle-data-point-value>\n        <lg-card-principle-data-point-date>\n          as of 01 Jan 2020\n        </lg-card-principle-data-point-date>\n      </lg-card-principle-data-point>\n    </div>\n  </lg-card-content>\n</lg-card>\n~~~\n\n#### Form Journey card\n\nCreates the Form Journey template, used to display a single page form. Note that the <form> element is a parent of the <lg-card> component, this is because the form inputs and submit button are spread out between the card content and card footer.\n\n~~~html\n<div lgContainer>\n<div lgRow>\n  <div lgCol=\"12\" lgColLg=\"6\" lgColLgOffset=\"3\" lgColMd=\"10\" lgColMdOffset=\"1\">\n    <form [formGroup]=\"form\" (ngSubmit)=\"onSubmit(form)\">\n      <lg-card lgPadding=\"none\">\n        <lg-card-header lgPadding=\"sm\" lgPaddingBottom=\"xs\" lgMarginBottom=\"lg\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\">\n                <lg-icon [name]=\"'chevron-left'\"></lg-icon>\n                Back\n              </a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </lg-card-header>\n        <lg-card-content>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <lg-card-title headingLevel=\"3\" lgPaddingBottom=\"md\">{{ title }}</lg-card-title>\n                <p>{{cardContent}}</p>\n\n                <lg-input-field [block]=\"block\">\n                  {{ label }}\n                  <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n                  <input lgInput formControlName=\"accountNumber\" size=\"8\" />\n                </lg-input-field>\n\n              </div>\n            </div>\n          </div>\n        </lg-card-content>\n        <lg-card-footer>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <button lg-button type=\"button\" variant=\"outline-primary\" lgMarginRight=\"sm\">Back</button>\n                <button lg-button type=\"submit\" variant=\"solid-primary\">Confirm</button>\n                <p *ngIf=\"policy\" lgPaddingBottom=\"md\">{{ policy }}</p>\n              </div>\n            </div>\n          </div>\n        </lg-card-footer>\n      </lg-card>\n    </form>\n  </div>\n</div>\n</div>\n~~~\n\n### Inputs\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`<default>\\`\\` | The main body content of the card\n\n### LgCardHeaderComponent\nThis is the primary layout section of the card component, it is used to contain breadcrumbs or other similar content.\n\n### LgCardContent\nThis is the secondary layout section of the card component, it is used to contain the cards main content and provides the inner padding of the card.\n\n### LgCardTitleComponent\nThis is where the main title should be provided. It should be located inside the card content.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgCardSubtitleComponent\nIf the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.\n\n### LgCardPrincipleDataPoint\nSometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card content which will control it's layout\n\n### LgCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointDate\nThis is where the date for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardFooter\nThis is the footer layout section of the card component, it is used to contain call to action buttons as well as messages or hints.\n`"
                 }
             ],
-            "projects/canopy/src/lib/data-point/data-point.notes.ts": [
+            "projects/canopy/src/lib/footer/footer.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
+                    "file": "projects/canopy/src/lib/footer/footer.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
+                    "defaultValue": "`\n# Footer Component\n\n## Purpose\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<footer\n  lg-footer\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  copyright=\"© Some Company plc 2018\">\n</footer>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`copyright\\`\\` | Copyright text to display in footer | string | null | No |\n| \\`\\`primaryLinks\\`\\` | The primary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n| \\`\\`secondaryLinks\\`\\` | The secondary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`primaryLinkClicked\\`\\` | Event emitted when a primary link is clicked | EventEmitter<any> | n/a | No |\n| \\`\\`secondaryLinkClicked\\`\\` | Event emitted when a secondary link is clicked | EventEmitter<any> | n/a | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/details/details.notes.ts": [
@@ -40236,6 +40286,30 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Details Component\n\n\n## Purpose\nThe Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgDetailsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-details [isActive]=\"expand\">\n  <lg-details-panel-heading [headingLevel]=\"5\">\n    How do I change my payment details?\n  </lg-details-panel-heading>\n  Give us a call on 0800 123 4567 and we'll be happy to help you change\n  your payment details\n</lg-details>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Expand the details | boolean | false | no |\n| \\`\\`headingLevel\\`\\` | The level of the details heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n|\\`\\`variant\\`\\`| Applies colour treatment and ARIA role if applicable: \\`\\`generic\\`\\`, \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'generic' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display on the warning, error or success variants | boolean | true | No |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the details are opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the details are closed | EventEmitter<void> | n/a | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/carousel/carousel.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/data-point/data-point.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
                 }
             ],
             "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts": [
@@ -40262,40 +40336,16 @@
                     "defaultValue": "`\n# Focus directive\n\n## Purpose\nThis directive allows for focus to be set dynamically on a focusable element.\n\n## Usage\nImport the directive in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgFocusDirective ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<button [lgFocus]=\"<boolean-var>\">Button</button>\n~~~\n\n## Inputs\n\n| Name | Description | Type |\n|------|-------------|:----:|\n| \\`\\`lgFocus\\`\\` | If the element should have focus or not | boolean |\n\n`"
                 }
             ],
-            "projects/canopy/src/lib/footer/footer.notes.ts": [
+            "projects/canopy/src/lib/hero/hero.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/footer/footer.notes.ts",
+                    "file": "projects/canopy/src/lib/hero/hero.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Footer Component\n\n## Purpose\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<footer\n  lg-footer\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  copyright=\"© Some Company plc 2018\">\n</footer>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`copyright\\`\\` | Copyright text to display in footer | string | null | No |\n| \\`\\`primaryLinks\\`\\` | The primary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n| \\`\\`secondaryLinks\\`\\` | The secondary footer links | \\`[{ text: string, href: string, id?: string, target?: string }]\\` | null | No |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`primaryLinkClicked\\`\\` | Event emitted when a primary link is clicked | EventEmitter<any> | n/a | No |\n| \\`\\`secondaryLinkClicked\\`\\` | Event emitted when a secondary link is clicked | EventEmitter<any> | n/a | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/grid/grid.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/grid/grid.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
-                }
-            ],
-            "projects/canopy/src/lib/header/header.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/header/header.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Header Component\n\n## Purpose\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<header\n  lg-header\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  logoHref=\"http://company.com\">\n</header>\n~~~\n\n## Inputs\n\n### LgHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`logoHref\\`\\` | Url link if the logo is clickable | string | null | No |\n`"
+                    "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/heading/heading.notes.ts": [
@@ -40310,28 +40360,28 @@
                     "defaultValue": "`\n# Heading Component\n\n## Purpose\nThis component allows for headings to be set dynamically.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeadingModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-heading [level]=\"1\">Heading</lg-heading>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`level\\`\\` | The heading level | number | undefined | Yes |\n`"
                 }
             ],
-            "projects/canopy/src/lib/hero/hero.notes.ts": [
+            "projects/canopy/src/lib/header/header.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/hero/hero.notes.ts",
+                    "file": "projects/canopy/src/lib/header/header.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
+                    "defaultValue": "`\n# Header Component\n\n## Purpose\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<header\n  lg-header\n  logo=\"/logo.svg\"\n  logoAlt=\"Company Logo\"\n  logoHref=\"http://company.com\">\n</header>\n~~~\n\n## Inputs\n\n### LgHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`logo\\`\\` | A url link to the logo | string | null | Yes |\n| \\`\\`logoAlt\\`\\` | alt text to display alongside the logo | string | '2rem' | Yes |\n| \\`\\`logoHref\\`\\` | Url link if the logo is clickable | string | null | No |\n`"
                 }
             ],
-            "projects/canopy/src/lib/hide-at/hide-at.notes.ts": [
+            "projects/canopy/src/lib/grid/grid.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/hide-at/hide-at.notes.ts",
+                    "file": "projects/canopy/src/lib/grid/grid.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Hide At Directive\n\n## Purpose\nThis directive allows for media quieries to be added to components, so they can be hidden at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to hide a component on wider viewports, such as desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgShowAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHideAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgHideAt=\"sm\">\n  <lg-card-content>\n    I get hidden at \"sm\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgHideAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
+                    "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
                 }
             ],
             "projects/canopy/src/lib/icon/icon.notes.ts": [
@@ -40346,6 +40396,18 @@
                     "defaultValue": "`\n# Icon Component\n\n## Purpose\nProvides a way of adding common svg icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgIconModule],\n})\n~~~\n\nImport the \\`LgIconRegistry\\` and register your icons:\n\n~~~js\nexport class AppModule {\n  constructor(private iconRegistry: LgIconRegistry) {\n    this.iconRegistry.registerIcons([\n      lgIconEmail\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-icon name=\"email\"></lg-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n\nAll icons have height and width equal to 1em. This means the icons will be as big as the font-size specified by the parent.\n\n*By default the icons have the \\`\\`fill\\`\\` css property set to \\`\\`currentColor\\`\\`.*\n\n> \\`\\`currentColor\\`\\` acts like a variable for the current value of the \\`\\`color\\`\\` property on the element. And the Cascading part of CSS is still effective, so if there’s no defined \\`\\`color\\`\\` property on an element, the cascade will determine the value of \\`\\`currentColor\\`\\`.\n>\n> *Understanding the currentColor Keyword in CSS - https://alligator.io/css/currentcolor/*\n\n*Please note that the 'need-help' and 'question-mark' icons currently don't have the ability to change colour.*\n`"
                 }
             ],
+            "projects/canopy/src/lib/hide-at/hide-at.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/hide-at/hide-at.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Hide At Directive\n\n## Purpose\nThis directive allows for media quieries to be added to components, so they can be hidden at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to hide a component on wider viewports, such as desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgShowAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHideAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgHideAt=\"sm\">\n  <lg-card-content>\n    I get hidden at \"sm\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgHideAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
+                }
+            ],
             "projects/canopy/src/lib/modal/modal.notes.ts": [
                 {
                     "name": "notes",
@@ -40356,30 +40418,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Modal Component\n\n\n## Purpose\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Lorem ipsum</lg-modal-header>\n  <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nfor a timout modal you can use the following structure:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Logout</lg-modal-header>\n  <lg-modal-body>\n    For your security, we'll log yuo out in:\n    <lg-modal-body-timer timer=\"0:58\"></lg-modal-body-timer>\n  </lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nOpening and closing the modal is also possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
-                }
-            ],
-            "projects/canopy/src/lib/page/page.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/page/page.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/primary-message/primary-message.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/primary-message/primary-message.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Primary Message Component\n\n\n## Purpose\nThe Primary Message is used to communicate key information to the user.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPrimaryMessageModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-primary-message>\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title>\n      This is a primary message\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">Call to action</button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`hasRole\\`\\` | If false, removes the role \\`\\`alert\\`\\` from the component | boolean | true | No |\n\n`"
                 }
             ],
             "projects/canopy/src/lib/promo-card/promo-card.notes.ts": [
@@ -40406,28 +40444,28 @@
                     "defaultValue": "`\n# Quick Action Component\n\n## Purpose\nQuick Actions are small clickable elements that can be used to provide functionality in context, such as editing a form or actions on a card.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgQuickActionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-quick-action>\n  <lg-icon name=\"repeat\"></lg-icon>\n  Load more\n</button>\n~~~\n\nor:\n\n~~~html\n<a lg-quick-action\n  href=\"/mailbox\">\n  <lg-icon name=\"secure-message\"></lg-icon>\n  Send us a message\n</a>\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/separator/separator.notes.ts": [
+            "projects/canopy/src/lib/page/page.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/separator/separator.notes.ts",
+                    "file": "projects/canopy/src/lib/page/page.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Separator Component\n\n\n## Purpose\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-separator></lg-separator>\n\n<lg-separator variant='dotted'></lg-separator>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of separator: \\`\\`solid\\`\\`, \\`\\`dotted\\`\\` | SeparatorVariant | 'solid' | No |\n| \\`\\`hasRole\\`\\` | If true, adds a role of \\`\\`separator\\`\\` to the component | boolean | false | No |\n`"
+                    "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/shadow/shadow.notes.ts": [
+            "projects/canopy/src/lib/primary-message/primary-message.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/shadow/shadow.notes.ts",
+                    "file": "projects/canopy/src/lib/primary-message/primary-message.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Shadow Directive\n\n## Purpose\nThis directive adds a box shadow to a component.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShadowModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShadow>\n  <lg-card-content>\n    This card has a shadow\n  </lg-card-content>\n</lg-card>\n~~~\n\n`"
+                    "defaultValue": "`\n# Primary Message Component\n\n\n## Purpose\nThe Primary Message is used to communicate key information to the user.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPrimaryMessageModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-primary-message>\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title>\n      This is a primary message\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">Call to action</button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`hasRole\\`\\` | If false, removes the role \\`\\`alert\\`\\` from the component | boolean | true | No |\n\n`"
                 }
             ],
             "projects/canopy/src/lib/side-nav/side-nav.notes.ts": [
@@ -40442,6 +40480,18 @@
                     "defaultValue": "`\n# Side Nav Component\n\n## Purpose\n\nSide Navs are components that allow the user to define a series of navigation items that display content in a predefined area.\n\n### Side Nav Bar\n\nHere is where the navigation menu items are put. The links, once clicked on, will display their routes'\ncontent in the Side Nav Content component.\nOn mobile devices, the menu is below the content area, instead of to the left.\n\n### Side Nav Bar Link\nThis \\`lgSideNavBarLink\\` directive applies the appropriate styling to the links. It also emits an event when the link is activated.\n\n### Side Nav Bar Footer\n\nThe footer is below the navigation items and can hold different kinds of content (e.g. a button).\n\n### Side Nav Content\n\nThis is the predefined area where content is shown. It should always contain a router outlet to be able to display\nthe different nav item routes.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgSideNavModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-side-nav>\n    <lg-side-nav-bar label=\"Side Nav Demo\">\n      <a id=\"side-nav-0\"\n         [routerLink]=\"'firstPage'\"\n         [isActive]=\"true\"\n         lgSideNavBarLink\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Overview</lg-side-nav-bar-item-heading>\n        </lg-side-nav-bar-item>\n      </a>\n      <a id=\"side-nav-1\"\n         [routerLink]=\"'secondPage'\"\n         lgSideNavBarLink\n        >\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Personal details</lg-side-nav-bar-item-heading>\n            <lg-side-nav-bar-item-content>Your name, date of birth, marital status and National Insurance Number.</lg-side-nav-bar-item-content>\n        </lg-side-nav-bar-item>\n      </a>\n      <lg-side-nav-bar-footer>\n        <a lg-button lgMarginTop=\"xxl\" variant=\"outline-primary\" [fullWidth]=\"false\" href=\"#\">Logout</a>\n      </lg-side-nav-bar-footer>\n    </lg-side-nav-bar>\n    <lg-side-nav-content tabindex=\"0\">\n      <router-outlet></router-outlet>\n    </lg-side-nav-content>\n</lg-side-nav>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-------:|:--------:|\n| isActive | specifies whether or not the navigation link is in an active state | boolean | false | No\n`"
                 }
             ],
+            "projects/canopy/src/lib/separator/separator.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/separator/separator.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Separator Component\n\n\n## Purpose\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-separator></lg-separator>\n\n<lg-separator variant='dotted'></lg-separator>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of separator: \\`\\`solid\\`\\`, \\`\\`dotted\\`\\` | SeparatorVariant | 'solid' | No |\n| \\`\\`hasRole\\`\\` | If true, adds a role of \\`\\`separator\\`\\` to the component | boolean | false | No |\n`"
+                }
+            ],
             "projects/canopy/src/lib/show-at/show-at.notes.ts": [
                 {
                     "name": "notes",
@@ -40452,18 +40502,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Show At Directive\n\n## Purpose\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShowAt=\"md\">\n  <lg-card-content>\n    I get dispalayed at the \"md\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgShowAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/skeleton/skeleton.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/skeleton/skeleton.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Skeleton Loading Directive\n\n## Purpose\nThe skeleton directive adds a skeleton loading state to a component or element.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSkeletonModule],\n})\n~~~\n\nThe directive works on components that output text or projected content. On composite components that\nare made up of other child components, it is best to add the skeleton loading directive to the child\ncomponents or even wrap the projected content inside another element. E.g. In the example,\nthe \\`lg-data-point-label\\` projects the content into an \\`lg-heading\\` component,\nso the directive is added to a span wrapping the content. However, the \\`lg-data-point-value\\` component\nsimply projects the content only so the directive can be applied to the component itself.\n\n~~~html\n<lg-data-point>\n  <lg-data-point-label [headingLevel]=\"4\">\n    <span lgSkeleton lgSkeletonWidth=\"10\">{{ data?.label }}</span>\n  </lg-data-point-label>\n  <lg-data-point-value lgSkeleton lgSkeletonWidth=\"8\">\n    {{ data?.value }}\n  </lg-data-point-value>\n</lg-data-point>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgSkeletonWidth\\`\\` | Override the default width with the desired value in ems | string | 100% | No |\n| \\`\\`lgSkeletonHeight\\`\\` | Override the default height with the desired value in ems | string | auto | No |\n\n`"
                 }
             ],
             "projects/canopy/src/lib/spinner/spinner.notes.ts": [
@@ -40478,6 +40516,30 @@
                     "defaultValue": "`\n# Spinner Component\n\n## Purpose\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<lg-spinner></lg-spinner>\n~~~\n\n## Inputs\n\n### LgSpinnerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The spinner variant | SpinnerVariant ['dark', 'light', 'color', 'inherit'] | 'dark' | No |\n| \\`\\`size\\`\\` | The size of the spinner | SpinnerSize ['sm', 'md'] | 'md' | No |\n| \\`\\`text\\`\\` | The text to show under the spinner | string | undefined | No |\n\n\nIf the \\`\\`variant\\`\\` is set to  \\`\\`'inherit'\\`\\`, then it will inherit the font colour of it's parent element. This is used on the loading button, where the spinner inherits the font colour of the button.\n`"
                 }
             ],
+            "projects/canopy/src/lib/shadow/shadow.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/shadow/shadow.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Shadow Directive\n\n## Purpose\nThis directive adds a box shadow to a component.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShadowModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShadow>\n  <lg-card-content>\n    This card has a shadow\n  </lg-card-content>\n</lg-card>\n~~~\n\n`"
+                }
+            ],
+            "projects/canopy/src/lib/skeleton/skeleton.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/skeleton/skeleton.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Skeleton Loading Directive\n\n## Purpose\nThe skeleton directive adds a skeleton loading state to a component or element.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSkeletonModule],\n})\n~~~\n\nThe directive works on components that output text or projected content. On composite components that\nare made up of other child components, it is best to add the skeleton loading directive to the child\ncomponents or even wrap the projected content inside another element. E.g. In the example,\nthe \\`lg-data-point-label\\` projects the content into an \\`lg-heading\\` component,\nso the directive is added to a span wrapping the content. However, the \\`lg-data-point-value\\` component\nsimply projects the content only so the directive can be applied to the component itself.\n\n~~~html\n<lg-data-point>\n  <lg-data-point-label [headingLevel]=\"4\">\n    <span lgSkeleton lgSkeletonWidth=\"10\">{{ data?.label }}</span>\n  </lg-data-point-label>\n  <lg-data-point-value lgSkeleton lgSkeletonWidth=\"8\">\n    {{ data?.value }}\n  </lg-data-point-value>\n</lg-data-point>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgSkeletonWidth\\`\\` | Override the default width with the desired value in ems | string | 100% | No |\n| \\`\\`lgSkeletonHeight\\`\\` | Override the default height with the desired value in ems | string | auto | No |\n\n`"
+                }
+            ],
             "projects/canopy/src/lib/table/table.notes.ts": [
                 {
                     "name": "notes",
@@ -40488,6 +40550,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/variant/variant.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/variant/variant.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/tabs/tabs.notes.ts": [
@@ -40510,18 +40584,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Tab Navigation Bar Component\n\n## Purpose\nThe tabbed navigation bar provides a tab-like UI for navigating between routes or urls. The tabbed navigatiom bar is router agnostic, so you will need to place the \\`router-outlet\\` anywhere in your view. Don't forget to add the \\`aria-labelledby\\` attribute to the content output by the \\`router-outlet\\`.\nThe \\`isActive\\` property is used to select the current active tab.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tab-nav-bar label=\"Tabbed navigtion label\">\n  <a lgTabNavBarLink id=\"tabbed-nav-1\" [isActive]=\"true\" [routerLink]=\"\">Tab 1</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-2\" [routerLink]=\"\">Tab 2</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-3\" [routerLink]=\"\">Tab 3</a>\n</lg-tab-nav-bar>\n<lg-tab-nav-content [selectedTabId]=\"tabbed-nav-1\">\n  <p>Insert router-outlet here.</p>\n</lg-tab-nav-content>\n~~~\n\n## \\`lg-tab-nav-bar\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | Label for the tab list| string | Tabs | No |\n\n## \\`lgTabNavBarLink\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`index\\`\\` | Sets the tab index position in tab list | number | 0 | No |\n| \\`\\`isActive\\`\\` | Sets the active state of the tab | boolean | false | No |\n| \\`\\`isFocused\\`\\` | Sets the focus state of the tab | boolean | false | No |\n\n## \\`lgTabNavBarLink\\` Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Sets the current actve tab | boolean | undefined | No |\n\n## \\`lg-tab-nav-content\\` Inputs\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`selectedTabId\\`\\` | Sets the id of the current selected tab | string | undefined | No |\n\n`"
-                }
-            ],
-            "projects/canopy/src/lib/variant/variant.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/variant/variant.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/forms/date/date-field.notes.ts": [
@@ -40572,30 +40634,6 @@
                     "defaultValue": "(name: string) => `\n# ${name} Group and ${name} Button Components\n\n## Purpose\nProvides a set of components to implement ${name} buttons in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more ${name} Button components. The ${name} Button component represents a single ${name} button. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the Radio Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgRadioModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${name.toLowerCase()}-group ${\n  name === 'Radio' ? '[inline]=\"true\"' : ''\n} formControlName=\"color\">\n  Colour\n  <lg-hint>Please select a colour</lg-hint>\n  <lg-${name.toLowerCase()}-button value=\"red\">Red</lg-${name.toLowerCase()}-button>\n  <lg-${name.toLowerCase()}-button value=\"yellow\">Yellow</lg-${name.toLowerCase()}-button>\n</lg-${name.toLowerCase()}-group>\n~~~\n\\\n${\n  name === 'Segment' &&\n  `### Displaying the buttons at different breakpoints\n\nRadios are displayed inline, unless given a \\`RadioStackBreakpoint\\`, which tells them at which breakpoint should they appear stacked on top of each other:\n\n~~~html\n<lg-segment-group [stack]=\"sm\" formControlName=\"color\">\n  Colour\n  <lg-segment-button value=\"red\">Red</lg-segment-button>\n  <lg-segment-button value=\"yellow\">Yellow</lg-segment-button>\n</lg-segment-group>\n~~~\n    `\n}\n\n## Inputs\n\n### LgRadioGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\\${nextUniqueId++}' | No |\n| \\`\\`value\\`\\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n${\n  name === 'Radio'\n    ? `| \\`\\`inline\\`\\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`\n    : name === 'Segment'\n    ? `| \\`\\`stack\\`\\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`\n    : ''\n}\n\n### LgRadioButtonComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML name attribute | string | null | Yes |\n| \\`\\`value\\`\\` | HTML value attribute | string | null | Yes |\n`"
                 }
             ],
-            "projects/canopy/src/lib/forms/select/select.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Sort Code Component\n\n## Purpose\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
-                }
-            ],
             "projects/canopy/src/lib/forms/toggle/toggle.notes.ts": [
                 {
                     "name": "notes",
@@ -40606,6 +40644,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "(name: string) => `\n# ${name} Component\n\n## Purpose\nProvides a ${name} component for boolean form controls. The ${name} component is a variant of the Toggle component.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgToggleModule ],\n})\n~~~\n\nand in your HTML for a regular *checkbox*:\n\n~~~html\n<lg-toggle formControlName=\"confirm\" value=\"yes\" variant=\"${name.toLowerCase()}\">Do you agree?</lg-toggle>\n~~~\n\nor\n\n~~~html\n<lg-${name.toLowerCase()} formControlName=\"confirm\" value=\"yes\">Do you agree?</lg-${name.toLowerCase()}>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`value\\`\\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`variant\\`\\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |\n| \\`\\`focus\\`\\` | Set the focus on the input field | boolean | null | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/select/select.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
                 }
             ],
             "projects/canopy/src/lib/forms/validation/form.notes.ts": [
@@ -40632,16 +40682,16 @@
                     "defaultValue": "`\n# Error Component\n\n\n## Purpose\nThe validation component is used to provide contextual information for a form input field. The most common use case is to display validation errors however it can also be used to show additional information.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgValidationModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-validation>Enter a valid postcode</lg-validation>\n\n<lg-validation variant=\"success\">Username is available</lg-validation>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of the validation: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'error' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display | boolean | true | No |\n`"
                 }
             ],
-            "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts": [
+            "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
+                    "defaultValue": "`\n# Sort Code Component\n\n## Purpose\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
                 }
             ],
             "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts": [
@@ -40656,16 +40706,16 @@
                     "defaultValue": "`\n# Kebab case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into kebab case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgKebabCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | kebabCase}}</p>\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/spacing/padding/padding.notes.ts": [
+            "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
+                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+                    "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/spacing/margin/margin.notes.ts": [
@@ -40680,26 +40730,16 @@
                     "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
                 }
             ],
-            "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts": [
+            "projects/canopy/src/lib/spacing/padding/padding.notes.ts": [
                 {
-                    "name": "options",
+                    "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "LgFeatureToggleOptions",
-                    "defaultValue": "{\n  // disable undefined feature e.g. Feature 4 in the following story\n  defaultHide: true,\n}"
-                },
-                {
-                    "name": "stories",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                    "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "storiesOf('Directives', module)"
+                    "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/pipes/pipes.module.ts": [
@@ -40762,28 +40802,6 @@
                     "defaultValue": "() => ({\n  template: `\n    <p><strong>Change viewport width to see the card appear at specified breakpoint</strong></p>\n    <pre>lgShowAt=\"{{breakpoint}}\"</pre>\n    <lg-separator></lg-separator>\n    <lg-card [lgShowAt]=\"breakpoint\">\n      <lg-card-content>\n        Now you see me...\n      </lg-card-content>\n    </lg-card>\n  `,\n  props: {\n    breakpoint: select('breakpoints', ['sm', 'md', 'lg', 'xl', 'xxl'], 'md'),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/spacing/padding/padding.stories.ts": [
-                {
-                    "name": "spaces",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[\n  'undefined',\n  'none',\n  'xxxs',\n  'xxs',\n  'xs',\n  'sm',\n  'md',\n  'lg',\n  'xl',\n  'xxl',\n  'xxxl',\n  'xxxxl',\n]"
-                },
-                {
-                    "name": "stories",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "storiesOf('Directives', module)"
-                }
-            ],
             "projects/canopy/src/lib/spacing/margin/margin.stories.ts": [
                 {
                     "name": "spaces",
@@ -40800,6 +40818,28 @@
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "storiesOf('Directives', module)"
+                }
+            ],
+            "projects/canopy/src/lib/spacing/padding/padding.stories.ts": [
+                {
+                    "name": "spaces",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[\n  'undefined',\n  'none',\n  'xxxs',\n  'xxs',\n  'xs',\n  'sm',\n  'md',\n  'lg',\n  'xl',\n  'xxl',\n  'xxxl',\n  'xxxxl',\n]"
+                },
+                {
+                    "name": "stories",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
@@ -40938,18 +40978,6 @@
                     "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select all colors that apply'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/forms/radio/segment.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/radio/segment.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-segment\n    [stack]=\"stack === 'false' ? false : stack\"\n    [disabled]=\"disabled\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    [secondButtonLabel]=\"secondButtonLabel\"\n    (segmentChange)=\"segmentChange($event)\">\n  </lg-reactive-form-segment>\n  `,\n  props: {\n    label: text('label', 'Select a color'),\n    secondButtonLabel: text('secondButtonLabel', 'Yellow'),\n    segmentChange: action('segmentChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n    stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),\n  },\n})"
-                }
-            ],
             "projects/canopy/src/lib/forms/radio/radio.stories.ts": [
                 {
                     "name": "standard",
@@ -40962,28 +40990,16 @@
                     "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-radio\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [label]=\"label\"\n    (radioChange)=\"radioChange($event)\">\n  </lg-reactive-form-radio>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    radioChange: action('radioChange'),\n    disabled: boolean('disabled', false),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/forms/select/select.stories.ts": [
+            "projects/canopy/src/lib/forms/radio/segment.stories.ts": [
                 {
                     "name": "standard",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                    "file": "projects/canopy/src/lib/forms/radio/segment.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
-                }
-            ],
-            "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
+                    "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-segment\n    [stack]=\"stack === 'false' ? false : stack\"\n    [disabled]=\"disabled\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    [secondButtonLabel]=\"secondButtonLabel\"\n    (segmentChange)=\"segmentChange($event)\">\n  </lg-reactive-form-segment>\n  `,\n  props: {\n    label: text('label', 'Select a color'),\n    secondButtonLabel: text('secondButtonLabel', 'Yellow'),\n    segmentChange: action('segmentChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n    stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/forms/toggle/checkbox.stories.ts": [
@@ -41010,6 +41026,18 @@
                     "defaultValue": "() => createToggleStory('switch')"
                 }
             ],
+            "projects/canopy/src/lib/forms/select/select.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
+                }
+            ],
             "projects/canopy/src/lib/forms/validation/form.stories.ts": [
                 {
                     "name": "standard",
@@ -41032,6 +41060,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/focus/focus.stories.ts": [
@@ -41058,24 +41098,24 @@
                     "defaultValue": "storiesOf('Directives', module)"
                 }
             ],
-            "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts": [
-                {
-                    "name": "stories",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "storiesOf('Pipes', module)"
-                }
-            ],
             "projects/canopy/src/lib/pipes/kebab-case/kebab-case.stories.ts": [
                 {
                     "name": "stories",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "storiesOf('Pipes', module)"
+                }
+            ],
+            "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts": [
+                {
+                    "name": "stories",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
@@ -43440,6 +43480,26 @@
                 "type": "variable",
                 "linktype": "miscellaneous",
                 "linksubtype": "variable",
+                "name": "featureToggle",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "featureToggleTemplate",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
                 "name": "options",
                 "coveragePercent": 0,
                 "coverageCount": "0/1",
@@ -43450,7 +43510,7 @@
                 "type": "variable",
                 "linktype": "miscellaneous",
                 "linksubtype": "variable",
-                "name": "stories",
+                "name": "template",
                 "coveragePercent": 0,
                 "coverageCount": "0/1",
                 "status": "low"

--- a/projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts
+++ b/projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts
@@ -1,49 +1,89 @@
-import { storiesOf } from '@storybook/angular';
+import { Meta, Story } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
 import { of } from 'rxjs';
 
-import { CanopyModule } from '../canopy.module';
-import type { LgFeatureToggleOptions } from './feature-toggle.interface';
+import { LgFeatureToggleOptions } from './feature-toggle.interface';
+import { CanopyModule } from './../canopy.module';
+import { LgFeatureToggleDirective } from './feature-toggle.directive';
 import { LgFeatureToggleModule } from './feature-toggle.module';
 import { notes } from './feature-toggle.notes';
 
-const stories = storiesOf('Directives', module);
 const options: LgFeatureToggleOptions = {
   // disable undefined feature e.g. Feature 4 in the following story
   defaultHide: true,
 };
 
-stories
-  .addParameters({
-    backgrounds: [{ name: 'default', value: '#0076d6', default: true }],
-  })
-  .add(
-    'Feature Toggle',
-    () => ({
-      moduleMetadata: {
-        imports: [
-          CanopyModule,
-          LgFeatureToggleModule.forRoot(
-            {
-              useFactory: () =>
-                of({
-                  firstFeature: true,
-                  secondFeature: false,
-                  thirdFeature: true,
-                  fourthFeature: false,
-                }),
-            },
-            options,
-          ),
-        ],
-      },
-      template: `
-  <lg-card *lgFeatureToggle="'firstFeature'"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>
-  <lg-card *lgFeatureToggle="'secondFeature'"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>
-  <lg-card *lgFeatureToggle="'thirdFeature'"><lg-card-content>Feature 3 showing</lg-card-content></lg-card>
-  <lg-card *lgFeatureToggle="'fourthFeature'"><lg-card-content>Feature 4 not showing</lg-card-content></lg-card>
-  `,
+// This default export determines where your story goes in the story list
+export default {
+  title: 'Directives/FeatureToggle',
+  component: LgFeatureToggleDirective,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CanopyModule,
+        LgFeatureToggleModule.forRoot(
+          {
+            useFactory: () =>
+              of({
+                firstFeature: true,
+                secondFeature: false,
+                thirdFeature: true,
+                fourthFeature: false,
+              }),
+          },
+          options,
+        ),
+      ],
     }),
-    {
-      notes: { markdown: notes },
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: notes,
+      },
     },
-  );
+    controls: {
+      disable: true,
+    },
+    backgrounds: {
+      default: 'Super Blue',
+    },
+  },
+  argTypes: {
+    lgFeatureToggle: {
+      table: {
+        disable: true,
+      },
+    },
+    ngOnInit: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const template = `
+<lg-card *lgFeatureToggle="'firstFeature'"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>
+<lg-card *lgFeatureToggle="'secondFeature'"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>
+<lg-card *lgFeatureToggle="'thirdFeature'"><lg-card-content>Feature 3 showing</lg-card-content></lg-card>
+<lg-card *lgFeatureToggle="'fourthFeature'"><lg-card-content>Feature 4 not showing</lg-card-content></lg-card>
+`;
+
+const featureToggleTemplate: Story<LgFeatureToggleDirective> = (
+  args: LgFeatureToggleDirective,
+) => ({
+  component: LgFeatureToggleDirective,
+  props: args,
+  template,
+});
+
+export const featureToggle = featureToggleTemplate.bind({});
+featureToggle.storyName = 'Feature Toggle';
+featureToggle.parameters = {
+  docs: {
+    source: {
+      code: template,
+    },
+  },
+};


### PR DESCRIPTION
# Description

Upgrades the feature-toggle directive to use the CSF format. 

One issue that can't be resolved, is that the default background for this is blue. However, the `addon-backgrounds` plugin is not compatible with the story preview on the docsPage. Will need to keep a look out for a future fix by the Storybook team.


This can also be used as a use-case for removing the  use of `storiesOf` as it is no longer supported.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
