### PR TITLE
feat(brand-icon): upgrade to CSF format

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,7 @@ module.exports = {
   stories: [
     '../projects/canopy/src/lib/accordion/accordion.stories.ts',
     '../projects/canopy/src/lib/alert/alert.stories.ts',
+    '../projects/canopy/src/lib/brand-icon/brand-icons.stories.ts',
     '../projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts',
     '../projects/canopy/src/lib/focus/focus.stories.ts',
     '../projects/canopy/src/lib/footer/footer.stories.ts',

--- a/documentation.json
+++ b/documentation.json
@@ -23595,7 +23595,155 @@
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-2af65b95dd2fba2a15db16813f570923",
+            "id": "component-ReactiveFormComponent-706ae1e845eda2ef6cad4a6ee109cf81",
+            "file": "projects/canopy/src/lib/forms/date/date-field.stories.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lg-reactive-form",
+            "styleUrls": [],
+            "styles": [],
+            "template": "<form [formGroup]=\"form\">\n  <lg-date-field formControlName=\"date\">\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n  </lg-date-field>\n</form>\n",
+            "templateUrl": [],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "disabled",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 27,
+                    "type": "boolean"
+                },
+                {
+                    "name": "hint",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 23,
+                    "type": "string"
+                },
+                {
+                    "name": "label",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 24,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "inputChange",
+                    "defaultValue": "new EventEmitter()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 38,
+                    "type": "EventEmitter<void>"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "fb",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormBuilder",
+                    "optional": false,
+                    "description": "",
+                    "line": 42,
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "form",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormGroup",
+                    "optional": false,
+                    "description": "",
+                    "line": 40
+                }
+            ],
+            "methodsClass": [],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { action } from '@storybook/addon-actions';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { moduleMetadata } from '@storybook/angular';\n\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './date-field.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-date-field formControlName=\"date\">\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n      </lg-date-field>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled === true) {\n      this.form.controls.date.disable();\n    } else {\n      this.form.controls.date.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.name.disabled;\n  }\n\n  @Output() inputChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      date: { value: '1970-01-01', disabled: false },\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Date Input',\n  parameters: {\n    decorators: [\n      withKnobs,\n      moduleMetadata({\n        declarations: [ReactiveFormComponent],\n        imports: [ReactiveFormsModule, CanopyModule],\n      }),\n    ],\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n});\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "args": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": ""
+                    }
+                ],
+                "line": 40,
+                "jsdoctags": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "accessors": {
+                "disabled": {
+                    "name": "disabled",
+                    "setSignature": {
+                        "name": "disabled",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 27,
+                        "jsdoctags": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "disabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 34
+                    }
+                }
+            }
+        },
+        {
+            "name": "ReactiveFormComponent",
+            "id": "component-ReactiveFormComponent-2af65b95dd2fba2a15db16813f570923-1",
             "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -23755,11 +23903,14 @@
                         "line": 37
                     }
                 }
-            }
+            },
+            "isDuplicate": true,
+            "duplicateId": 1,
+            "duplicateName": "ReactiveFormComponent-1"
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-c3f914cc5ff5dceb09857f6f1cfd4180-1",
+            "id": "component-ReactiveFormComponent-c3f914cc5ff5dceb09857f6f1cfd4180-2",
             "file": "projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -23894,157 +24045,6 @@
                         "type": "boolean",
                         "returnType": "boolean",
                         "line": 35
-                    }
-                }
-            },
-            "isDuplicate": true,
-            "duplicateId": 1,
-            "duplicateName": "ReactiveFormComponent-1"
-        },
-        {
-            "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-706ae1e845eda2ef6cad4a6ee109cf81-2",
-            "file": "projects/canopy/src/lib/forms/date/date-field.stories.ts",
-            "encapsulation": [],
-            "entryComponents": [],
-            "inputs": [],
-            "outputs": [],
-            "providers": [],
-            "selector": "lg-reactive-form",
-            "styleUrls": [],
-            "styles": [],
-            "template": "<form [formGroup]=\"form\">\n  <lg-date-field formControlName=\"date\">\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n  </lg-date-field>\n</form>\n",
-            "templateUrl": [],
-            "viewProviders": [],
-            "inputsClass": [
-                {
-                    "name": "disabled",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 27,
-                    "type": "boolean"
-                },
-                {
-                    "name": "hint",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 23,
-                    "type": "string"
-                },
-                {
-                    "name": "label",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 24,
-                    "type": "string"
-                }
-            ],
-            "outputsClass": [
-                {
-                    "name": "inputChange",
-                    "defaultValue": "new EventEmitter()",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 38,
-                    "type": "EventEmitter<void>"
-                }
-            ],
-            "propertiesClass": [
-                {
-                    "name": "fb",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormBuilder",
-                    "optional": false,
-                    "description": "",
-                    "line": 42,
-                    "modifierKind": [
-                        123
-                    ]
-                },
-                {
-                    "name": "form",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormGroup",
-                    "optional": false,
-                    "description": "",
-                    "line": 40
-                }
-            ],
-            "methodsClass": [],
-            "deprecated": false,
-            "deprecationMessage": "",
-            "hostBindings": [],
-            "hostListeners": [],
-            "description": "",
-            "rawdescription": "\n",
-            "type": "component",
-            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { action } from '@storybook/addon-actions';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { moduleMetadata } from '@storybook/angular';\n\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './date-field.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-date-field formControlName=\"date\">\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n      </lg-date-field>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled === true) {\n      this.form.controls.date.disable();\n    } else {\n      this.form.controls.date.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.name.disabled;\n  }\n\n  @Output() inputChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      date: { value: '1970-01-01', disabled: false },\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Date Input',\n  parameters: {\n    decorators: [\n      withKnobs,\n      moduleMetadata({\n        declarations: [ReactiveFormComponent],\n        imports: [ReactiveFormsModule, CanopyModule],\n      }),\n    ],\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n});\n",
-            "assetsDirs": [],
-            "styleUrlsData": "",
-            "stylesData": "",
-            "constructorObj": {
-                "name": "constructor",
-                "description": "",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "args": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": ""
-                    }
-                ],
-                "line": 40,
-                "jsdoctags": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "tagName": {
-                            "text": "param"
-                        }
-                    }
-                ]
-            },
-            "accessors": {
-                "disabled": {
-                    "name": "disabled",
-                    "setSignature": {
-                        "name": "disabled",
-                        "type": "void",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "args": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": ""
-                            }
-                        ],
-                        "returnType": "void",
-                        "line": 27,
-                        "jsdoctags": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": "",
-                                "tagName": {
-                                    "text": "param"
-                                }
-                            }
-                        ]
-                    },
-                    "getSignature": {
-                        "name": "disabled",
-                        "type": "boolean",
-                        "returnType": "boolean",
-                        "line": 34
                     }
                 }
             },
@@ -24523,7 +24523,165 @@
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-58c496c2e7f18b071e4677d85e360314-5",
+            "id": "component-ReactiveFormComponent-50d7afa6e8971c1ef656db2a20f0daba-5",
+            "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lg-reactive-form",
+            "styleUrls": [],
+            "styles": [],
+            "template": "<form [formGroup]=\"form\">\n  <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n  </lg-sort-code>\n</form>\n",
+            "templateUrl": [],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "disabled",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 29,
+                    "type": "boolean"
+                },
+                {
+                    "name": "focus",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 26,
+                    "type": "boolean"
+                },
+                {
+                    "name": "hint",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 24,
+                    "type": "string"
+                },
+                {
+                    "name": "label",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 25,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "inputChange",
+                    "defaultValue": "new EventEmitter<void>()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 40,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "fb",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormBuilder",
+                    "optional": false,
+                    "description": "",
+                    "line": 44,
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "form",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormGroup",
+                    "optional": false,
+                    "description": "",
+                    "line": 42
+                }
+            ],
+            "methodsClass": [],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata } from '@storybook/angular';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { action } from '@storybook/addon-actions';\n\nimport { LgSortCodeComponent } from './sort-code.component';\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './sort-code.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n      </lg-sort-code>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n  @Input() focus: boolean;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled) {\n      this.form.controls.sortCode.disable();\n    } else {\n      this.form.controls.sortCode.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.sortCode.disabled;\n  }\n\n  @Output() inputChange = new EventEmitter<void>();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      sortCode: [''],\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Sort Code',\n  component: LgSortCodeComponent,\n  decorators: [\n    withKnobs,\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, CanopyModule],\n    }),\n  ],\n  parameters: {\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n});\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "args": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": ""
+                    }
+                ],
+                "line": 42,
+                "jsdoctags": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "accessors": {
+                "disabled": {
+                    "name": "disabled",
+                    "setSignature": {
+                        "name": "disabled",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 29,
+                        "jsdoctags": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "disabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 36
+                    }
+                }
+            },
+            "isDuplicate": true,
+            "duplicateId": 5,
+            "duplicateName": "ReactiveFormComponent-5"
+        },
+        {
+            "name": "ReactiveFormComponent",
+            "id": "component-ReactiveFormComponent-58c496c2e7f18b071e4677d85e360314-6",
             "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -24783,164 +24941,6 @@
                         "type": "",
                         "returnType": "",
                         "line": 246
-                    }
-                }
-            },
-            "isDuplicate": true,
-            "duplicateId": 5,
-            "duplicateName": "ReactiveFormComponent-5"
-        },
-        {
-            "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-50d7afa6e8971c1ef656db2a20f0daba-6",
-            "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-            "encapsulation": [],
-            "entryComponents": [],
-            "inputs": [],
-            "outputs": [],
-            "providers": [],
-            "selector": "lg-reactive-form",
-            "styleUrls": [],
-            "styles": [],
-            "template": "<form [formGroup]=\"form\">\n  <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n  </lg-sort-code>\n</form>\n",
-            "templateUrl": [],
-            "viewProviders": [],
-            "inputsClass": [
-                {
-                    "name": "disabled",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 29,
-                    "type": "boolean"
-                },
-                {
-                    "name": "focus",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 26,
-                    "type": "boolean"
-                },
-                {
-                    "name": "hint",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 24,
-                    "type": "string"
-                },
-                {
-                    "name": "label",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 25,
-                    "type": "string"
-                }
-            ],
-            "outputsClass": [
-                {
-                    "name": "inputChange",
-                    "defaultValue": "new EventEmitter<void>()",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 40,
-                    "type": "EventEmitter"
-                }
-            ],
-            "propertiesClass": [
-                {
-                    "name": "fb",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormBuilder",
-                    "optional": false,
-                    "description": "",
-                    "line": 44,
-                    "modifierKind": [
-                        123
-                    ]
-                },
-                {
-                    "name": "form",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormGroup",
-                    "optional": false,
-                    "description": "",
-                    "line": 42
-                }
-            ],
-            "methodsClass": [],
-            "deprecated": false,
-            "deprecationMessage": "",
-            "hostBindings": [],
-            "hostListeners": [],
-            "description": "",
-            "rawdescription": "\n",
-            "type": "component",
-            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata } from '@storybook/angular';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { action } from '@storybook/addon-actions';\n\nimport { LgSortCodeComponent } from './sort-code.component';\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './sort-code.notes';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-sort-code formControlName=\"sortCode\" [focus]=\"focus\">\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n      </lg-sort-code>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n  @Input() focus: boolean;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled) {\n      this.form.controls.sortCode.disable();\n    } else {\n      this.form.controls.sortCode.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.sortCode.disabled;\n  }\n\n  @Output() inputChange = new EventEmitter<void>();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      sortCode: [''],\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Sort Code',\n  component: LgSortCodeComponent,\n  decorators: [\n    withKnobs,\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, CanopyModule],\n    }),\n  ],\n  parameters: {\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n});\n",
-            "assetsDirs": [],
-            "styleUrlsData": "",
-            "stylesData": "",
-            "constructorObj": {
-                "name": "constructor",
-                "description": "",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "args": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": ""
-                    }
-                ],
-                "line": 42,
-                "jsdoctags": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "tagName": {
-                            "text": "param"
-                        }
-                    }
-                ]
-            },
-            "accessors": {
-                "disabled": {
-                    "name": "disabled",
-                    "setSignature": {
-                        "name": "disabled",
-                        "type": "void",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "args": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": ""
-                            }
-                        ],
-                        "returnType": "void",
-                        "line": 29,
-                        "jsdoctags": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": "",
-                                "tagName": {
-                                    "text": "param"
-                                }
-                            }
-                        ]
-                    },
-                    "getSignature": {
-                        "name": "disabled",
-                        "type": "boolean",
-                        "returnType": "boolean",
-                        "line": 36
                     }
                 }
             },
@@ -25892,7 +25892,7 @@
         },
         {
             "name": "SwatchBrandIconComponent",
-            "id": "component-SwatchBrandIconComponent-b3667c3991251ed1c40718a675085e6c",
+            "id": "component-SwatchBrandIconComponent-d1afae42a65c0c707a1392ab4fb05ba1",
             "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -25912,21 +25912,21 @@
                     "name": "colour",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 78,
+                    "line": 77,
                     "type": "string"
                 },
                 {
                     "name": "size",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 77,
+                    "line": 76,
                     "type": "string"
                 },
                 {
                     "name": "specificColour",
                     "deprecated": false,
                     "deprecationMessage": "",
-                    "line": 79,
+                    "line": 78,
                     "type": "string"
                 }
             ],
@@ -25939,7 +25939,7 @@
                     "type": "SafeStyle",
                     "optional": false,
                     "description": "",
-                    "line": 82
+                    "line": 81
                 },
                 {
                     "name": "icons",
@@ -25949,7 +25949,7 @@
                     "type": "",
                     "optional": false,
                     "description": "",
-                    "line": 81
+                    "line": 80
                 }
             ],
             "methodsClass": [
@@ -25965,7 +25965,7 @@
                     "optional": false,
                     "returnType": "void",
                     "typeParameters": [],
-                    "line": 88,
+                    "line": 87,
                     "deprecated": false,
                     "deprecationMessage": "",
                     "jsdoctags": [
@@ -25987,7 +25987,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';\nimport { DomSanitizer, SafeStyle } from '@angular/platform-browser';\n\nimport { select, withKnobs } from '@storybook/addon-knobs';\nimport { moduleMetadata } from '@storybook/angular';\n\nimport { LgBrandIconComponent } from './brand-icon.component';\nimport { notes } from './brand-icon.notes';\nimport { LgBrandIconRegistry } from './brand-icon.registry';\nimport * as brandIconSet from './brand-icons.interface';\n\nexport const brandIconsArray: Array<brandIconSet.BrandIcon> = [\n  brandIconSet.lgBrandIconCalendar,\n  brandIconSet.lgBrandIconChangeExistingHoldings,\n  brandIconSet.lgBrandIconChangeFutureContributions,\n  brandIconSet.lgBrandIconCookiesAndArrows,\n  brandIconSet.lgBrandIconErrorInBrowser,\n  brandIconSet.lgBrandIconGuaranteedIncome,\n  brandIconSet.lgBrandIconNoInformation,\n  brandIconSet.lgBrandIconNoTransactionsMatch,\n  brandIconSet.lgBrandIconPaymentSuccess,\n  brandIconSet.lgBrandIconPensionPot,\n  brandIconSet.lgBrandIconPeople,\n  brandIconSet.lgBrandIconPerformance,\n  brandIconSet.lgBrandIconPiggyBank,\n  brandIconSet.lgBrandIconRainOrShine,\n  brandIconSet.lgBrandIconSun,\n  brandIconSet.lgBrandIconSurvey,\n  brandIconSet.lgBrandIconThumbsUp,\n  brandIconSet.lgBrandIconVideoGuides,\n  brandIconSet.lgBrandIconWarning,\n  brandIconSet.lgBrandIconMinutes,\n  brandIconSet.lgBrandIconQuickAndEasy,\n  brandIconSet.lgBrandIconHandFlower,\n];\n\n@Component({\n  selector: 'lg-swatch-brand-icon',\n  template: `\n    <div class=\"swatch\" *ngFor=\"let icon of icons; let i = index\">\n      <lg-brand-icon\n        class=\"swatch__svg\"\n        [name]=\"icon.name\"\n        [size]=\"size\"\n        [colour]=\"i === 0 ? specificColour : null\"\n        [attr.style]=\"cssVar\"\n      ></lg-brand-icon>\n      <span class=\"swatch__name\">{{ icon.name }}</span>\n    </div>\n  `,\n  styles: [\n    `\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-md);\n        flex: 0 0 8rem;\n      }\n\n      .swatch__name {\n        display: block;\n        text-align: center;\n        margin-top: var(--space-xxs);\n      }\n\n      .swatch__svg {\n        display: block;\n        margin: 0 auto;\n      }\n    `,\n  ],\n})\nclass SwatchBrandIconComponent implements OnChanges {\n  @Input() size: string;\n  @Input() colour: string;\n  @Input() specificColour: string;\n\n  icons = brandIconsArray;\n  cssVar: SafeStyle;\n\n  constructor(private registry: LgBrandIconRegistry, private sanitizer: DomSanitizer) {\n    this.registry.registerBrandIcon(this.icons);\n  }\n\n  ngOnChanges({ colour }: SimpleChanges) {\n    if (colour && colour.currentValue) {\n      this.cssVar = this.sanitizer.bypassSecurityTrustStyle(\n        `--brand-icon-fill-primary: var(${colour.currentValue})`,\n      );\n    }\n  }\n}\n\nconst sizes = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'];\n\nexport default {\n  title: 'Components/Brand Icon',\n  excludeStories: ['brandIconsArray'],\n  parameters: {\n    decorators: [\n      withKnobs,\n      moduleMetadata({\n        declarations: [SwatchBrandIconComponent, LgBrandIconComponent],\n      }),\n    ],\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nconst colours = [\n  '--color-dandelion-yellow',\n  '--color-super-blue',\n  '--color-lily-green',\n  '--color-shocking-pink',\n  '--color-poppy-red-dark',\n];\n\nexport const standard = () => ({\n  template: `\n    <lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [specificColour]=\"specificColour\"></lg-swatch-brand-icon>\n  `,\n  props: {\n    size: select('size', sizes, 'xs'),\n    colour: select(\n      'example of applying colour globally',\n      colours,\n      '--color-dandelion-yellow',\n    ),\n    specificColour: select(\n      'example of applying colour specifically to an icon',\n      colours,\n      '--color-super-blue',\n    ),\n  },\n});\n",
+            "sourceCode": "import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';\nimport { DomSanitizer, SafeStyle } from '@angular/platform-browser';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { LgBrandIconComponent } from './brand-icon.component';\nimport { notes } from './brand-icon.notes';\nimport { LgBrandIconRegistry } from './brand-icon.registry';\n\nimport * as brandIconSet from './brand-icons.interface';\n\nconst brandIconsArray: Array<brandIconSet.BrandIcon> = [\n  brandIconSet.lgBrandIconCalendar,\n  brandIconSet.lgBrandIconChangeExistingHoldings,\n  brandIconSet.lgBrandIconChangeFutureContributions,\n  brandIconSet.lgBrandIconCookiesAndArrows,\n  brandIconSet.lgBrandIconErrorInBrowser,\n  brandIconSet.lgBrandIconGuaranteedIncome,\n  brandIconSet.lgBrandIconNoInformation,\n  brandIconSet.lgBrandIconNoTransactionsMatch,\n  brandIconSet.lgBrandIconPaymentSuccess,\n  brandIconSet.lgBrandIconPensionPot,\n  brandIconSet.lgBrandIconPeople,\n  brandIconSet.lgBrandIconPerformance,\n  brandIconSet.lgBrandIconPiggyBank,\n  brandIconSet.lgBrandIconRainOrShine,\n  brandIconSet.lgBrandIconSun,\n  brandIconSet.lgBrandIconSurvey,\n  brandIconSet.lgBrandIconThumbsUp,\n  brandIconSet.lgBrandIconVideoGuides,\n  brandIconSet.lgBrandIconWarning,\n  brandIconSet.lgBrandIconMinutes,\n  brandIconSet.lgBrandIconQuickAndEasy,\n  brandIconSet.lgBrandIconHandFlower,\n];\n@Component({\n  selector: 'lg-swatch-brand-icon',\n  template: `\n    <div class=\"swatch\" *ngFor=\"let icon of icons; let i = index\">\n      <lg-brand-icon\n        class=\"swatch__svg\"\n        [name]=\"icon.name\"\n        [size]=\"size\"\n        [colour]=\"i === 0 ? specificColour : null\"\n        [attr.style]=\"cssVar\"\n      ></lg-brand-icon>\n      <span class=\"swatch__name\">{{ icon.name }}</span>\n    </div>\n  `,\n  styles: [\n    `\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-md);\n        flex: 0 0 8rem;\n      }\n\n      .swatch__name {\n        display: block;\n        text-align: center;\n        margin-top: var(--space-xxs);\n      }\n\n      .swatch__svg {\n        display: block;\n        margin: 0 auto;\n      }\n    `,\n  ],\n})\nclass SwatchBrandIconComponent implements OnChanges {\n  @Input() size: string;\n  @Input() colour: string;\n  @Input() specificColour: string;\n\n  icons = brandIconsArray;\n  cssVar: SafeStyle;\n\n  constructor(private registry: LgBrandIconRegistry, private sanitizer: DomSanitizer) {\n    this.registry.registerBrandIcon(this.icons);\n  }\n\n  ngOnChanges({ colour }: SimpleChanges) {\n    if (colour && colour.currentValue) {\n      this.cssVar = this.sanitizer.bypassSecurityTrustStyle(\n        `--brand-icon-fill-primary: var(${colour.currentValue})`,\n      );\n    }\n  }\n}\n\nconst sizes = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'];\n\nconst colours = [\n  '--color-dandelion-yellow',\n  '--color-super-blue',\n  '--color-lily-green',\n  '--color-shocking-pink',\n  '--color-poppy-red-dark',\n];\n\nexport default {\n  title: 'Components/Brand Icon',\n  decorators: [\n    moduleMetadata({\n      declarations: [SwatchBrandIconComponent, LgBrandIconComponent],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    size: {\n      options: sizes,\n      description: 'The size of the icon',\n      table: {\n        type: {\n          summary: sizes,\n        },\n        defaultValue: {\n          summary: 'sm',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n    gloablColour: {\n      options: colours,\n      description:\n        'The primary colour of icons globally. Can be changed by overriding the `--brand-icon-fill-primary` CSS variable.',\n      table: {\n        defaultValue: {\n          summary: '--color-dandelion-yellow',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n    colour: {\n      options: colours,\n      description: 'The colour of a specific icon, using the `colour` input',\n      table: {\n        type: {\n          summary: colours,\n        },\n        defaultValue: {\n          summary: '--color-dandelion-yellow',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n  },\n};\n\n\nconst brandIconsTemplate: Story<LgBrandIconComponent> = (args: LgBrandIconComponent) => ({\n  props: args,\n  template: '<lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [specificColour]=\"specificColour\"></lg-swatch-brand-icon>',\n});\n\nexport const standardBrandIcons = brandIconsTemplate.bind({});\nstandardBrandIcons.storyName = 'Standard';\nstandardBrandIcons.args = {\n  size: 'sm'\n}\nstandardBrandIcons.parameters = {\n  docs: {\n    description: {\n      component: notes,\n    },\n  },\n};\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-md);\n        flex: 0 0 8rem;\n      }\n\n      .swatch__name {\n        display: block;\n        text-align: center;\n        margin-top: var(--space-xxs);\n      }\n\n      .swatch__svg {\n        display: block;\n        margin: 0 auto;\n      }\n    \n",
@@ -26010,7 +26010,7 @@
                         "deprecationMessage": ""
                     }
                 ],
-                "line": 82,
+                "line": 81,
                 "jsdoctags": [
                     {
                         "name": "registry",
@@ -29682,6 +29682,16 @@
                 "defaultValue": "[\n  brandIconSet.lgBrandIconCalendar,\n  brandIconSet.lgBrandIconChangeExistingHoldings,\n  brandIconSet.lgBrandIconChangeFutureContributions,\n  brandIconSet.lgBrandIconCookiesAndArrows,\n  brandIconSet.lgBrandIconErrorInBrowser,\n  brandIconSet.lgBrandIconGuaranteedIncome,\n  brandIconSet.lgBrandIconNoInformation,\n  brandIconSet.lgBrandIconNoTransactionsMatch,\n  brandIconSet.lgBrandIconPaymentSuccess,\n  brandIconSet.lgBrandIconPensionPot,\n  brandIconSet.lgBrandIconPeople,\n  brandIconSet.lgBrandIconPerformance,\n  brandIconSet.lgBrandIconPiggyBank,\n  brandIconSet.lgBrandIconRainOrShine,\n  brandIconSet.lgBrandIconSun,\n  brandIconSet.lgBrandIconSurvey,\n  brandIconSet.lgBrandIconThumbsUp,\n  brandIconSet.lgBrandIconVideoGuides,\n  brandIconSet.lgBrandIconWarning,\n  brandIconSet.lgBrandIconMinutes,\n  brandIconSet.lgBrandIconQuickAndEasy,\n  brandIconSet.lgBrandIconHandFlower,\n]"
             },
             {
+                "name": "brandIconsTemplate",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story<LgBrandIconComponent>",
+                "defaultValue": "(args: LgBrandIconComponent) => ({\n  props: args,\n  template: '<lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [specificColour]=\"specificColour\"></lg-swatch-brand-icon>',\n})"
+            },
+            {
                 "name": "button",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -29745,11 +29755,11 @@
                 "name": "colours",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/styles/color.stories.ts",
+                "file": "projects/canopy/src/lib/icon/icons.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <h2>Shades</h2>\n\n    <div>\n      <lg-swatch name=\"--color-white\"></lg-swatch>\n      <lg-swatch name=\"--color-white-smoke\"></lg-swatch>\n      <lg-swatch name=\"--color-platinum\"></lg-swatch>\n      <lg-swatch name=\"--color-taupe-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-battleship-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-charcoal\"></lg-swatch>\n      <lg-swatch name=\"--color-black\"></lg-swatch>\n    </div>\n\n    <h2>Colours</h2>\n\n    <div>\n      <div>\n        <lg-swatch name=\"--color-lavender\"></lg-swatch>\n        <lg-swatch name=\"--color-sky-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-super-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-midnight-blue\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-tea-green\"></lg-swatch>\n        <lg-swatch name=\"--color-lily-green\"></lg-swatch>\n        <lg-swatch name=\"--color-leafy-green\"></lg-swatch>\n        <lg-swatch name=\"--color-mexican-green\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-dusky-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-shocking-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-poppy-red\"></lg-swatch>\n        <lg-swatch name=\"--color-terracotta\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-champagne\"></lg-swatch>\n        <lg-swatch name=\"--color-dandelion-yellow\"></lg-swatch>\n        <lg-swatch name=\"--color-harvest-gold\"></lg-swatch>\n        <lg-swatch name=\"--color-earth-brown\"></lg-swatch>\n      </div>\n    </div>\n\n    <h2>Tints</h2>\n\n    <div>\n      <div>\n        <lg-tint-swatch\n          names=\"--color-super-blue-lightest,--color-super-blue-light,--color-super-blue,--color-super-blue-dark,--color-super-blue-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-leafy-green-lightest,--color-leafy-green-light,--color-leafy-green,--color-leafy-green-dark,--color-leafy-green-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-poppy-red-lightest,--color-poppy-red-light,--color-poppy-red,--color-poppy-red-dark\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-dandelion-yellow-lightest,--color-dandelion-yellow-light,--color-dandelion-yellow\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-earth-brown,--color-earth-brown-dark,--color-earth-brown-darkest\">\n      </lg-tint-swatch>\n      </div>\n    </div>\n  `,\n})"
+                "type": "[]",
+                "defaultValue": "[\n  '--color-charcoal',\n  '--color-super-blue',\n  '--color-leafy-green-dark',\n  '--color-poppy-red-dark',\n]"
             },
             {
                 "name": "colours",
@@ -29765,11 +29775,11 @@
                 "name": "colours",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/icon/icons.stories.ts",
+                "file": "projects/canopy/src/styles/color.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
-                "type": "[]",
-                "defaultValue": "[\n  '--color-charcoal',\n  '--color-super-blue',\n  '--color-leafy-green-dark',\n  '--color-poppy-red-dark',\n]"
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <h2>Shades</h2>\n\n    <div>\n      <lg-swatch name=\"--color-white\"></lg-swatch>\n      <lg-swatch name=\"--color-white-smoke\"></lg-swatch>\n      <lg-swatch name=\"--color-platinum\"></lg-swatch>\n      <lg-swatch name=\"--color-taupe-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-battleship-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-charcoal\"></lg-swatch>\n      <lg-swatch name=\"--color-black\"></lg-swatch>\n    </div>\n\n    <h2>Colours</h2>\n\n    <div>\n      <div>\n        <lg-swatch name=\"--color-lavender\"></lg-swatch>\n        <lg-swatch name=\"--color-sky-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-super-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-midnight-blue\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-tea-green\"></lg-swatch>\n        <lg-swatch name=\"--color-lily-green\"></lg-swatch>\n        <lg-swatch name=\"--color-leafy-green\"></lg-swatch>\n        <lg-swatch name=\"--color-mexican-green\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-dusky-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-shocking-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-poppy-red\"></lg-swatch>\n        <lg-swatch name=\"--color-terracotta\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-champagne\"></lg-swatch>\n        <lg-swatch name=\"--color-dandelion-yellow\"></lg-swatch>\n        <lg-swatch name=\"--color-harvest-gold\"></lg-swatch>\n        <lg-swatch name=\"--color-earth-brown\"></lg-swatch>\n      </div>\n    </div>\n\n    <h2>Tints</h2>\n\n    <div>\n      <div>\n        <lg-tint-swatch\n          names=\"--color-super-blue-lightest,--color-super-blue-light,--color-super-blue,--color-super-blue-dark,--color-super-blue-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-leafy-green-lightest,--color-leafy-green-light,--color-leafy-green,--color-leafy-green-dark,--color-leafy-green-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-poppy-red-lightest,--color-poppy-red-light,--color-poppy-red,--color-poppy-red-dark\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-dandelion-yellow-lightest,--color-dandelion-yellow-light,--color-dandelion-yellow\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-earth-brown,--color-earth-brown-dark,--color-earth-brown-darkest\">\n      </lg-tint-swatch>\n      </div>\n    </div>\n  `,\n})"
             },
             {
                 "name": "columns",
@@ -29785,21 +29795,11 @@
                 "name": "components",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/accordion/accordion.module.ts",
+                "file": "projects/canopy/src/lib/promo-card/promo-card.module.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
-                "defaultValue": "[\n  LgAccordionComponent,\n  LgAccordionItemComponent,\n  LgAccordionPanelHeadingComponent,\n  LgAccordionItemContentDirective,\n]"
-            },
-            {
-                "name": "components",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/card/card.module.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "[]",
-                "defaultValue": "[\n  LgCardComponent,\n  LgCardHeaderComponent,\n  LgCardTitleComponent,\n  LgCardFooterComponent,\n  LgCardSubtitleComponent,\n  LgCardPrincipleDataPointComponent,\n  LgCardPrincipleDataPointLabelComponent,\n  LgCardPrincipleDataPointValueComponent,\n  LgCardPrincipleDataPointDateComponent,\n  LgCardContentComponent,\n]"
+                "defaultValue": "[\n  LgPromoCardComponent,\n  LgPromoCardListComponent,\n  LgPromoCardTitleComponent,\n  LgPromoCardFooterComponent,\n  LgPromoCardContentComponent,\n  LgPromoCardImageComponent,\n  LgPromoCardListTitleComponent,\n]"
             },
             {
                 "name": "components",
@@ -29815,11 +29815,21 @@
                 "name": "components",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/promo-card/promo-card.module.ts",
+                "file": "projects/canopy/src/lib/card/card.module.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
-                "defaultValue": "[\n  LgPromoCardComponent,\n  LgPromoCardListComponent,\n  LgPromoCardTitleComponent,\n  LgPromoCardFooterComponent,\n  LgPromoCardContentComponent,\n  LgPromoCardImageComponent,\n  LgPromoCardListTitleComponent,\n]"
+                "defaultValue": "[\n  LgCardComponent,\n  LgCardHeaderComponent,\n  LgCardTitleComponent,\n  LgCardFooterComponent,\n  LgCardSubtitleComponent,\n  LgCardPrincipleDataPointComponent,\n  LgCardPrincipleDataPointLabelComponent,\n  LgCardPrincipleDataPointValueComponent,\n  LgCardPrincipleDataPointDateComponent,\n  LgCardContentComponent,\n]"
+            },
+            {
+                "name": "components",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/accordion/accordion.module.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "[]",
+                "defaultValue": "[\n  LgAccordionComponent,\n  LgAccordionItemComponent,\n  LgAccordionPanelHeadingComponent,\n  LgAccordionItemContentDirective,\n]"
             },
             {
                 "name": "components",
@@ -29835,16 +29845,6 @@
                 "name": "components",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/side-nav/side-nav.module.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "[]",
-                "defaultValue": "[\n  LgSideNavComponent,\n  LgSideNavContentComponent,\n  LgSideNavBarComponent,\n  LgSideNavBarItemComponent,\n  LgSideNavBarFooterComponent,\n  LgSideNavBarItemHeadingComponent,\n  LgSideNavBarItemContentComponent,\n  LgSideNavBarLinkDirective,\n]"
-            },
-            {
-                "name": "components",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/carousel/carousel.module.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -29855,11 +29855,31 @@
                 "name": "components",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/side-nav/side-nav.module.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "[]",
+                "defaultValue": "[\n  LgSideNavComponent,\n  LgSideNavContentComponent,\n  LgSideNavBarComponent,\n  LgSideNavBarItemComponent,\n  LgSideNavBarFooterComponent,\n  LgSideNavBarItemHeadingComponent,\n  LgSideNavBarItemContentComponent,\n  LgSideNavBarLinkDirective,\n]"
+            },
+            {
+                "name": "components",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/table/table.module.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
                 "defaultValue": "[\n  LgTableComponent,\n  LgTableCellComponent,\n  LgTableHeadComponent,\n  LgTableRowComponent,\n  LgTableExpandedDetailComponent,\n  LgTableRowToggleComponent,\n  LgTableBodyComponent,\n  LgTableHeadCellComponent,\n]"
+            },
+            {
+                "name": "contentGroupId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/input/input.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "string",
+                "defaultValue": "'content'"
             },
             {
                 "name": "contentGroupId",
@@ -29882,20 +29902,10 @@
                 "defaultValue": "'content'"
             },
             {
-                "name": "contentGroupId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "string",
-                "defaultValue": "'content'"
-            },
-            {
                 "name": "context",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/test.ts",
+                "file": "projects/canopy-test-app/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -29905,7 +29915,7 @@
                 "name": "context",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy-test-app/src/test.ts",
+                "file": "projects/canopy/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -30005,26 +30015,6 @@
                 "name": "detailsTemplate",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/details/details.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "Story<LgDetailsComponent>",
-                "defaultValue": "(args: LgDetailsComponent) => ({\n  props: args,\n  template,\n})"
-            },
-            {
-                "name": "detailsTemplate",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/footer/footer.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "Story<LgFooterComponent>",
-                "defaultValue": "(args: LgFooterComponent) => ({\n  props: args,\n  template,\n})"
-            },
-            {
-                "name": "detailsTemplate",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/header/header.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -30040,6 +30030,26 @@
                 "deprecationMessage": "",
                 "type": "Story<LgHeadingComponent>",
                 "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
+            },
+            {
+                "name": "detailsTemplate",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/details/details.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story<LgDetailsComponent>",
+                "defaultValue": "(args: LgDetailsComponent) => ({\n  props: args,\n  template,\n})"
+            },
+            {
+                "name": "detailsTemplate",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/footer/footer.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story<LgFooterComponent>",
+                "defaultValue": "(args: LgFooterComponent) => ({\n  props: args,\n  template,\n})"
             },
             {
                 "name": "environment",
@@ -33205,177 +33215,7 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/accordion/accordion.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/brand-icon/brand-icon.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/details/details.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/icon/icon.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/prefix/prefix.directive.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/tabs/tabs.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/suffix/suffix.directive.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/date/date-field.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/hint/hint.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/label/label.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select-field.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select.directive.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33395,7 +33235,17 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
+                "file": "projects/canopy/src/lib/brand-icon/brand-icon.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/prefix/prefix.directive.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33415,7 +33265,167 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/accordion/accordion.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select.directive.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select-field.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/label/label.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/table/table/table.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/hint/hint.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/date/date-field.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/details/details.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/icon/icon.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/tabs/tabs.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -33425,11 +33435,61 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/styles/color.notes.ts",
+                "file": "projects/canopy/src/lib/quick-action/quick-action.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Colours\n\n## Purpose\nProvides available brand colours and tints via CSS variables\n\n## Usage\nImport the css into the angular.json file of your application, the variables should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\n`"
+                "defaultValue": "`\n# Quick Action Component\n\n## Purpose\nQuick Actions are small clickable elements that can be used to provide functionality in context, such as editing a form or actions on a card.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgQuickActionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-quick-action>\n  <lg-icon name=\"repeat\"></lg-icon>\n  Load more\n</button>\n~~~\n\nor:\n\n~~~html\n<a lg-quick-action\n  href=\"/mailbox\">\n  <lg-icon name=\"secure-message\"></lg-icon>\n  Send us a message\n</a>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/icon/icon.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Icon Component\n\n## Purpose\nProvides a way of adding common svg icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgIconModule],\n})\n~~~\n\nImport the \\`LgIconRegistry\\` and register your icons:\n\n~~~js\nexport class AppModule {\n  constructor(private iconRegistry: LgIconRegistry) {\n    this.iconRegistry.registerIcons([\n      lgIconEmail\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-icon name=\"email\"></lg-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n\nAll icons have height and width equal to 1em. This means the icons will be as big as the font-size specified by the parent.\n\n*By default the icons have the \\`\\`fill\\`\\` css property set to \\`\\`currentColor\\`\\`.*\n\n> \\`\\`currentColor\\`\\` acts like a variable for the current value of the \\`\\`color\\`\\` property on the element. And the Cascading part of CSS is still effective, so if there’s no defined \\`\\`color\\`\\` property on an element, the cascade will determine the value of \\`\\`currentColor\\`\\`.\n>\n> *Understanding the currentColor Keyword in CSS - https://alligator.io/css/currentcolor/*\n\n*Please note that the 'need-help' and 'question-mark' icons currently don't have the ability to change colour.*\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/input/input.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Input Component\n\n## Purpose\nProvides a common input directive and input field component. The input field component deals with linking the label and field.\nThe width of the input field is controlled by the HTML size attribute, this allows us to provide the user with an indication of the expected length of the value.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgInputModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n</lg-input-field>\n~~~\n\n### Adding input buttons\n\nButtons can be added within input fields to provide functionality linked to the input.\nThe \\`lgSuffix\\` directive needs to be added to the button to place it in the correct place.\nOnly small size buttons should be placed in the input field.\nThere is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.\n\n#### Button suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\">\n    Search\n  </button>\n</lg-input-field>\n~~~\n\n#### Icon Button suffix with add-on class\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\" [iconButton]=\"true\" variant=\"add-on\">\n    <lg-icon name=\"search\" />\n  </button>\n</lg-input-field>\n~~~\n\n### Adding prefixes and suffixes\n\nPrefix and suffix text can be added to input fields using the \\`lgSuffix\\` and \\`lgPrefix\\` directive.\n\n#### Text prefix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgPrefix>£</span>\n</lg-input-field>\n~~~\n\n#### Text suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgSuffix>%</span>\n</lg-input-field>\n~~~\n\n## Inputs\n\n### LgInputDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n\n### LgInputFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the input full width (for small screens only). | boolean | false | no\n| \\`\\`showLabel\\`\\` | Show or visually hide the label | boolean | true | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/hero/hero.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "(name: string, modifier?) => `\n# ${name} Group Components\n\n## Purpose\nProvides a set of components to implement ${name} groups in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more Toggle components. The Toggle component represents a single ${name.toLowerCase()}. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the CheckboxGroup Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgCheckboxGroupModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg-toggle value=\"red\">Red</lg-toggle>\n  <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\nor\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"red\">Red</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"yellow\">Yellow</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\n## Inputs\n\n### LgCheckboxGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-checkbox-group-id-\\${this.nextUniqueId}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-checkbox-group-\\${this.nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Sets the default checked ${name.toLowerCase()} buttons, must match the values of the ${name.toLowerCase()} buttons | array of strings | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`inline\\`\\` | If true, displays the ${\n  name.toLowerCase\n}s inline rather than stacked | boolean | false | No |\n\n### LgToggleComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Value that is set when the toggle is checked | string | null | No |\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`focus\\`\\` | Set the focus on the input | boolean | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/date/date-field.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Date Input Component\n\n## Purpose\nProvides a component for capturing and validating a date. Output is a concatenation of individual string values into a valid ISO 8601 date format 'YYYY-MM-DD'.\n\n## Usage\nImport the Date Input Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgDateFieldModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-date-field formControlName=\"date\">\n    Date of birth\n    <lg-hint>For example, 12 06 1983</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(date, validationForm)\">\n      <ng-container *ngIf=\"date.hasError('invalidField')\">\n        Enter a valid {{ date.errors.invalidField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidFields')\">\n        Enter a valid {{ date.errors.invalidFields[0] }} and\n        {{ date.errors.invalidFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredField')\">\n        Date of birth must include a {{ date.errors.requiredField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredFields')\">\n        Date of birth must include a {{ date.errors.requiredFields[0] }} and\n        {{ date.errors.requiredFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidDate')\">\n        Enter a valid date of birth\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('futureDate')\">\n        Date must be in the past\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('required')\">\n        Enter a date of birth\n      </ng-container>\n    </lg-validation>\n  </lg-date-field>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgDateFieldComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`dateId\\`\\` | HTML ID attribute for the date input, auto generated if not provided | string | 'lg-input-date-\\${nextUniqueId++}' | No |\n| \\`\\`monthId\\`\\` | HTML ID attribute for the month input, auto generated if not provided | string | 'lg-input-month-\\${nextUniqueId++}' | No |\n| \\`\\`yearId\\`\\` | HTML ID attribute for the year input, auto generated if not provided | string | 'lg-input-year-\\${nextUniqueId++}' | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the date field, if not provided it will use the hint field where appropriate | string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n\n## Validation\nDate validation is quite complex with a range of different validation errors, where possible we have encapsulated as much of that complexity into the components as we can.\n\nInternally the date-field can determine if the entered date is a valid date. If additional validation is required such as checking for past or future dates this can be done with external validators.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n### Internal validation\nIn some scenarios there could be multiple fields that are incorrect, to help guide the users to the correct issue the date field only returns the most significant validation error. Only one error should be shown at a time.\n\nOnce the user has rectified the first error the next error will take it's place if there is one. This allows us to write linear lists of validation messages without the need to apply complex logic in the applications.\n\nThe current significance of errors with their recommended messages is as follows.\n\n#### 1. Invalid fields\n\nOne field is invalid, this may be a non numerical character, or a number outside the valid range .e.g 13 for a month.\n\\`Enter a valid month\\`\n\n~~~json\n{ invalidField: 'month'}\n~~~\n\n\nAs above but with two fields displaying an error.\n\\`Enter a valid month and year\\`\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are invalid a generic 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Required fields\n\nIf one field is empty either through form submission or inline deletion of the content.\n\\`Date of birth must include month\\`\n\n~~~json\n{ requiredField: 'month'}\n~~~\n\nAs above but with two fields missing.\n\\`Date of birth must include a month and year\\`\n\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are missing an 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Invalid date\n\nIf all of the individual fields are correct but they do not concatenate to a valid date. e.g. 30 02 2020\n\n~~~json\n{ invalidDate: true }\n~~~\n\\`Enter a valid date of birth\\`\n\n### External validation\n\nIt is also possible to provide your own custom validation messages using [custom validators](https://angular.io/guide/form-validation#custom-validators)\nand the validation component. This is particularly useful for checking things like wether the date is in the past or the future. Under the hood the date field uses the [date-fns](https://date-fns.org/) library as a peer dependency, to keep build size to a minimum it may be worth considering using the same library in your application.\n\n~~~js\nfunction notMondayValidator(): ValidatorFn {\n  return (control: AbstractControl): { [key: string]: any } | null => {\n    return getDay(parseISO(control.value)) === 'monday' ? { notMonday: true } : null;\n  };\n}\n...\nconst date = new FormControl('', [notMondayValidator()])\n~~~\n\n~~~html\n<lg-date-field formControlName=\"date\">\n  Date of appointment\n  <lg-hint>For example, 12 06 1983</lg-hint>\n  <lg-validation *ngIf=\"isControlInvalid(date, validationForm) && date.hasError('notMonday')\">\n    Date cannot be a Monday\n  </lg-validation>\n </lg-date-field>\n~~~\n\n### Additional validators\n\nTo aid with common validation needs some additional reactive form validators are provided.\n\n#### Future date validator\nThis validator checks if the specified date is in the future, if not it returns a futureDate error\n\n~~~js\nimport { futureDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [futureDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('futureDate')\">\n  Date must be in the future\n</ng-container>\n~~~\n\n#### Past date validator\nThis validator checks if the specified date is in the past, if not it returns a pastDate error\n\n~~~js\nimport { pastDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [pastDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('pastDate')\">\n  Date must be in the past\n</ng-container>\n~~~\n\n#### Before date validator\nThis validator checks if the specified date is before another specified date, if not it returns a beforeDate error.\nThe beforeDate error contains the date that it was compared against.\n\n~~~js\nimport { beforeDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [beforeDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('beforeDate')\">\n  Date must be before {{ date.errors.beforeDate.required }}\n</ng-container>\n~~~\n\n#### After date validator\nThis validator checks if the specified date is after another specified date, if not it returns a afterDate error.\nThe afterDate error contains the date that it was compared against.\n\n~~~js\nimport { afterDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [afterDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('afterDate')\">\n  Date must be after {{ date.errors.afterDate.required }}\n</ng-container>\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -33455,161 +33515,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/styles/mixins.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Mixins\n\n## Purpose\nProvides available mixins\n\n## Mixins\n### lg-inner-focus-outline($bg-color, $color: var(--color-white))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\n\\`\\`$color\\`\\`: colour of the outline.\n\nSets the focus outline inside the element, by using multiple box shadows.\n\n### lg-outer-focus-outline($bg-color: var(--default-focus-color))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\nSets the focus outline outside the element, by using box shadows.\n\n### lg-link($default-color, $hover-color, $visited-color, $active-color, $active-bg-color, $focus-color, $focus-bg-color)\n\\`\\`$default-color\\`\\`: the default color of the element (default value: \\`\\`var(--link-color)\\`\\`).\n\n\\`\\`$hover-color\\`\\`: the hover color of the element (default value: \\`\\`var(--link-hover-color)\\`\\`).\n\n\\`\\`$visited-color\\`\\`: the visited color of the element (default value: \\`\\`var(--link-visited-color)\\`\\`).\n\n\\`\\`$active-color\\`\\`: the active color of the element (default value: \\`\\`var(--link-active-color)\\`\\`).\n\n\\`\\`$active-bg-color\\`\\`: the active background color of the element (default value: \\`\\`var(--link-active-bg-color)\\`\\`).\n\n\\`\\`$focus-color\\`\\`: the focus color color of the element (default value: \\`\\`var(--link-focus-color)\\`\\`).\n\n\\`\\`$focus-bg-color\\`\\`: the focus background color of the element (default value: \\`\\`var(--link-focus-bg-color)\\`\\`).\n\nStyles elements with the link style.\n\n### lg-unstyled-link\nRevert the links styles added with \\`\\`lg-link\\`\\`.\n\n### lg-font-size($size)\n\\`\\`$size\\`\\`: The font size, '7' | '6' | '5' | '4' | '3' | '2' | '1' | '-8' | '-6' | .\n\nStyles text to one of the predefined font sizes. '-8' and '-6' are the sub body font sizes.\n\n### lg-visually-hidden()\nProvides styles to hide information intended only for screen readers from the layout of the rendered page.\n\n### lg-breakpoint($breakpoint)\n\\`\\`$breakpoint\\`\\`: string value for the breakpoint screen size.\n\nAllows breakpoints to be added to css blocks.\n\n### lg-variant($variant: 'generic')\n\\`\\`$variant\\`\\`: The variant type, 'generic' | 'info' | 'success' | 'warning' | 'error'.\n\nStyles components and native child elements to the specified variant.\n\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/styles/spacing.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Spacing\n\n## Purpose\nProvides available spacing via CSS variables\n\n## Variables\n| Name | Value | Equivalent in px (based on 16px font-size)\n|------|-------------|-------------|\n| \\`\\`--space-unit\\`\\` | 1rem | 16px |\n| \\`\\`--space-xxxs\\`\\` | calc(0.25 * var(--space-unit)) | 4px |\n| \\`\\`--space-xxs\\`\\` | calc(0.5 * var(--space-unit)) | 8px |\n| \\`\\`--space-xs\\`\\` | calc(0.75 * var(--space-unit)) | 12px |\n| \\`\\`--space-sm\\`\\` | var(--space-unit) | 16px |\n| \\`\\`--space-md\\`\\` | calc(1.5 * var(--space-unit)) | 24px |\n| \\`\\`--space-lg\\`\\` | calc(2 * var(--space-unit)) | 32px |\n| \\`\\`--space-xl\\`\\` | calc(2.5 * var(--space-unit)) | 40px |\n| \\`\\`--space-xxl\\`\\` | calc(3 * var(--space-unit)) | 48px |\n| \\`\\`--space-xxxl\\`\\` | calc(4.5 * var(--space-unit)) | 72px |\n| \\`\\`--space-xxxxl\\`\\` | calc(9 * var(--space-unit)) | 144px |\n\n### For components padding:\n| Name | Value from 0 to md breakpoint | Value from md breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-padding\\`\\` | var(--space-sm) | var(--space-lg) |\n\n### For components margin:\n| Name | Value from 0 to lg breakpoint | Value from lg breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-margin\\`\\` | var(--space-md) | var(--space-lg) |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/styles/typography.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Typography\n\n## Purpose\nProvides common typographic styles for native elements with additional utility classes.\n\nCanopy consists of two fonts:\n\n* **Roboto**: Productive font, for general use in self serve apps (default)\n* **Lyon**: Expressive font, for headings in promo material (applied by class modifier)\n\n> **IMPORTANT** - Lyon font files are not included in the Canopy package, you have to serve it yourself, see below for details.\n\n## Serving the Lyon font files\n\nDue to commercial licensing agreements the Lyon font is not included in the distributed package. You will need to manually add it to the **assets** directory of your application. Canopy does provide the css to work with the font and no additional code should be required. You will  need to ensure the font is in the directory specified by Canopy.\n\nCanopy's path for Lyon is **/assets/fonts/lyon/**, therefore you need to put the font files in the following location:\n\n~~~bash\nmy-app/\n  src/\n    assets/\n      fonts/\n        lyon/\n          lyon-display-regular.woff\n          lyon-display-regular.woff2\n          lyon-display-bold.woff\n          lyon-display-bold.woff2\n~~~\n\n> This will result in the font being served in your app like this: <br />http://my-app.landg.com/assets/fonts/lyon/LyonDisplay-Regular-Web.woff2\n\nWhen you include the canopy.css file in your project, it will try to load the font from that exact path. If your font files are in the wrong location, or have a typo in the filename, the Lyon font won't load correctly.\n\nPlease ensure you have the correct licensing agreement in place before using the Lyon font in your application.\n\n## Usage\nThe typography styles will provide styling for all native text elements e.g. \\`\\`h1\\`\\`, \\`\\`h2\\`\\`, \\`\\`p\\`\\`, \\`\\`em\\`\\`, \\`\\`b\\`\\`, \\`\\`strong\\`\\` etc.\n\nBy default the font used is Roboto.\n\nIn addition to the native styling, the following utility classes are exposed, allowing you to change the font size and weight where required.\n\n~~~html\n.lg-font-size-7\n.lg-font-size-7--strong\n\n.lg-font-size-6\n.lg-font-size-6--strong\n\n.lg-font-size-5\n.lg-font-size-5--strong\n\n.lg-font-size-4\n.lg-font-size-4--strong\n\n.lg-font-size-3\n.lg-font-size-3--strong\n\n.lg-font-size-2\n.lg-font-size-2--strong\n\n.lg-font-size-1\n.lg-font-size-1--strong\n\n.lg-font-size-0-8\n\n.lg-font-size-0-6\n~~~\n\n\\`.lg-font-size-1\\` is the base font size that is used to style native elements like p and span, as the numbers increase so\ndoes the font size up to the largest \\`.lg-font-size-7.\\` Each of the primary font styles also have a \\`--strong\\` modifier.\n\nThere are two additional styles which are smaller \\`.lg-font-size-0-8\\`\nand \\`.lg-font-size-0-6\\`. The utility classes are particularly useful for when you want to decouple the semantics and styling,\nfor example making an h1 look like an h3:\n\n~~~html\n<h1 class=\"lg-font-size-3\">H1 that looks like a H3</h1>\n~~~\n<br />\n\n### Using the Lyon font\n\nLyon can be applied using the modifier class: \\`\\`lg-font--expressive\\`\\`. For example:\n\n~~~html\n<h1 class=\"lg-font--expressive\">Heading in Lyon</h1>\n~~~\n\nIt can also be used in addition to the above utility classes:\n\n~~~html\n<p class=\"lg-font-size-5 lg-font--expressive\">Paragraph in Lyon and font size 5</p>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/styles/utils.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Utils\n\n## Purpose\nProvides available utils classes\n\n## Classes\n| Class | Description |\n|------|-------------|\n| \\`\\`lg-visually-hidden\\`\\` | Hides information intended only for screen readers from the layout of the rendered page. |\n| \\`\\`lg-unstyled-link\\`\\` | Revert the links styles to a more default style. |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/accordion/accordion.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Accordion Component\n\n## Purpose\nAccordions allow users to quickly expand and collapse grouped sections of content.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAccordionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-accordion [headingLevel]=\"2\">\n    <lg-accordion-item [isActive]=\"isActive\" (opened)=\"handleItemOpened()\" (closed)=\"handleItemClosed()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua.</p>\n    </lg-accordion-item>\n    <lg-accordion-item>\n      <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>\n      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\n        ut aliquip ex ea commodo consequat. Duis aute irure dolor in\n        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\n        pariatur.</p>\n      <button lg-button lgMarginTop=\"sm\" variant=\"solid-primary\">\n        Test primary button\n      </button>\n    </lg-accordion-item>\n    <lg-accordion-item (opened)=\"loadDynamicContent()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n\n      <ng-template lgAccordionItemContent>\n        <app-dynamic-component [content]=\"dynamicContentItems$ | async\">\n            An example component that loads data from the network when this panel is opened.\n        </app-dynamic-component>\n      </ng-template>\n    </lg-accordion-item>\n  </lg-accordion>\n~~~\n\n## Accordion Item Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | The active state of the accordion item | boolean | false | No |\n\n\n## Accordion Item Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the accordion item is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the accordion item is closed | EventEmitter<void> | n/a | No |\n\n\n## Lazy content initialisation\n\nWrap the panel content in a \\`ng-template\\` with the \\`lgAccordionContent\\` directive to only initialise and render\nthe panel when it is first opened.\n`"
+                "defaultValue": "`\nAccordions allow users to quickly expand and collapse grouped sections of content.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAccordionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-accordion [headingLevel]=\"2\">\n    <lg-accordion-item [isActive]=\"isActive\" (opened)=\"handleItemOpened()\" (closed)=\"handleItemClosed()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua.</p>\n    </lg-accordion-item>\n    <lg-accordion-item>\n      <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>\n      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\n        ut aliquip ex ea commodo consequat. Duis aute irure dolor in\n        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\n        pariatur.</p>\n      <button lg-button lgMarginTop=\"sm\" variant=\"solid-primary\">\n        Test primary button\n      </button>\n    </lg-accordion-item>\n    <lg-accordion-item (opened)=\"loadDynamicContent()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n\n      <ng-template lgAccordionItemContent>\n        <app-dynamic-component [content]=\"dynamicContentItems$ | async\">\n            An example component that loads data from the network when this panel is opened.\n        </app-dynamic-component>\n      </ng-template>\n    </lg-accordion-item>\n  </lg-accordion>\n~~~\n\n## Accordion Item Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | The active state of the accordion item | boolean | false | No |\n\n\n## Accordion Item Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the accordion item is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the accordion item is closed | EventEmitter<void> | n/a | No |\n\n\n## Lazy content initialisation\n\nWrap the panel content in a \\`ng-template\\` with the \\`lgAccordionContent\\` directive to only initialise and render\nthe panel when it is first opened.\n`"
             },
             {
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/alert/alert.notes.ts",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Brand Icon Component\n\n## Purpose\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` and register your brand icons:\n\n~~~js\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n| \\`\\`size\\`\\` | the size of the icon | BrandIconSize | 'sm' | no |\n| \\`\\`colour\\`\\` | the specific colour of the icon (for global colours see the \"Branding\" section below) | css variable as a string | undefined | no |\n\n## Branding\nThe yellow fill colour of the brand icons can be changed by overriding the \\`--brand-icon-fill-primary\\` css variable.\n\nNote that changing that variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input (see details in the table above).\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/button/button.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Button Component\n\n## Purpose\nProvides common styles and behaviours for buttons and links.\n\n## Usage\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgButtonModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n~~~\n\nor:\n\n~~~html\n<a lg-button href=\"#\" variant=\"primary\">Link</a>\n~~~\n\n## Button with icon with text\n\nIcons can be content projected into the button, the button component will then handle the styling of that icon.\nThe \\`ButtonIconPosition\\` property can be used to locate the icon on the left hand side of the text, the default is to the right hand side.\nContent projection is used as Canopy Icons need loading via the \\`iconRegistry\\` which enables tree shaking of icons.\n\n~~~html\n<button lg-button type=\"button\" iconPosition=\"left\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## Button with icon only\n\nButtons can be setup as icon only buttons, this is done in a similar way to a button with icon and text.\nYou will still need to include text content inside the button as this information is vital to screen readers.\nThe \\`iconButton\\` property is used to visually hide that text.\n\n~~~html\n<button lg-button type=\"button\" iconButton=\"true\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## ButtonComponent inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of button: \\`\\`solid-primary\\`\\`, \\`\\`solid-secondary\\`\\`, \\`\\`outline-primary\\`\\`, \\`\\`outline-secondary\\`\\`, \\`\\`reverse-primary\\`\\`, \\`\\`reverse-secondary\\`\\`, \\`\\`add-on\\`\\`; | string | solid-primary | No |\n| \\`\\`size\\`\\` | The size of the button | ButtonSize [\\`\\`sm\\`\\`, \\`\\`md\\`\\`] | \\`\\`md\\`\\` | No |\n| \\`\\`fullWidth\\`\\` | If the button has to span full width or not. For 'sm' and 'md' sized screens, the button will always be full width and this input has no affect | boolean | false | No |\n| \\`\\`disabled\\`\\` | Programmatically disable the button via this property | boolean | false | No |\n| \\`\\`loading\\`\\` | If the button shows a loading spinner and is also disabled | boolean | false | No |\n| \\`\\`iconPosition\\`\\` | The position of the icon in the button | string | right | No |\n| \\`\\`iconButton\\`\\` | The button displays an icon only | boolean | false | No |\n\n## Button group\n\nButtons can be grouped together by using the \\`\\`ButtonGroupComponent\\`\\`:\n\n~~~html\n<lg-button-group>\n  <button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n  <a lg-button href=\"#\" variant=\"outline-primary\">Link</a>\n</lg-button-group>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/details/details.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\nThe Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgDetailsModule ],\n})\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\nThis module allows you to enable and disable features by using the \\`lgFeatureToggle\\` directive and passing an observable of the toggle's configuration to the module.\n\n## Usage\n\nImport the module in your core component, e.g.:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n})\n~~~\n\nand also import \\`LgFeatureToggleModule\\` (without the \\`forRoot\\`) in the modules that will need it.\n\n\\`useFactory\\` returns an observable of a config file structured as below:\n\n~~~\n{\n  \"exampleFeature\": true,\n  \"anotherExampleFeature\": false\n}\n~~~\n\nThe default behaviour is to show a feature if it's undefined, but we can override it by passing an optional object with defaultHide set to true like this:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n  },\n  {\n    defaultHide: true\n  }\n)\n~~~\n\nIn your component(s) add the structural directive like in the example below:\n\n~~~\n<div *lgFeatureToggle=\"'exampleFeature'\">\n  <p>The enabled feature</p>\n</div>\n\n<div *lgFeatureToggle=\"'anotherExampleFeature'\">\n  <p>The disabled feature</p>\n</div>\n~~~\n\n## FeatureToggleGuard configuration\n\nTo use the FeatureToggleGuard you need to add it to your routes configuration in the usual canActive, canActivateChild, canLoad, and then add in the data property like\n\n~~~\ndata: {\n  featureToggle: 'myToggle',\n},\n~~~\n\nif you use canActivateChild, child route definitions can add its own featureToggle in their data, and the path is only valid when all the featureToggle flags of each route segment are true\n\nExample with a lazy loading route\n\n~~~\n{\n  path: 'parent',\n  loadChildren: () => import('./parent/parent.module').then(m => m.ParentnModule),\n  canActivate: [ FeatureToggleGuard ],\n  canActivateChild: [ FeatureToggleGuard ],\n  canLoad: [ FeatureToggleGuard ],\n  data: {\n    featureToggle: 'parentToggle',\n  },\n},\n~~~\n\nExample of inner routes (route definition inside ParentModule)\n\n~~~\n{\n  path: 'child',\n  component: ChildContainerComponent,\n  data: {\n    featureToggle: 'childToggle',\n  },\n},\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/card/card.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Card Component\n\n## Purpose\nProvides a generic card component for displaying content. Consists of various card components that are designed to create modular and flexible card layouts, from a basic card with a title, text and buttons to a single-page Form Journey card.\n\n## Usage\n\nFor a basic card, import the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgCardModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-card>\n  <lg-card-header>\n    Your title\n  </lg-card-header>\n  <lg-card-content>\n    Your content\n  </lg-card-content>\n</lg-card>\n~~~\n\n---\n\n### Other card types and templates\n\nYou can extend the basic card component and create specific card implementations.\n\n#### Product card\n\nThis component uses some extra card components, such as \\`LgCardPrincipleDataPoint\\` and \\`LgCardPrincipleDataPointValue\\` to display data points.\n\n~~~html\n<lg-card>\n  <lg-card-content>\n    <div lgRow>\n      <div lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-title headingLevel=\"4\">\n          <a href=\"#\">{{title}}</a>.\n        </lg-card-title>\n        <lg-card-subtitle>\n          Payroll Reference Number P23456\n        </lg-card-subtitle>\n      </div>\n      <lg-card-principle-data-point lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-principle-data-point-label>\n          Last payment (after tax and deductions)\n        </lg-card-principle-data-point-label>\n        <lg-card-principle-data-point-value>\n          <span><span class=\"lg-font-size-3\">£</span>230.20</span>\n        </lg-card-principle-data-point-value>\n        <lg-card-principle-data-point-date>\n          as of 01 Jan 2020\n        </lg-card-principle-data-point-date>\n      </lg-card-principle-data-point>\n    </div>\n  </lg-card-content>\n</lg-card>\n~~~\n\n#### Form Journey card\n\nCreates the Form Journey template, used to display a single page form. Note that the <form> element is a parent of the <lg-card> component, this is because the form inputs and submit button are spread out between the card content and card footer.\n\n~~~html\n<div lgContainer>\n<div lgRow>\n  <div lgCol=\"12\" lgColLg=\"6\" lgColLgOffset=\"3\" lgColMd=\"10\" lgColMdOffset=\"1\">\n    <form [formGroup]=\"form\" (ngSubmit)=\"onSubmit(form)\">\n      <lg-card lgPadding=\"none\">\n        <lg-card-header lgPadding=\"sm\" lgPaddingBottom=\"xs\" lgMarginBottom=\"lg\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\">\n                <lg-icon [name]=\"'chevron-left'\"></lg-icon>\n                Back\n              </a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </lg-card-header>\n        <lg-card-content>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <lg-card-title headingLevel=\"3\" lgPaddingBottom=\"md\">{{ title }}</lg-card-title>\n                <p>{{cardContent}}</p>\n\n                <lg-input-field [block]=\"block\">\n                  {{ label }}\n                  <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n                  <input lgInput formControlName=\"accountNumber\" size=\"8\" />\n                </lg-input-field>\n\n              </div>\n            </div>\n          </div>\n        </lg-card-content>\n        <lg-card-footer>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <button lg-button type=\"button\" variant=\"outline-primary\" lgMarginRight=\"sm\">Back</button>\n                <button lg-button type=\"submit\" variant=\"solid-primary\">Confirm</button>\n                <p *ngIf=\"policy\" lgPaddingBottom=\"md\">{{ policy }}</p>\n              </div>\n            </div>\n          </div>\n        </lg-card-footer>\n      </lg-card>\n    </form>\n  </div>\n</div>\n</div>\n~~~\n\n### Inputs\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`<default>\\`\\` | The main body content of the card\n\n### LgCardHeaderComponent\nThis is the primary layout section of the card component, it is used to contain breadcrumbs or other similar content.\n\n### LgCardContent\nThis is the secondary layout section of the card component, it is used to contain the cards main content and provides the inner padding of the card.\n\n### LgCardTitleComponent\nThis is where the main title should be provided. It should be located inside the card content.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgCardSubtitleComponent\nIf the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.\n\n### LgCardPrincipleDataPoint\nSometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card content which will control it's layout\n\n### LgCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointDate\nThis is where the date for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardFooter\nThis is the footer layout section of the card component, it is used to contain call to action buttons as well as messages or hints.\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/focus/focus.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\nThis directive allows for focus to be set dynamically on a focusable element.\n\n## Usage\nImport the directive in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgFocusDirective ],\n})\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/footer/footer.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/grid/grid.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
+                "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
             },
             {
                 "name": "notes",
@@ -33625,11 +33545,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/hero/hero.notes.ts",
+                "file": "projects/canopy/src/lib/card/card.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
+                "defaultValue": "`\n# Card Component\n\n## Purpose\nProvides a generic card component for displaying content. Consists of various card components that are designed to create modular and flexible card layouts, from a basic card with a title, text and buttons to a single-page Form Journey card.\n\n## Usage\n\nFor a basic card, import the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgCardModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-card>\n  <lg-card-header>\n    Your title\n  </lg-card-header>\n  <lg-card-content>\n    Your content\n  </lg-card-content>\n</lg-card>\n~~~\n\n---\n\n### Other card types and templates\n\nYou can extend the basic card component and create specific card implementations.\n\n#### Product card\n\nThis component uses some extra card components, such as \\`LgCardPrincipleDataPoint\\` and \\`LgCardPrincipleDataPointValue\\` to display data points.\n\n~~~html\n<lg-card>\n  <lg-card-content>\n    <div lgRow>\n      <div lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-title headingLevel=\"4\">\n          <a href=\"#\">{{title}}</a>.\n        </lg-card-title>\n        <lg-card-subtitle>\n          Payroll Reference Number P23456\n        </lg-card-subtitle>\n      </div>\n      <lg-card-principle-data-point lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-principle-data-point-label>\n          Last payment (after tax and deductions)\n        </lg-card-principle-data-point-label>\n        <lg-card-principle-data-point-value>\n          <span><span class=\"lg-font-size-3\">£</span>230.20</span>\n        </lg-card-principle-data-point-value>\n        <lg-card-principle-data-point-date>\n          as of 01 Jan 2020\n        </lg-card-principle-data-point-date>\n      </lg-card-principle-data-point>\n    </div>\n  </lg-card-content>\n</lg-card>\n~~~\n\n#### Form Journey card\n\nCreates the Form Journey template, used to display a single page form. Note that the <form> element is a parent of the <lg-card> component, this is because the form inputs and submit button are spread out between the card content and card footer.\n\n~~~html\n<div lgContainer>\n<div lgRow>\n  <div lgCol=\"12\" lgColLg=\"6\" lgColLgOffset=\"3\" lgColMd=\"10\" lgColMdOffset=\"1\">\n    <form [formGroup]=\"form\" (ngSubmit)=\"onSubmit(form)\">\n      <lg-card lgPadding=\"none\">\n        <lg-card-header lgPadding=\"sm\" lgPaddingBottom=\"xs\" lgMarginBottom=\"lg\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\">\n                <lg-icon [name]=\"'chevron-left'\"></lg-icon>\n                Back\n              </a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </lg-card-header>\n        <lg-card-content>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <lg-card-title headingLevel=\"3\" lgPaddingBottom=\"md\">{{ title }}</lg-card-title>\n                <p>{{cardContent}}</p>\n\n                <lg-input-field [block]=\"block\">\n                  {{ label }}\n                  <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n                  <input lgInput formControlName=\"accountNumber\" size=\"8\" />\n                </lg-input-field>\n\n              </div>\n            </div>\n          </div>\n        </lg-card-content>\n        <lg-card-footer>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <button lg-button type=\"button\" variant=\"outline-primary\" lgMarginRight=\"sm\">Back</button>\n                <button lg-button type=\"submit\" variant=\"solid-primary\">Confirm</button>\n                <p *ngIf=\"policy\" lgPaddingBottom=\"md\">{{ policy }}</p>\n              </div>\n            </div>\n          </div>\n        </lg-card-footer>\n      </lg-card>\n    </form>\n  </div>\n</div>\n</div>\n~~~\n\n### Inputs\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`<default>\\`\\` | The main body content of the card\n\n### LgCardHeaderComponent\nThis is the primary layout section of the card component, it is used to contain breadcrumbs or other similar content.\n\n### LgCardContent\nThis is the secondary layout section of the card component, it is used to contain the cards main content and provides the inner padding of the card.\n\n### LgCardTitleComponent\nThis is where the main title should be provided. It should be located inside the card content.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgCardSubtitleComponent\nIf the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.\n\n### LgCardPrincipleDataPoint\nSometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card content which will control it's layout\n\n### LgCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointDate\nThis is where the date for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardFooter\nThis is the footer layout section of the card component, it is used to contain call to action buttons as well as messages or hints.\n`"
             },
             {
                 "name": "notes",
@@ -33645,11 +33565,111 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/icon/icon.notes.ts",
+                "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Icon Component\n\n## Purpose\nProvides a way of adding common svg icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgIconModule],\n})\n~~~\n\nImport the \\`LgIconRegistry\\` and register your icons:\n\n~~~js\nexport class AppModule {\n  constructor(private iconRegistry: LgIconRegistry) {\n    this.iconRegistry.registerIcons([\n      lgIconEmail\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-icon name=\"email\"></lg-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n\nAll icons have height and width equal to 1em. This means the icons will be as big as the font-size specified by the parent.\n\n*By default the icons have the \\`\\`fill\\`\\` css property set to \\`\\`currentColor\\`\\`.*\n\n> \\`\\`currentColor\\`\\` acts like a variable for the current value of the \\`\\`color\\`\\` property on the element. And the Cascading part of CSS is still effective, so if there’s no defined \\`\\`color\\`\\` property on an element, the cascade will determine the value of \\`\\`currentColor\\`\\`.\n>\n> *Understanding the currentColor Keyword in CSS - https://alligator.io/css/currentcolor/*\n\n*Please note that the 'need-help' and 'question-mark' icons currently don't have the ability to change colour.*\n`"
+                "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/details/details.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nThe Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgDetailsModule ],\n})\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/focus/focus.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nThis directive allows for focus to be set dynamically on a focusable element.\n\n## Usage\nImport the directive in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgFocusDirective ],\n})\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Kebab case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into kebab case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgKebabCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | kebabCase}}</p>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/validation/validation.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Error Component\n\n\n## Purpose\nThe validation component is used to provide contextual information for a form input field. The most common use case is to display validation errors however it can also be used to show additional information.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgValidationModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-validation>Enter a valid postcode</lg-validation>\n\n<lg-validation variant=\"success\">Username is available</lg-validation>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of the validation: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'error' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display | boolean | true | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nThis module allows you to enable and disable features by using the \\`lgFeatureToggle\\` directive and passing an observable of the toggle's configuration to the module.\n\n## Usage\n\nImport the module in your core component, e.g.:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n})\n~~~\n\nand also import \\`LgFeatureToggleModule\\` (without the \\`forRoot\\`) in the modules that will need it.\n\n\\`useFactory\\` returns an observable of a config file structured as below:\n\n~~~\n{\n  \"exampleFeature\": true,\n  \"anotherExampleFeature\": false\n}\n~~~\n\nThe default behaviour is to show a feature if it's undefined, but we can override it by passing an optional object with defaultHide set to true like this:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n  },\n  {\n    defaultHide: true\n  }\n)\n~~~\n\nIn your component(s) add the structural directive like in the example below:\n\n~~~\n<div *lgFeatureToggle=\"'exampleFeature'\">\n  <p>The enabled feature</p>\n</div>\n\n<div *lgFeatureToggle=\"'anotherExampleFeature'\">\n  <p>The disabled feature</p>\n</div>\n~~~\n\n## FeatureToggleGuard configuration\n\nTo use the FeatureToggleGuard you need to add it to your routes configuration in the usual canActive, canActivateChild, canLoad, and then add in the data property like\n\n~~~\ndata: {\n  featureToggle: 'myToggle',\n},\n~~~\n\nif you use canActivateChild, child route definitions can add its own featureToggle in their data, and the path is only valid when all the featureToggle flags of each route segment are true\n\nExample with a lazy loading route\n\n~~~\n{\n  path: 'parent',\n  loadChildren: () => import('./parent/parent.module').then(m => m.ParentnModule),\n  canActivate: [ FeatureToggleGuard ],\n  canActivateChild: [ FeatureToggleGuard ],\n  canLoad: [ FeatureToggleGuard ],\n  data: {\n    featureToggle: 'parentToggle',\n  },\n},\n~~~\n\nExample of inner routes (route definition inside ParentModule)\n\n~~~\n{\n  path: 'child',\n  component: ChildContainerComponent,\n  data: {\n    featureToggle: 'childToggle',\n  },\n},\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/variant/variant.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
             },
             {
                 "name": "notes",
@@ -33665,11 +33685,121 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/modal/modal.notes.ts",
+                "file": "projects/canopy/src/styles/mixins.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Modal Component\n\n\n## Purpose\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Lorem ipsum</lg-modal-header>\n  <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nfor a timout modal you can use the following structure:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Logout</lg-modal-header>\n  <lg-modal-body>\n    For your security, we'll log yuo out in:\n    <lg-modal-body-timer timer=\"0:58\"></lg-modal-body-timer>\n  </lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nOpening and closing the modal is also possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
+                "defaultValue": "`\n# Mixins\n\n## Purpose\nProvides available mixins\n\n## Mixins\n### lg-inner-focus-outline($bg-color, $color: var(--color-white))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\n\\`\\`$color\\`\\`: colour of the outline.\n\nSets the focus outline inside the element, by using multiple box shadows.\n\n### lg-outer-focus-outline($bg-color: var(--default-focus-color))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\nSets the focus outline outside the element, by using box shadows.\n\n### lg-link($default-color, $hover-color, $visited-color, $active-color, $active-bg-color, $focus-color, $focus-bg-color)\n\\`\\`$default-color\\`\\`: the default color of the element (default value: \\`\\`var(--link-color)\\`\\`).\n\n\\`\\`$hover-color\\`\\`: the hover color of the element (default value: \\`\\`var(--link-hover-color)\\`\\`).\n\n\\`\\`$visited-color\\`\\`: the visited color of the element (default value: \\`\\`var(--link-visited-color)\\`\\`).\n\n\\`\\`$active-color\\`\\`: the active color of the element (default value: \\`\\`var(--link-active-color)\\`\\`).\n\n\\`\\`$active-bg-color\\`\\`: the active background color of the element (default value: \\`\\`var(--link-active-bg-color)\\`\\`).\n\n\\`\\`$focus-color\\`\\`: the focus color color of the element (default value: \\`\\`var(--link-focus-color)\\`\\`).\n\n\\`\\`$focus-bg-color\\`\\`: the focus background color of the element (default value: \\`\\`var(--link-focus-bg-color)\\`\\`).\n\nStyles elements with the link style.\n\n### lg-unstyled-link\nRevert the links styles added with \\`\\`lg-link\\`\\`.\n\n### lg-font-size($size)\n\\`\\`$size\\`\\`: The font size, '7' | '6' | '5' | '4' | '3' | '2' | '1' | '-8' | '-6' | .\n\nStyles text to one of the predefined font sizes. '-8' and '-6' are the sub body font sizes.\n\n### lg-visually-hidden()\nProvides styles to hide information intended only for screen readers from the layout of the rendered page.\n\n### lg-breakpoint($breakpoint)\n\\`\\`$breakpoint\\`\\`: string value for the breakpoint screen size.\n\nAllows breakpoints to be added to css blocks.\n\n### lg-variant($variant: 'generic')\n\\`\\`$variant\\`\\`: The variant type, 'generic' | 'info' | 'success' | 'warning' | 'error'.\n\nStyles components and native child elements to the specified variant.\n\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/button/button.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Button Component\n\n## Purpose\nProvides common styles and behaviours for buttons and links.\n\n## Usage\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgButtonModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n~~~\n\nor:\n\n~~~html\n<a lg-button href=\"#\" variant=\"primary\">Link</a>\n~~~\n\n## Button with icon with text\n\nIcons can be content projected into the button, the button component will then handle the styling of that icon.\nThe \\`ButtonIconPosition\\` property can be used to locate the icon on the left hand side of the text, the default is to the right hand side.\nContent projection is used as Canopy Icons need loading via the \\`iconRegistry\\` which enables tree shaking of icons.\n\n~~~html\n<button lg-button type=\"button\" iconPosition=\"left\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## Button with icon only\n\nButtons can be setup as icon only buttons, this is done in a similar way to a button with icon and text.\nYou will still need to include text content inside the button as this information is vital to screen readers.\nThe \\`iconButton\\` property is used to visually hide that text.\n\n~~~html\n<button lg-button type=\"button\" iconButton=\"true\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## ButtonComponent inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of button: \\`\\`solid-primary\\`\\`, \\`\\`solid-secondary\\`\\`, \\`\\`outline-primary\\`\\`, \\`\\`outline-secondary\\`\\`, \\`\\`reverse-primary\\`\\`, \\`\\`reverse-secondary\\`\\`, \\`\\`add-on\\`\\`; | string | solid-primary | No |\n| \\`\\`size\\`\\` | The size of the button | ButtonSize [\\`\\`sm\\`\\`, \\`\\`md\\`\\`] | \\`\\`md\\`\\` | No |\n| \\`\\`fullWidth\\`\\` | If the button has to span full width or not. For 'sm' and 'md' sized screens, the button will always be full width and this input has no affect | boolean | false | No |\n| \\`\\`disabled\\`\\` | Programmatically disable the button via this property | boolean | false | No |\n| \\`\\`loading\\`\\` | If the button shows a loading spinner and is also disabled | boolean | false | No |\n| \\`\\`iconPosition\\`\\` | The position of the icon in the button | string | right | No |\n| \\`\\`iconButton\\`\\` | The button displays an icon only | boolean | false | No |\n\n## Button group\n\nButtons can be grouped together by using the \\`\\`ButtonGroupComponent\\`\\`:\n\n~~~html\n<lg-button-group>\n  <button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n  <a lg-button href=\"#\" variant=\"outline-primary\">Link</a>\n</lg-button-group>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/grid/grid.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/validation/form.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Form Validation\n\n## Purpose\nTo provide a consistent approach to form validation.\n\n## Usage\nThe rules to display the error states are incorporated into the individual Canopy\nform components. When used in conjunction with standard [Angular form validation](https://angular.io/guide/form-validation)\nthe error styles will be displayed automatically.\n\nError messages need to be handled by the individual applications by utilising the\n[Validation](/?path=/story/components-form-validation--component) component and\nthe LgErrorStateMatcher.\n\nImport the module in your core component, e.g.:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgValidationModule]\n})\n~~~\n\nIn your component file set up the relevant validators :\n\n~~~js\nconstructor(public fb: FormBuilder, private errorState: LgErrorStateMatcher) {\n  this.form = this.fb.group({\n    text: ['', [Validators.required, Validators.minLength(4)]]\n  });\n}\n\nisControlInvalid(control: NgControl, form: FormGroupDirective) {\n  return this.errorState.isControlInvalid(control, form);\n}\n~~~\n\nIn your HTML add the validation components with the appropriate structural\ndirectives to determine if they should be visible. The error state matcher will\ndetermine wether the form field is in an error state.\n\n~~~html\n<form\n  [formGroup]=\"form\"\n  (ngSubmit)=\"onSubmit(form)\"\n  #userForm=\"ngForm\">\n  <lg-input-field>\n    Text\n    <input lgInput formControlName=\"username\" />\n    <lg-hint>This is a standard input field</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(text, userForm) && text.hasError('required')\">\n      Username is a required field\n    </lg-validation>\n    <lg-validation *ngIf=\"isControlInvalid(text, validationForm) && text.hasError('minlength')\">\n      Username needs to be at least 4 characters\n    </lg-validation>\n  </lg-input-field>\n</form>\n~~~\n\n## Using only the SCSS files\n\nGenerate the markup as show in the example below, you will need to ensure the aria\nattributes are correctly labelled.\n\n### Examples:\n\n## Input field\nFor a select field replace the input field with a select option.\n\n~~~html\n<div class=\"lg-input-field\">\n  <label class=\"lg-label\" for=\"lg-input-1\">\n    Username\n  </label>\n  <div id=\"lg-hint-1\" class=\"lg-hint\">\n    Please enter a username\n  </div>\n  <input\n    name=\"username\"\n    class=\"lg-input lg-input--error\" aria-invalid=\"true\" name=\"lg-input-2\" id=\"lg-input-1\" aria-describedby=\"lg-hint-1 lg-validation-1\">\n  <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-1\">\n    Text is a required field\n  </div>\n</div>\n~~~\n\n## Radio group\n\n~~~html\n<div class=\"lg-radio-group lg-radio-group--error\">\n  <fieldset aria-describedby=\"lg-hint-2 lg-validation-2\">\n    <legend class=\"lg-label\" id=\"lg-label-2\">\n      Color\n    </legend>\n    <div id=\"lg-hint-2\" class=\"lg-hint\">\n      Choose a colour\n    </div>\n    <div value=\"yellow\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-1\" name=\"lg-radio-group-1\" value=\"yellow\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-1\">Yellow</label>\n    </div>\n    <div value=\"red\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-2\" name=\"lg-radio-group-1\" value=\"red\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-2\">Red</label>\n    </div>\n    <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-2\">\n      Please select a colour\n    </div>\n  </fieldset>\n</div>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/styles/spacing.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Spacing\n\n## Purpose\nProvides available spacing via CSS variables\n\n## Variables\n| Name | Value | Equivalent in px (based on 16px font-size)\n|------|-------------|-------------|\n| \\`\\`--space-unit\\`\\` | 1rem | 16px |\n| \\`\\`--space-xxxs\\`\\` | calc(0.25 * var(--space-unit)) | 4px |\n| \\`\\`--space-xxs\\`\\` | calc(0.5 * var(--space-unit)) | 8px |\n| \\`\\`--space-xs\\`\\` | calc(0.75 * var(--space-unit)) | 12px |\n| \\`\\`--space-sm\\`\\` | var(--space-unit) | 16px |\n| \\`\\`--space-md\\`\\` | calc(1.5 * var(--space-unit)) | 24px |\n| \\`\\`--space-lg\\`\\` | calc(2 * var(--space-unit)) | 32px |\n| \\`\\`--space-xl\\`\\` | calc(2.5 * var(--space-unit)) | 40px |\n| \\`\\`--space-xxl\\`\\` | calc(3 * var(--space-unit)) | 48px |\n| \\`\\`--space-xxxl\\`\\` | calc(4.5 * var(--space-unit)) | 72px |\n| \\`\\`--space-xxxxl\\`\\` | calc(9 * var(--space-unit)) | 144px |\n\n### For components padding:\n| Name | Value from 0 to md breakpoint | Value from md breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-padding\\`\\` | var(--space-sm) | var(--space-lg) |\n\n### For components margin:\n| Name | Value from 0 to lg breakpoint | Value from lg breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-margin\\`\\` | var(--space-md) | var(--space-lg) |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/radio/radio.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "(name: string) => `\n# ${name} Group and ${name} Button Components\n\n## Purpose\nProvides a set of components to implement ${name} buttons in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more ${name} Button components. The ${name} Button component represents a single ${name} button. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the Radio Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgRadioModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${name.toLowerCase()}-group ${\n  name === 'Radio' ? '[inline]=\"true\"' : ''\n} formControlName=\"color\">\n  Colour\n  <lg-hint>Please select a colour</lg-hint>\n  <lg-${name.toLowerCase()}-button value=\"red\">Red</lg-${name.toLowerCase()}-button>\n  <lg-${name.toLowerCase()}-button value=\"yellow\">Yellow</lg-${name.toLowerCase()}-button>\n</lg-${name.toLowerCase()}-group>\n~~~\n\\\n${\n  name === 'Segment' &&\n  `### Displaying the buttons at different breakpoints\n\nRadios are displayed inline, unless given a \\`RadioStackBreakpoint\\`, which tells them at which breakpoint should they appear stacked on top of each other:\n\n~~~html\n<lg-segment-group [stack]=\"sm\" formControlName=\"color\">\n  Colour\n  <lg-segment-button value=\"red\">Red</lg-segment-button>\n  <lg-segment-button value=\"yellow\">Yellow</lg-segment-button>\n</lg-segment-group>\n~~~\n    `\n}\n\n## Inputs\n\n### LgRadioGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\\${nextUniqueId++}' | No |\n| \\`\\`value\\`\\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n${\n  name === 'Radio'\n    ? `| \\`\\`inline\\`\\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`\n    : name === 'Segment'\n    ? `| \\`\\`stack\\`\\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`\n    : ''\n}\n\n### LgRadioButtonComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML name attribute | string | null | Yes |\n| \\`\\`value\\`\\` | HTML value attribute | string | null | Yes |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/toggle/toggle.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "(name: string) => `\n# ${name} Component\n\n## Purpose\nProvides a ${name} component for boolean form controls. The ${name} component is a variant of the Toggle component.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgToggleModule ],\n})\n~~~\n\nand in your HTML for a regular *checkbox*:\n\n~~~html\n<lg-toggle formControlName=\"confirm\" value=\"yes\" variant=\"${name.toLowerCase()}\">Do you agree?</lg-toggle>\n~~~\n\nor\n\n~~~html\n<lg-${name.toLowerCase()} formControlName=\"confirm\" value=\"yes\">Do you agree?</lg-${name.toLowerCase()}>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`value\\`\\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`variant\\`\\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |\n| \\`\\`focus\\`\\` | Set the focus on the input field | boolean | null | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/footer/footer.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/styles/typography.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Typography\n\n## Purpose\nProvides common typographic styles for native elements with additional utility classes.\n\nCanopy consists of two fonts:\n\n* **Roboto**: Productive font, for general use in self serve apps (default)\n* **Lyon**: Expressive font, for headings in promo material (applied by class modifier)\n\n> **IMPORTANT** - Lyon font files are not included in the Canopy package, you have to serve it yourself, see below for details.\n\n## Serving the Lyon font files\n\nDue to commercial licensing agreements the Lyon font is not included in the distributed package. You will need to manually add it to the **assets** directory of your application. Canopy does provide the css to work with the font and no additional code should be required. You will  need to ensure the font is in the directory specified by Canopy.\n\nCanopy's path for Lyon is **/assets/fonts/lyon/**, therefore you need to put the font files in the following location:\n\n~~~bash\nmy-app/\n  src/\n    assets/\n      fonts/\n        lyon/\n          lyon-display-regular.woff\n          lyon-display-regular.woff2\n          lyon-display-bold.woff\n          lyon-display-bold.woff2\n~~~\n\n> This will result in the font being served in your app like this: <br />http://my-app.landg.com/assets/fonts/lyon/LyonDisplay-Regular-Web.woff2\n\nWhen you include the canopy.css file in your project, it will try to load the font from that exact path. If your font files are in the wrong location, or have a typo in the filename, the Lyon font won't load correctly.\n\nPlease ensure you have the correct licensing agreement in place before using the Lyon font in your application.\n\n## Usage\nThe typography styles will provide styling for all native text elements e.g. \\`\\`h1\\`\\`, \\`\\`h2\\`\\`, \\`\\`p\\`\\`, \\`\\`em\\`\\`, \\`\\`b\\`\\`, \\`\\`strong\\`\\` etc.\n\nBy default the font used is Roboto.\n\nIn addition to the native styling, the following utility classes are exposed, allowing you to change the font size and weight where required.\n\n~~~html\n.lg-font-size-7\n.lg-font-size-7--strong\n\n.lg-font-size-6\n.lg-font-size-6--strong\n\n.lg-font-size-5\n.lg-font-size-5--strong\n\n.lg-font-size-4\n.lg-font-size-4--strong\n\n.lg-font-size-3\n.lg-font-size-3--strong\n\n.lg-font-size-2\n.lg-font-size-2--strong\n\n.lg-font-size-1\n.lg-font-size-1--strong\n\n.lg-font-size-0-8\n\n.lg-font-size-0-6\n~~~\n\n\\`.lg-font-size-1\\` is the base font size that is used to style native elements like p and span, as the numbers increase so\ndoes the font size up to the largest \\`.lg-font-size-7.\\` Each of the primary font styles also have a \\`--strong\\` modifier.\n\nThere are two additional styles which are smaller \\`.lg-font-size-0-8\\`\nand \\`.lg-font-size-0-6\\`. The utility classes are particularly useful for when you want to decouple the semantics and styling,\nfor example making an h1 look like an h3:\n\n~~~html\n<h1 class=\"lg-font-size-3\">H1 that looks like a H3</h1>\n~~~\n<br />\n\n### Using the Lyon font\n\nLyon can be applied using the modifier class: \\`\\`lg-font--expressive\\`\\`. For example:\n\n~~~html\n<h1 class=\"lg-font--expressive\">Heading in Lyon</h1>\n~~~\n\nIt can also be used in addition to the above utility classes:\n\n~~~html\n<p class=\"lg-font-size-5 lg-font--expressive\">Paragraph in Lyon and font size 5</p>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` service and register your brand icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgBrandIconSun } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    // register the icon using the \\`brandIconRegistry\\` service\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<!-- with default size and colour -->\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n\n<!-- with a size set -->\n<lg-brand-icon name=\"sun\" size=\"sm\"></lg-brand-icon>\n\n<!-- with a colour set -->\n<lg-brand-icon name=\"sun\" colour=\"--color-lily-green\"></lg-brand-icon>\n~~~\n\n## Branding / Colours\nThe yellow fill colour of the brand icons can be changed globally  by overriding the \\`--brand-icon-fill-primary\\` css variable. Note that changing this variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input on the component.\n`"
             },
             {
                 "name": "notes",
@@ -33685,11 +33815,31 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/quick-action/quick-action.notes.ts",
+                "file": "projects/canopy/src/lib/table/table.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Quick Action Component\n\n## Purpose\nQuick Actions are small clickable elements that can be used to provide functionality in context, such as editing a form or actions on a card.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgQuickActionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-quick-action>\n  <lg-icon name=\"repeat\"></lg-icon>\n  Load more\n</button>\n~~~\n\nor:\n\n~~~html\n<a lg-quick-action\n  href=\"/mailbox\">\n  <lg-icon name=\"secure-message\"></lg-icon>\n  Send us a message\n</a>\n~~~\n`"
+                "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/styles/utils.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Utils\n\n## Purpose\nProvides available utils classes\n\n## Classes\n| Class | Description |\n|------|-------------|\n| \\`\\`lg-visually-hidden\\`\\` | Hides information intended only for screen readers from the layout of the rendered page. |\n| \\`\\`lg-unstyled-link\\`\\` | Revert the links styles to a more default style. |\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/modal/modal.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Modal Component\n\n\n## Purpose\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Lorem ipsum</lg-modal-header>\n  <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nfor a timout modal you can use the following structure:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Logout</lg-modal-header>\n  <lg-modal-body>\n    For your security, we'll log yuo out in:\n    <lg-modal-body-timer timer=\"0:58\"></lg-modal-body-timer>\n  </lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nOpening and closing the modal is also possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
             },
             {
                 "name": "notes",
@@ -33700,6 +33850,26 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Primary Message Component\n\n\n## Purpose\nThe Primary Message is used to communicate key information to the user.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPrimaryMessageModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-primary-message>\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title>\n      This is a primary message\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">Call to action</button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`hasRole\\`\\` | If false, removes the role \\`\\`alert\\`\\` from the component | boolean | true | No |\n\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/spinner/spinner.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Spinner Component\n\n## Purpose\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<lg-spinner></lg-spinner>\n~~~\n\n## Inputs\n\n### LgSpinnerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The spinner variant | SpinnerVariant ['dark', 'light', 'color', 'inherit'] | 'dark' | No |\n| \\`\\`size\\`\\` | The size of the spinner | SpinnerSize ['sm', 'md'] | 'md' | No |\n| \\`\\`text\\`\\` | The text to show under the spinner | string | undefined | No |\n\n\nIf the \\`\\`variant\\`\\` is set to  \\`\\`'inherit'\\`\\`, then it will inherit the font colour of it's parent element. This is used on the loading button, where the spinner inherits the font colour of the button.\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/alert/alert.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -33745,61 +33915,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/spinner/spinner.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Spinner Component\n\n## Purpose\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<lg-spinner></lg-spinner>\n~~~\n\n## Inputs\n\n### LgSpinnerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The spinner variant | SpinnerVariant ['dark', 'light', 'color', 'inherit'] | 'dark' | No |\n| \\`\\`size\\`\\` | The size of the spinner | SpinnerSize ['sm', 'md'] | 'md' | No |\n| \\`\\`text\\`\\` | The text to show under the spinner | string | undefined | No |\n\n\nIf the \\`\\`variant\\`\\` is set to  \\`\\`'inherit'\\`\\`, then it will inherit the font colour of it's parent element. This is used on the loading button, where the spinner inherits the font colour of the button.\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/table/table.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Show At Directive\n\n## Purpose\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShowAt=\"md\">\n  <lg-card-content>\n    I get dispalayed at the \"md\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgShowAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/variant/variant.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
             },
             {
                 "name": "notes",
@@ -33815,86 +33935,6 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "(name: string, modifier?) => `\n# ${name} Group Components\n\n## Purpose\nProvides a set of components to implement ${name} groups in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more Toggle components. The Toggle component represents a single ${name.toLowerCase()}. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the CheckboxGroup Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgCheckboxGroupModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg-toggle value=\"red\">Red</lg-toggle>\n  <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\nor\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"red\">Red</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"yellow\">Yellow</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\n## Inputs\n\n### LgCheckboxGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-checkbox-group-id-\\${this.nextUniqueId}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-checkbox-group-\\${this.nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Sets the default checked ${name.toLowerCase()} buttons, must match the values of the ${name.toLowerCase()} buttons | array of strings | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`inline\\`\\` | If true, displays the ${\n  name.toLowerCase\n}s inline rather than stacked | boolean | false | No |\n\n### LgToggleComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Value that is set when the toggle is checked | string | null | No |\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`focus\\`\\` | Set the focus on the input | boolean | null | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/date/date-field.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Date Input Component\n\n## Purpose\nProvides a component for capturing and validating a date. Output is a concatenation of individual string values into a valid ISO 8601 date format 'YYYY-MM-DD'.\n\n## Usage\nImport the Date Input Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgDateFieldModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-date-field formControlName=\"date\">\n    Date of birth\n    <lg-hint>For example, 12 06 1983</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(date, validationForm)\">\n      <ng-container *ngIf=\"date.hasError('invalidField')\">\n        Enter a valid {{ date.errors.invalidField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidFields')\">\n        Enter a valid {{ date.errors.invalidFields[0] }} and\n        {{ date.errors.invalidFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredField')\">\n        Date of birth must include a {{ date.errors.requiredField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredFields')\">\n        Date of birth must include a {{ date.errors.requiredFields[0] }} and\n        {{ date.errors.requiredFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidDate')\">\n        Enter a valid date of birth\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('futureDate')\">\n        Date must be in the past\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('required')\">\n        Enter a date of birth\n      </ng-container>\n    </lg-validation>\n  </lg-date-field>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgDateFieldComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`dateId\\`\\` | HTML ID attribute for the date input, auto generated if not provided | string | 'lg-input-date-\\${nextUniqueId++}' | No |\n| \\`\\`monthId\\`\\` | HTML ID attribute for the month input, auto generated if not provided | string | 'lg-input-month-\\${nextUniqueId++}' | No |\n| \\`\\`yearId\\`\\` | HTML ID attribute for the year input, auto generated if not provided | string | 'lg-input-year-\\${nextUniqueId++}' | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the date field, if not provided it will use the hint field where appropriate | string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n\n## Validation\nDate validation is quite complex with a range of different validation errors, where possible we have encapsulated as much of that complexity into the components as we can.\n\nInternally the date-field can determine if the entered date is a valid date. If additional validation is required such as checking for past or future dates this can be done with external validators.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n### Internal validation\nIn some scenarios there could be multiple fields that are incorrect, to help guide the users to the correct issue the date field only returns the most significant validation error. Only one error should be shown at a time.\n\nOnce the user has rectified the first error the next error will take it's place if there is one. This allows us to write linear lists of validation messages without the need to apply complex logic in the applications.\n\nThe current significance of errors with their recommended messages is as follows.\n\n#### 1. Invalid fields\n\nOne field is invalid, this may be a non numerical character, or a number outside the valid range .e.g 13 for a month.\n\\`Enter a valid month\\`\n\n~~~json\n{ invalidField: 'month'}\n~~~\n\n\nAs above but with two fields displaying an error.\n\\`Enter a valid month and year\\`\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are invalid a generic 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Required fields\n\nIf one field is empty either through form submission or inline deletion of the content.\n\\`Date of birth must include month\\`\n\n~~~json\n{ requiredField: 'month'}\n~~~\n\nAs above but with two fields missing.\n\\`Date of birth must include a month and year\\`\n\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are missing an 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Invalid date\n\nIf all of the individual fields are correct but they do not concatenate to a valid date. e.g. 30 02 2020\n\n~~~json\n{ invalidDate: true }\n~~~\n\\`Enter a valid date of birth\\`\n\n### External validation\n\nIt is also possible to provide your own custom validation messages using [custom validators](https://angular.io/guide/form-validation#custom-validators)\nand the validation component. This is particularly useful for checking things like wether the date is in the past or the future. Under the hood the date field uses the [date-fns](https://date-fns.org/) library as a peer dependency, to keep build size to a minimum it may be worth considering using the same library in your application.\n\n~~~js\nfunction notMondayValidator(): ValidatorFn {\n  return (control: AbstractControl): { [key: string]: any } | null => {\n    return getDay(parseISO(control.value)) === 'monday' ? { notMonday: true } : null;\n  };\n}\n...\nconst date = new FormControl('', [notMondayValidator()])\n~~~\n\n~~~html\n<lg-date-field formControlName=\"date\">\n  Date of appointment\n  <lg-hint>For example, 12 06 1983</lg-hint>\n  <lg-validation *ngIf=\"isControlInvalid(date, validationForm) && date.hasError('notMonday')\">\n    Date cannot be a Monday\n  </lg-validation>\n </lg-date-field>\n~~~\n\n### Additional validators\n\nTo aid with common validation needs some additional reactive form validators are provided.\n\n#### Future date validator\nThis validator checks if the specified date is in the future, if not it returns a futureDate error\n\n~~~js\nimport { futureDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [futureDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('futureDate')\">\n  Date must be in the future\n</ng-container>\n~~~\n\n#### Past date validator\nThis validator checks if the specified date is in the past, if not it returns a pastDate error\n\n~~~js\nimport { pastDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [pastDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('pastDate')\">\n  Date must be in the past\n</ng-container>\n~~~\n\n#### Before date validator\nThis validator checks if the specified date is before another specified date, if not it returns a beforeDate error.\nThe beforeDate error contains the date that it was compared against.\n\n~~~js\nimport { beforeDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [beforeDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('beforeDate')\">\n  Date must be before {{ date.errors.beforeDate.required }}\n</ng-container>\n~~~\n\n#### After date validator\nThis validator checks if the specified date is after another specified date, if not it returns a afterDate error.\nThe afterDate error contains the date that it was compared against.\n\n~~~js\nimport { afterDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [afterDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('afterDate')\">\n  Date must be after {{ date.errors.afterDate.required }}\n</ng-container>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Input Component\n\n## Purpose\nProvides a common input directive and input field component. The input field component deals with linking the label and field.\nThe width of the input field is controlled by the HTML size attribute, this allows us to provide the user with an indication of the expected length of the value.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgInputModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n</lg-input-field>\n~~~\n\n### Adding input buttons\n\nButtons can be added within input fields to provide functionality linked to the input.\nThe \\`lgSuffix\\` directive needs to be added to the button to place it in the correct place.\nOnly small size buttons should be placed in the input field.\nThere is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.\n\n#### Button suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\">\n    Search\n  </button>\n</lg-input-field>\n~~~\n\n#### Icon Button suffix with add-on class\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\" [iconButton]=\"true\" variant=\"add-on\">\n    <lg-icon name=\"search\" />\n  </button>\n</lg-input-field>\n~~~\n\n### Adding prefixes and suffixes\n\nPrefix and suffix text can be added to input fields using the \\`lgSuffix\\` and \\`lgPrefix\\` directive.\n\n#### Text prefix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgPrefix>£</span>\n</lg-input-field>\n~~~\n\n#### Text suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgSuffix>%</span>\n</lg-input-field>\n~~~\n\n## Inputs\n\n### LgInputDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n\n### LgInputFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the input full width (for small screens only). | boolean | false | no\n| \\`\\`showLabel\\`\\` | Show or visually hide the label | boolean | true | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/radio/radio.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "(name: string) => `\n# ${name} Group and ${name} Button Components\n\n## Purpose\nProvides a set of components to implement ${name} buttons in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more ${name} Button components. The ${name} Button component represents a single ${name} button. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the Radio Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgRadioModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${name.toLowerCase()}-group ${\n  name === 'Radio' ? '[inline]=\"true\"' : ''\n} formControlName=\"color\">\n  Colour\n  <lg-hint>Please select a colour</lg-hint>\n  <lg-${name.toLowerCase()}-button value=\"red\">Red</lg-${name.toLowerCase()}-button>\n  <lg-${name.toLowerCase()}-button value=\"yellow\">Yellow</lg-${name.toLowerCase()}-button>\n</lg-${name.toLowerCase()}-group>\n~~~\n\\\n${\n  name === 'Segment' &&\n  `### Displaying the buttons at different breakpoints\n\nRadios are displayed inline, unless given a \\`RadioStackBreakpoint\\`, which tells them at which breakpoint should they appear stacked on top of each other:\n\n~~~html\n<lg-segment-group [stack]=\"sm\" formControlName=\"color\">\n  Colour\n  <lg-segment-button value=\"red\">Red</lg-segment-button>\n  <lg-segment-button value=\"yellow\">Yellow</lg-segment-button>\n</lg-segment-group>\n~~~\n    `\n}\n\n## Inputs\n\n### LgRadioGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\\${nextUniqueId++}' | No |\n| \\`\\`value\\`\\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n${\n  name === 'Radio'\n    ? `| \\`\\`inline\\`\\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`\n    : name === 'Segment'\n    ? `| \\`\\`stack\\`\\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`\n    : ''\n}\n\n### LgRadioButtonComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML name attribute | string | null | Yes |\n| \\`\\`value\\`\\` | HTML value attribute | string | null | Yes |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/toggle/toggle.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "(name: string) => `\n# ${name} Component\n\n## Purpose\nProvides a ${name} component for boolean form controls. The ${name} component is a variant of the Toggle component.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgToggleModule ],\n})\n~~~\n\nand in your HTML for a regular *checkbox*:\n\n~~~html\n<lg-toggle formControlName=\"confirm\" value=\"yes\" variant=\"${name.toLowerCase()}\">Do you agree?</lg-toggle>\n~~~\n\nor\n\n~~~html\n<lg-${name.toLowerCase()} formControlName=\"confirm\" value=\"yes\">Do you agree?</lg-${name.toLowerCase()}>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`value\\`\\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`variant\\`\\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |\n| \\`\\`focus\\`\\` | Set the focus on the input field | boolean | null | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/validation/form.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Form Validation\n\n## Purpose\nTo provide a consistent approach to form validation.\n\n## Usage\nThe rules to display the error states are incorporated into the individual Canopy\nform components. When used in conjunction with standard [Angular form validation](https://angular.io/guide/form-validation)\nthe error styles will be displayed automatically.\n\nError messages need to be handled by the individual applications by utilising the\n[Validation](/?path=/story/components-form-validation--component) component and\nthe LgErrorStateMatcher.\n\nImport the module in your core component, e.g.:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgValidationModule]\n})\n~~~\n\nIn your component file set up the relevant validators :\n\n~~~js\nconstructor(public fb: FormBuilder, private errorState: LgErrorStateMatcher) {\n  this.form = this.fb.group({\n    text: ['', [Validators.required, Validators.minLength(4)]]\n  });\n}\n\nisControlInvalid(control: NgControl, form: FormGroupDirective) {\n  return this.errorState.isControlInvalid(control, form);\n}\n~~~\n\nIn your HTML add the validation components with the appropriate structural\ndirectives to determine if they should be visible. The error state matcher will\ndetermine wether the form field is in an error state.\n\n~~~html\n<form\n  [formGroup]=\"form\"\n  (ngSubmit)=\"onSubmit(form)\"\n  #userForm=\"ngForm\">\n  <lg-input-field>\n    Text\n    <input lgInput formControlName=\"username\" />\n    <lg-hint>This is a standard input field</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(text, userForm) && text.hasError('required')\">\n      Username is a required field\n    </lg-validation>\n    <lg-validation *ngIf=\"isControlInvalid(text, validationForm) && text.hasError('minlength')\">\n      Username needs to be at least 4 characters\n    </lg-validation>\n  </lg-input-field>\n</form>\n~~~\n\n## Using only the SCSS files\n\nGenerate the markup as show in the example below, you will need to ensure the aria\nattributes are correctly labelled.\n\n### Examples:\n\n## Input field\nFor a select field replace the input field with a select option.\n\n~~~html\n<div class=\"lg-input-field\">\n  <label class=\"lg-label\" for=\"lg-input-1\">\n    Username\n  </label>\n  <div id=\"lg-hint-1\" class=\"lg-hint\">\n    Please enter a username\n  </div>\n  <input\n    name=\"username\"\n    class=\"lg-input lg-input--error\" aria-invalid=\"true\" name=\"lg-input-2\" id=\"lg-input-1\" aria-describedby=\"lg-hint-1 lg-validation-1\">\n  <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-1\">\n    Text is a required field\n  </div>\n</div>\n~~~\n\n## Radio group\n\n~~~html\n<div class=\"lg-radio-group lg-radio-group--error\">\n  <fieldset aria-describedby=\"lg-hint-2 lg-validation-2\">\n    <legend class=\"lg-label\" id=\"lg-label-2\">\n      Color\n    </legend>\n    <div id=\"lg-hint-2\" class=\"lg-hint\">\n      Choose a colour\n    </div>\n    <div value=\"yellow\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-1\" name=\"lg-radio-group-1\" value=\"yellow\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-1\">Yellow</label>\n    </div>\n    <div value=\"red\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-2\" name=\"lg-radio-group-1\" value=\"red\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-2\">Red</label>\n    </div>\n    <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-2\">\n      Please select a colour\n    </div>\n  </fieldset>\n</div>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/validation/validation.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Error Component\n\n\n## Purpose\nThe validation component is used to provide contextual information for a form input field. The most common use case is to display validation errors however it can also be used to show additional information.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgValidationModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-validation>Enter a valid postcode</lg-validation>\n\n<lg-validation variant=\"success\">Username is available</lg-validation>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of the validation: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'error' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display | boolean | true | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -33905,41 +33945,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                "file": "projects/canopy/src/styles/color.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Kebab case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into kebab case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgKebabCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | kebabCase}}</p>\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+                "defaultValue": "`\n# Colours\n\n## Purpose\nProvides available brand colours and tints via CSS variables\n\n## Usage\nImport the css into the angular.json file of your application, the variables should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\n`"
             },
             {
                 "name": "offsets",
@@ -34085,7 +34095,7 @@
                 "name": "propsGroupId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/button/button.stories.ts",
+                "file": "projects/canopy/src/lib/forms/input/input.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "string",
@@ -34095,7 +34105,7 @@
                 "name": "propsGroupId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input.stories.ts",
+                "file": "projects/canopy/src/lib/button/button.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "string",
@@ -34105,7 +34115,7 @@
                 "name": "require",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/test.ts",
+                "file": "projects/canopy-test-app/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "literal type"
@@ -34114,7 +34124,7 @@
                 "name": "require",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy-test-app/src/test.ts",
+                "file": "projects/canopy/src/test.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "literal type"
@@ -34243,7 +34253,7 @@
                 "name": "spaces",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
@@ -34253,7 +34263,7 @@
                 "name": "spaces",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
@@ -34273,91 +34283,11 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/canopy.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `<app-root></app-root>`,\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [specificColour]=\"specificColour\"></lg-swatch-brand-icon>\n  `,\n  props: {\n    size: select('size', sizes, 'xs'),\n    colour: select(\n      'example of applying colour globally',\n      colours,\n      '--color-dandelion-yellow',\n    ),\n    specificColour: select(\n      'example of applying colour specifically to an icon',\n      colours,\n      '--color-super-blue',\n    ),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/card/card.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-card>\n      <lg-card-header>\n        <lg-card-title headingLevel=\"4\">\n          {{title}}\n        </lg-card-title>\n      </lg-card-header>\n      <lg-card-content>\n        {{cardContent}} <a href=\"#\">Test link</a>.\n      </lg-card-content>\n    </lg-card>\n  `,\n  props: {\n    title: text('title', 'Card title'),\n    cardContent: text(\n      'cardContent',\n      `Leverage agile frameworks to provide a robust synopsis for high level\n    overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall\n    value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity\n    and empowerment.`,\n    ),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/icon/icons.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-swatch-icon [colour]=\"colour\"></lg-swatch-icon>\n  `,\n  props: {\n    colour: select('colour examples', colours, '--color-charcoal'),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/modal/modal.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n    <lg-modal id=\"modal-story\">\n      <lg-modal-header [headingLevel]=\"headingLevel\">Lorem ipsum</lg-modal-header>\n      <lg-modal-body>\n        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n        <lg-modal-body-timer timer=\"90\"></lg-modal-body-timer>\n      </lg-modal-body>\n      <lg-modal-footer>\n        <lg-button-group>\n          <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Button</button>\n          <button lg-button lgMarginBottom=\"none\" variant=\"outline-primary\" type=\"button\">Close</button>\n        </lg-button-group>\n      </lg-modal-footer>\n    </lg-modal>\n  `,\n  props: {\n    headingLevel: select('heading level', [1, 2, 3, 4, 5, 6], 2),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/primary-message/primary-message.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-primary-message-story [hasRole]=\"hasRole\"></lg-primary-message-story>\n  `,\n  props: {\n    hasRole: boolean('Set role attribute to alert', true),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/separator/separator.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "() => ({\n  template: `\n    <lg-separator [variant]=\"variant\" [hasRole]=\"hasRole\"></lg-separator>\n  `,\n  props: {\n    variant: select('variant', ['solid', 'dotted'], 'solid', ''),\n    hasRole: boolean('hasRole', false),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/side-nav/side-nav.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: '<story-side-nav [navItems]=\"navItems\"></story-side-nav>',\n  props: {\n    navItems: object('Navs', getDefaultNavItems()),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/carousel/carousel.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [slideDuration]=\"slideDuration\">${carouselItems}</lg-carousel>`,\n  props: props(),\n})"
             },
             {
                 "name": "standard",
@@ -34373,66 +34303,6 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/table/table.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <table lg-table [showColumnsAt]=\"columnBreakpoint\" [variant]=\"variant\">\n      <thead lg-table-head>\n        <tr lg-table-row>\n          <th lg-table-head-cell [showLabel]=\"showAuthorLabel\">Author</th>\n          <th lg-table-head-cell [align]=\"alignTitleColumn\">Title</th>\n          <th lg-table-head-cell [align]=\"alignPublishColumn\">Published</th>\n        </tr>\n      </thead>\n\n      <tbody lg-table-body>\n        <tr lg-table-row *ngFor=\"let book of books\">\n          <td lg-table-cell [stack]=\"stack\">{{ book.author }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.title }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.published }}</td>\n        </tr>\n      </tbody>\n    </table>\n  `,\n\n  props: {\n    books: object('Books', getDefaultTableContent(), 'Table data'),\n    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),\n    alignTitleColumn: select(\n      'Align Title column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.Start,\n      'Alignment',\n    ),\n    alignPublishColumn: select(\n      'Align Publish column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.End,\n      'Alignment',\n    ),\n    columnBreakpoint: select(\n      'Minimum breakpoint where column layout is used',\n      [\n        TableColumnLayoutBreakpoints.Small,\n        TableColumnLayoutBreakpoints.Medium,\n        TableColumnLayoutBreakpoints.Large,\n      ],\n      TableColumnLayoutBreakpoints.Medium,\n      'Responsive options',\n    ),\n    showAuthorLabel: boolean(\n      'Display author label in non-columns view (showLabel)',\n      false,\n      'Responsive options',\n    ),\n    stack: boolean(\n      'Stack label and content in non-columns view (stack)',\n      false,\n      'Responsive options',\n    ),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n  <lg-tab-nav-bar label=\"Tabbed navigation demo\">\n    <a *ngFor=\"let tab of tabs; index as i\" lgTabNavBarLink href=\"\" (click)=\"onClick($event)\" id=\"tabbed-nav-{{i}}\" [isActive]=\"i === selectedTabNavIndex\">{{tab}}</a>\n  </lg-tab-nav-bar>\n\n  <lg-tab-nav-content [selectedTabId]=\"'tabbed-nav-' + selectedTabNavIndex\">\n    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n  </lg-tab-nav-content>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    selectedTabNavIndex: 1,\n    onClick: (event: MouseEvent) => event.preventDefault(),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/tabs/tabs.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n  <lg-tabs [headingLevel]=\"headingLevel\"\n    label=\"Annuities\"\n    (tabEvent)=\"tabEvent($event)\"\n    [lgMarginRight]=\"'none'\"\n    [lgMarginBottom]=\"'none'\"\n    [lgMarginLeft]=\"'none'\"\n  >\n    <lg-tab-item *ngFor=\"let tab of tabs\">\n      <lg-tab-item-heading>{{ tab.header }}</lg-tab-item-heading>\n      <lg-tab-item-content>\n        <div class=\"lg-tabs__content-section\">{{ tab.content }}</div>\n      </lg-tab-item-content>\n    </lg-tab-item>\n  </lg-tabs>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 2),\n    tabEvent: action('tab selected'),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select all colors that apply'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/date/date-field.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/input/input.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => createInputStory({})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34443,11 +34313,41 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/radio/radio.stories.ts",
+                "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-radio\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [label]=\"label\"\n    (radioChange)=\"radioChange($event)\">\n  </lg-reactive-form-radio>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    radioChange: action('radioChange'),\n    disabled: boolean('disabled', false),\n  },\n})"
+                "defaultValue": "() => ({\n  template: `\n    <lg-validation-form\n      (formSubmit)=\"formSubmit($event)\">\n    </lg-validation-form>\n  `,\n  props: {\n    formSubmit: action('formSubmit'),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/modal/modal.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n    <lg-modal id=\"modal-story\">\n      <lg-modal-header [headingLevel]=\"headingLevel\">Lorem ipsum</lg-modal-header>\n      <lg-modal-body>\n        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n        <lg-modal-body-timer timer=\"90\"></lg-modal-body-timer>\n      </lg-modal-body>\n      <lg-modal-footer>\n        <lg-button-group>\n          <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Button</button>\n          <button lg-button lgMarginBottom=\"none\" variant=\"outline-primary\" type=\"button\">Close</button>\n        </lg-button-group>\n      </lg-modal-footer>\n    </lg-modal>\n  `,\n  props: {\n    headingLevel: select('heading level', [1, 2, 3, 4, 5, 6], 2),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/table/table.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <table lg-table [showColumnsAt]=\"columnBreakpoint\" [variant]=\"variant\">\n      <thead lg-table-head>\n        <tr lg-table-row>\n          <th lg-table-head-cell [showLabel]=\"showAuthorLabel\">Author</th>\n          <th lg-table-head-cell [align]=\"alignTitleColumn\">Title</th>\n          <th lg-table-head-cell [align]=\"alignPublishColumn\">Published</th>\n        </tr>\n      </thead>\n\n      <tbody lg-table-body>\n        <tr lg-table-row *ngFor=\"let book of books\">\n          <td lg-table-cell [stack]=\"stack\">{{ book.author }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.title }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.published }}</td>\n        </tr>\n      </tbody>\n    </table>\n  `,\n\n  props: {\n    books: object('Books', getDefaultTableContent(), 'Table data'),\n    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),\n    alignTitleColumn: select(\n      'Align Title column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.Start,\n      'Alignment',\n    ),\n    alignPublishColumn: select(\n      'Align Publish column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.End,\n      'Alignment',\n    ),\n    columnBreakpoint: select(\n      'Minimum breakpoint where column layout is used',\n      [\n        TableColumnLayoutBreakpoints.Small,\n        TableColumnLayoutBreakpoints.Medium,\n        TableColumnLayoutBreakpoints.Large,\n      ],\n      TableColumnLayoutBreakpoints.Medium,\n      'Responsive options',\n    ),\n    showAuthorLabel: boolean(\n      'Display author label in non-columns view (showLabel)',\n      false,\n      'Responsive options',\n    ),\n    stack: boolean(\n      'Stack label and content in non-columns view (stack)',\n      false,\n      'Responsive options',\n    ),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/validation/validation.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -34473,21 +34373,91 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
+                "file": "projects/canopy/src/lib/forms/radio/radio.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-validation-form\n      (formSubmit)=\"formSubmit($event)\">\n    </lg-validation-form>\n  `,\n  props: {\n    formSubmit: action('formSubmit'),\n  },\n})"
+                "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-radio\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [label]=\"label\"\n    (radioChange)=\"radioChange($event)\">\n  </lg-reactive-form-radio>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    radioChange: action('radioChange'),\n    disabled: boolean('disabled', false),\n  },\n})"
             },
             {
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/validation/validation.stories.ts",
+                "file": "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
+                "defaultValue": "() => ({\n  template: `\n  <lg-tab-nav-bar label=\"Tabbed navigation demo\">\n    <a *ngFor=\"let tab of tabs; index as i\" lgTabNavBarLink href=\"\" (click)=\"onClick($event)\" id=\"tabbed-nav-{{i}}\" [isActive]=\"i === selectedTabNavIndex\">{{tab}}</a>\n  </lg-tab-nav-bar>\n\n  <lg-tab-nav-content [selectedTabId]=\"'tabbed-nav-' + selectedTabNavIndex\">\n    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n  </lg-tab-nav-content>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    selectedTabNavIndex: 1,\n    onClick: (event: MouseEvent) => event.preventDefault(),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/date/date-field.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/primary-message/primary-message.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <lg-primary-message-story [hasRole]=\"hasRole\"></lg-primary-message-story>\n  `,\n  props: {\n    hasRole: boolean('Set role attribute to alert', true),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/card/card.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <lg-card>\n      <lg-card-header>\n        <lg-card-title headingLevel=\"4\">\n          {{title}}\n        </lg-card-title>\n      </lg-card-header>\n      <lg-card-content>\n        {{cardContent}} <a href=\"#\">Test link</a>.\n      </lg-card-content>\n    </lg-card>\n  `,\n  props: {\n    title: text('title', 'Card title'),\n    cardContent: text(\n      'cardContent',\n      `Leverage agile frameworks to provide a robust synopsis for high level\n    overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall\n    value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity\n    and empowerment.`,\n    ),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select all colors that apply'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/carousel/carousel.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [slideDuration]=\"slideDuration\">${carouselItems}</lg-carousel>`,\n  props: props(),\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/input/input.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => createInputStory({})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/tabs/tabs.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n  <lg-tabs [headingLevel]=\"headingLevel\"\n    label=\"Annuities\"\n    (tabEvent)=\"tabEvent($event)\"\n    [lgMarginRight]=\"'none'\"\n    [lgMarginBottom]=\"'none'\"\n    [lgMarginLeft]=\"'none'\"\n  >\n    <lg-tab-item *ngFor=\"let tab of tabs\">\n      <lg-tab-item-heading>{{ tab.header }}</lg-tab-item-heading>\n      <lg-tab-item-content>\n        <div class=\"lg-tabs__content-section\">{{ tab.content }}</div>\n      </lg-tab-item-content>\n    </lg-tab-item>\n  </lg-tabs>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 2),\n    tabEvent: action('tab selected'),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -34510,6 +34480,36 @@
                 "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
             },
             {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/side-nav/side-nav.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: '<story-side-nav [navItems]=\"navItems\"></story-side-nav>',\n  props: {\n    navItems: object('Navs', getDefaultNavItems()),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/icon/icons.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <lg-swatch-icon [colour]=\"colour\"></lg-swatch-icon>\n  `,\n  props: {\n    colour: select('colour examples', colours, '--color-charcoal'),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/canopy.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<app-root></app-root>`,\n})"
+            },
+            {
                 "name": "standardAccordion",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -34528,6 +34528,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "alertTemplate.bind({})"
+            },
+            {
+                "name": "standardBrandIcons",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "brandIconsTemplate.bind({})"
             },
             {
                 "name": "standardDetails",
@@ -34583,26 +34593,6 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/grid/grid.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "storiesOf('Directives', module)"
-            },
-            {
-                "name": "stories",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/skeleton/skeleton.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "storiesOf('Directives', module)"
-            },
-            {
-                "name": "stories",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34623,6 +34613,16 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "storiesOf('Directives', module)"
+            },
+            {
+                "name": "stories",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34633,7 +34633,17 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "file": "projects/canopy/src/lib/skeleton/skeleton.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "storiesOf('Directives', module)"
+            },
+            {
+                "name": "stories",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/grid/grid.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -34663,11 +34673,11 @@
                 "name": "template",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/alert/alert.stories.ts",
+                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n<lg-alert\n  [showIcon]=\"showIcon\"\n  [variant]=\"variant\">\n  {{content}} Here is some <a href=\"#\"> link text</a>.\n</lg-alert>\n`"
+                "defaultValue": "`\n<lg-card *lgFeatureToggle=\"'firstFeature'\"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>\n<lg-card *lgFeatureToggle=\"'secondFeature'\"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>\n<lg-card *lgFeatureToggle=\"'thirdFeature'\"><lg-card-content>Feature 3 showing</lg-card-content></lg-card>\n<lg-card *lgFeatureToggle=\"'fourthFeature'\"><lg-card-content>Feature 4 not showing</lg-card-content></lg-card>\n`"
             },
             {
                 "name": "template",
@@ -34678,16 +34688,6 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n  <lg-details\n    [isActive]=\"isActive\"\n    [variant]=\"variant\"\n    [showIcon]=\"showIcon\"\n    (opened)=\"toggle('Detail opened')\"\n    (closed)=\"toggle('Detail closed')\">\n    <lg-details-panel-heading [headingLevel]=\"headingLevel\">How do I change my payment details?</lg-details-panel-heading>\n    Give us a call on <a href=\"tel:08001234567\">0800 123 4567</a> and we'll be happy to help you change your\n    payment details\n  </lg-details>\n`"
-            },
-            {
-                "name": "template",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n<lg-card *lgFeatureToggle=\"'firstFeature'\"><lg-card-content>Feature 1 showing</lg-card-content></lg-card>\n<lg-card *lgFeatureToggle=\"'secondFeature'\"><lg-card-content>Feature 2 not showing</lg-card-content></lg-card>\n<lg-card *lgFeatureToggle=\"'thirdFeature'\"><lg-card-content>Feature 3 showing</lg-card-content></lg-card>\n<lg-card *lgFeatureToggle=\"'fourthFeature'\"><lg-card-content>Feature 4 not showing</lg-card-content></lg-card>\n`"
             },
             {
                 "name": "template",
@@ -34707,7 +34707,7 @@
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n <footer lg-footer\n   [copyright]=\"copyright\"\n   [logo]=\"logo\"\n   [logoAlt]=\"logoAlt\"\n   [primaryLinks]=\"primaryLinks\"\n   [secondaryLinks]=\"secondaryLinks\"\n   (primaryLinkClicked)=\"primaryLinkClicked($event)\"\n   (secondaryLinkClicked)=\"secondaryLinkClicked($event)\">\n </footer>\n`"
+                "defaultValue": "`\n <footer lg-footer\n   [copyright]=\"copyright\"\n   [logo]=\"logo\"\n   [logoAlt]=\"logoAlt\"\n   [primaryLinks]=\"primaryLinks\"\n   [secondaryLinks]=\"secondaryLinks\"\n   (primaryLinkClicked)=\"clickedLink($event)\"\n   (secondaryLinkClicked)=\"clickedLink($event)\">\n </footer>\n`"
             },
             {
                 "name": "template",
@@ -34718,6 +34718,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n  <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n`"
+            },
+            {
+                "name": "template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/alert/alert.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n<lg-alert\n  [showIcon]=\"showIcon\"\n  [variant]=\"variant\">\n  {{content}} Here is some <a href=\"#\"> link text</a>.\n</lg-alert>\n`"
             },
             {
                 "name": "template",
@@ -34803,7 +34813,7 @@
                 "name": "uniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts",
+                "file": "projects/canopy/src/lib/forms/radio/radio-group.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -34813,7 +34823,7 @@
                 "name": "uniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/radio/radio-group.component.ts",
+                "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -35348,8 +35358,8 @@
                 "name": "Name",
                 "ctype": "miscellaneous",
                 "subtype": "typealias",
-                "rawtype": "BrandIconName",
-                "file": "projects/canopy/src/lib/brand-icon/brand-icon.component.ts",
+                "rawtype": "IconName",
+                "file": "projects/canopy/src/lib/icon/icon.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "description": "",
@@ -35359,8 +35369,8 @@
                 "name": "Name",
                 "ctype": "miscellaneous",
                 "subtype": "typealias",
-                "rawtype": "IconName",
-                "file": "projects/canopy/src/lib/icon/icon.component.ts",
+                "rawtype": "BrandIconName",
+                "file": "projects/canopy/src/lib/brand-icon/brand-icon.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "description": "",
@@ -35978,6 +35988,16 @@
                     "defaultValue": "[\n  brandIconSet.lgBrandIconCalendar,\n  brandIconSet.lgBrandIconChangeExistingHoldings,\n  brandIconSet.lgBrandIconChangeFutureContributions,\n  brandIconSet.lgBrandIconCookiesAndArrows,\n  brandIconSet.lgBrandIconErrorInBrowser,\n  brandIconSet.lgBrandIconGuaranteedIncome,\n  brandIconSet.lgBrandIconNoInformation,\n  brandIconSet.lgBrandIconNoTransactionsMatch,\n  brandIconSet.lgBrandIconPaymentSuccess,\n  brandIconSet.lgBrandIconPensionPot,\n  brandIconSet.lgBrandIconPeople,\n  brandIconSet.lgBrandIconPerformance,\n  brandIconSet.lgBrandIconPiggyBank,\n  brandIconSet.lgBrandIconRainOrShine,\n  brandIconSet.lgBrandIconSun,\n  brandIconSet.lgBrandIconSurvey,\n  brandIconSet.lgBrandIconThumbsUp,\n  brandIconSet.lgBrandIconVideoGuides,\n  brandIconSet.lgBrandIconWarning,\n  brandIconSet.lgBrandIconMinutes,\n  brandIconSet.lgBrandIconQuickAndEasy,\n  brandIconSet.lgBrandIconHandFlower,\n]"
                 },
                 {
+                    "name": "brandIconsTemplate",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story<LgBrandIconComponent>",
+                    "defaultValue": "(args: LgBrandIconComponent) => ({\n  props: args,\n  template: '<lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [specificColour]=\"specificColour\"></lg-swatch-brand-icon>',\n})"
+                },
+                {
                     "name": "colours",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
@@ -35998,14 +36018,14 @@
                     "defaultValue": "['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl']"
                 },
                 {
-                    "name": "standard",
+                    "name": "standardBrandIcons",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [specificColour]=\"specificColour\"></lg-swatch-brand-icon>\n  `,\n  props: {\n    size: select('size', sizes, 'xs'),\n    colour: select(\n      'example of applying colour globally',\n      colours,\n      '--color-dandelion-yellow',\n    ),\n    specificColour: select(\n      'example of applying colour specifically to an icon',\n      colours,\n      '--color-super-blue',\n    ),\n  },\n})"
+                    "defaultValue": "brandIconsTemplate.bind({})"
                 }
             ],
             "projects/canopy/src/lib/quick-action/quick-action.stories.ts": [
@@ -36296,18 +36316,6 @@
                     "defaultValue": "() => createPromoCardListStory(cardListConfig)"
                 }
             ],
-            "projects/canopy/src/styles/color.stories.ts": [
-                {
-                    "name": "colours",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/color.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <h2>Shades</h2>\n\n    <div>\n      <lg-swatch name=\"--color-white\"></lg-swatch>\n      <lg-swatch name=\"--color-white-smoke\"></lg-swatch>\n      <lg-swatch name=\"--color-platinum\"></lg-swatch>\n      <lg-swatch name=\"--color-taupe-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-battleship-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-charcoal\"></lg-swatch>\n      <lg-swatch name=\"--color-black\"></lg-swatch>\n    </div>\n\n    <h2>Colours</h2>\n\n    <div>\n      <div>\n        <lg-swatch name=\"--color-lavender\"></lg-swatch>\n        <lg-swatch name=\"--color-sky-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-super-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-midnight-blue\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-tea-green\"></lg-swatch>\n        <lg-swatch name=\"--color-lily-green\"></lg-swatch>\n        <lg-swatch name=\"--color-leafy-green\"></lg-swatch>\n        <lg-swatch name=\"--color-mexican-green\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-dusky-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-shocking-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-poppy-red\"></lg-swatch>\n        <lg-swatch name=\"--color-terracotta\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-champagne\"></lg-swatch>\n        <lg-swatch name=\"--color-dandelion-yellow\"></lg-swatch>\n        <lg-swatch name=\"--color-harvest-gold\"></lg-swatch>\n        <lg-swatch name=\"--color-earth-brown\"></lg-swatch>\n      </div>\n    </div>\n\n    <h2>Tints</h2>\n\n    <div>\n      <div>\n        <lg-tint-swatch\n          names=\"--color-super-blue-lightest,--color-super-blue-light,--color-super-blue,--color-super-blue-dark,--color-super-blue-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-leafy-green-lightest,--color-leafy-green-light,--color-leafy-green,--color-leafy-green-dark,--color-leafy-green-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-poppy-red-lightest,--color-poppy-red-light,--color-poppy-red,--color-poppy-red-dark\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-dandelion-yellow-lightest,--color-dandelion-yellow-light,--color-dandelion-yellow\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-earth-brown,--color-earth-brown-dark,--color-earth-brown-darkest\">\n      </lg-tint-swatch>\n      </div>\n    </div>\n  `,\n})"
-                }
-            ],
             "projects/canopy/src/lib/icon/icons.stories.ts": [
                 {
                     "name": "colours",
@@ -36338,6 +36346,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "() => ({\n  template: `\n    <lg-swatch-icon [colour]=\"colour\"></lg-swatch-icon>\n  `,\n  props: {\n    colour: select('colour examples', colours, '--color-charcoal'),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/styles/color.stories.ts": [
+                {
+                    "name": "colours",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/styles/color.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n    <h2>Shades</h2>\n\n    <div>\n      <lg-swatch name=\"--color-white\"></lg-swatch>\n      <lg-swatch name=\"--color-white-smoke\"></lg-swatch>\n      <lg-swatch name=\"--color-platinum\"></lg-swatch>\n      <lg-swatch name=\"--color-taupe-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-battleship-grey\"></lg-swatch>\n      <lg-swatch name=\"--color-charcoal\"></lg-swatch>\n      <lg-swatch name=\"--color-black\"></lg-swatch>\n    </div>\n\n    <h2>Colours</h2>\n\n    <div>\n      <div>\n        <lg-swatch name=\"--color-lavender\"></lg-swatch>\n        <lg-swatch name=\"--color-sky-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-super-blue\"></lg-swatch>\n        <lg-swatch name=\"--color-midnight-blue\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-tea-green\"></lg-swatch>\n        <lg-swatch name=\"--color-lily-green\"></lg-swatch>\n        <lg-swatch name=\"--color-leafy-green\"></lg-swatch>\n        <lg-swatch name=\"--color-mexican-green\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-dusky-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-shocking-pink\"></lg-swatch>\n        <lg-swatch name=\"--color-poppy-red\"></lg-swatch>\n        <lg-swatch name=\"--color-terracotta\"></lg-swatch>\n      </div>\n      <div>\n        <lg-swatch name=\"--color-champagne\"></lg-swatch>\n        <lg-swatch name=\"--color-dandelion-yellow\"></lg-swatch>\n        <lg-swatch name=\"--color-harvest-gold\"></lg-swatch>\n        <lg-swatch name=\"--color-earth-brown\"></lg-swatch>\n      </div>\n    </div>\n\n    <h2>Tints</h2>\n\n    <div>\n      <div>\n        <lg-tint-swatch\n          names=\"--color-super-blue-lightest,--color-super-blue-light,--color-super-blue,--color-super-blue-dark,--color-super-blue-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-leafy-green-lightest,--color-leafy-green-light,--color-leafy-green,--color-leafy-green-dark,--color-leafy-green-darkest\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-poppy-red-lightest,--color-poppy-red-light,--color-poppy-red,--color-poppy-red-dark\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-dandelion-yellow-lightest,--color-dandelion-yellow-light,--color-dandelion-yellow\">\n        </lg-tint-swatch>\n        <lg-tint-swatch\n          names=\"--color-earth-brown,--color-earth-brown-dark,--color-earth-brown-darkest\">\n      </lg-tint-swatch>\n      </div>\n    </div>\n  `,\n})"
                 }
             ],
             "projects/canopy/src/lib/grid/grid.stories.ts": [
@@ -36402,28 +36422,16 @@
                     "defaultValue": "'Column 3'"
                 }
             ],
-            "projects/canopy/src/lib/accordion/accordion.module.ts": [
+            "projects/canopy/src/lib/promo-card/promo-card.module.ts": [
                 {
                     "name": "components",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/accordion/accordion.module.ts",
+                    "file": "projects/canopy/src/lib/promo-card/promo-card.module.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "[]",
-                    "defaultValue": "[\n  LgAccordionComponent,\n  LgAccordionItemComponent,\n  LgAccordionPanelHeadingComponent,\n  LgAccordionItemContentDirective,\n]"
-                }
-            ],
-            "projects/canopy/src/lib/card/card.module.ts": [
-                {
-                    "name": "components",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/card/card.module.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[\n  LgCardComponent,\n  LgCardHeaderComponent,\n  LgCardTitleComponent,\n  LgCardFooterComponent,\n  LgCardSubtitleComponent,\n  LgCardPrincipleDataPointComponent,\n  LgCardPrincipleDataPointLabelComponent,\n  LgCardPrincipleDataPointValueComponent,\n  LgCardPrincipleDataPointDateComponent,\n  LgCardContentComponent,\n]"
+                    "defaultValue": "[\n  LgPromoCardComponent,\n  LgPromoCardListComponent,\n  LgPromoCardTitleComponent,\n  LgPromoCardFooterComponent,\n  LgPromoCardContentComponent,\n  LgPromoCardImageComponent,\n  LgPromoCardListTitleComponent,\n]"
                 }
             ],
             "projects/canopy/src/lib/modal/modal.module.ts": [
@@ -36438,16 +36446,28 @@
                     "defaultValue": "[\n  LgModalComponent,\n  LgModalTriggerDirective,\n  LgModalHeaderComponent,\n  LgModalBodyComponent,\n  LgModalFooterComponent,\n  LgModalBodyTimerComponent,\n]"
                 }
             ],
-            "projects/canopy/src/lib/promo-card/promo-card.module.ts": [
+            "projects/canopy/src/lib/card/card.module.ts": [
                 {
                     "name": "components",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/promo-card/promo-card.module.ts",
+                    "file": "projects/canopy/src/lib/card/card.module.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "[]",
-                    "defaultValue": "[\n  LgPromoCardComponent,\n  LgPromoCardListComponent,\n  LgPromoCardTitleComponent,\n  LgPromoCardFooterComponent,\n  LgPromoCardContentComponent,\n  LgPromoCardImageComponent,\n  LgPromoCardListTitleComponent,\n]"
+                    "defaultValue": "[\n  LgCardComponent,\n  LgCardHeaderComponent,\n  LgCardTitleComponent,\n  LgCardFooterComponent,\n  LgCardSubtitleComponent,\n  LgCardPrincipleDataPointComponent,\n  LgCardPrincipleDataPointLabelComponent,\n  LgCardPrincipleDataPointValueComponent,\n  LgCardPrincipleDataPointDateComponent,\n  LgCardContentComponent,\n]"
+                }
+            ],
+            "projects/canopy/src/lib/accordion/accordion.module.ts": [
+                {
+                    "name": "components",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/accordion/accordion.module.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[\n  LgAccordionComponent,\n  LgAccordionItemComponent,\n  LgAccordionPanelHeadingComponent,\n  LgAccordionItemContentDirective,\n]"
                 }
             ],
             "projects/canopy/src/lib/primary-message/primary-message.module.ts": [
@@ -36462,18 +36482,6 @@
                     "defaultValue": "[\n  LgPrimaryMessageComponent,\n  LgPrimaryMessageTitleComponent,\n  LgPrimaryMessageDescriptionComponent,\n]"
                 }
             ],
-            "projects/canopy/src/lib/side-nav/side-nav.module.ts": [
-                {
-                    "name": "components",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/side-nav/side-nav.module.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[\n  LgSideNavComponent,\n  LgSideNavContentComponent,\n  LgSideNavBarComponent,\n  LgSideNavBarItemComponent,\n  LgSideNavBarFooterComponent,\n  LgSideNavBarItemHeadingComponent,\n  LgSideNavBarItemContentComponent,\n  LgSideNavBarLinkDirective,\n]"
-                }
-            ],
             "projects/canopy/src/lib/carousel/carousel.module.ts": [
                 {
                     "name": "components",
@@ -36484,6 +36492,18 @@
                     "deprecationMessage": "",
                     "type": "[]",
                     "defaultValue": "[LgCarouselItemComponent, LgCarouselComponent, LgAutoplayComponent]"
+                }
+            ],
+            "projects/canopy/src/lib/side-nav/side-nav.module.ts": [
+                {
+                    "name": "components",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/side-nav/side-nav.module.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[\n  LgSideNavComponent,\n  LgSideNavContentComponent,\n  LgSideNavBarComponent,\n  LgSideNavBarItemComponent,\n  LgSideNavBarFooterComponent,\n  LgSideNavBarItemHeadingComponent,\n  LgSideNavBarItemContentComponent,\n  LgSideNavBarLinkDirective,\n]"
                 }
             ],
             "projects/canopy/src/lib/table/table.module.ts": [
@@ -36600,27 +36620,6 @@
                     "defaultValue": "() => ({\n  props: createProps(),\n  template: `\n    <lg-page>\n      ${header}\n      <div lgContainer>\n        <div lgRow>\n          <div lgCol=\"12\" lgColMd=\"8\" lgColLg=\"5\" lgColLgOffset=\"2\">\n            <lg-card lgMarginHorizontal=\"none\">\n              <lg-card-content>\n                {{card1Content}}\n                {{card3Content}}\n              </lg-card-content>\n            </lg-card>\n          </div>\n          <div lgCol=\"12\" lgColMd=\"4\" lgColLg=\"3\">\n            <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n            <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card3Content}}</lg-card-content></lg-card>\n          </div>\n        </div>\n      </div>\n      ${footer}\n    </lg-page>\n  `,\n})"
                 }
             ],
-            "projects/canopy/src/test.ts": [
-                {
-                    "name": "context",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/test.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
-                },
-                {
-                    "name": "require",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/test.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "literal type"
-                }
-            ],
             "projects/canopy-test-app/src/test.ts": [
                 {
                     "name": "context",
@@ -36637,6 +36636,27 @@
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy-test-app/src/test.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "literal type"
+                }
+            ],
+            "projects/canopy/src/test.ts": [
+                {
+                    "name": "context",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/test.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
+                },
+                {
+                    "name": "require",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/test.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "literal type"
@@ -36686,6 +36706,70 @@
                     "deprecationMessage": "",
                     "type": "string",
                     "defaultValue": "'dd MMMM yyyy'"
+                }
+            ],
+            "projects/canopy/src/lib/header/header.stories.ts": [
+                {
+                    "name": "detailsTemplate",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/header/header.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story<LgHeaderComponent>",
+                    "defaultValue": "(args: LgHeaderComponent) => ({\n  props: args,\n  template,\n})"
+                },
+                {
+                    "name": "standardHeader",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/header/header.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "detailsTemplate.bind({})"
+                },
+                {
+                    "name": "template",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/header/header.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n  <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n`"
+                }
+            ],
+            "projects/canopy/src/lib/heading/heading.stories.ts": [
+                {
+                    "name": "detailsTemplate",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story<LgHeadingComponent>",
+                    "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
+                },
+                {
+                    "name": "standardHeading",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "detailsTemplate.bind({})"
+                },
+                {
+                    "name": "template",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n  <lg-heading [level]=\"level\">{{content}}</lg-heading>\n`"
                 }
             ],
             "projects/canopy/src/lib/details/details.stories.ts": [
@@ -36769,71 +36853,7 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n <footer lg-footer\n   [copyright]=\"copyright\"\n   [logo]=\"logo\"\n   [logoAlt]=\"logoAlt\"\n   [primaryLinks]=\"primaryLinks\"\n   [secondaryLinks]=\"secondaryLinks\"\n   (primaryLinkClicked)=\"primaryLinkClicked($event)\"\n   (secondaryLinkClicked)=\"secondaryLinkClicked($event)\">\n </footer>\n`"
-                }
-            ],
-            "projects/canopy/src/lib/header/header.stories.ts": [
-                {
-                    "name": "detailsTemplate",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/header/header.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "Story<LgHeaderComponent>",
-                    "defaultValue": "(args: LgHeaderComponent) => ({\n  props: args,\n  template,\n})"
-                },
-                {
-                    "name": "standardHeader",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/header/header.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "detailsTemplate.bind({})"
-                },
-                {
-                    "name": "template",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/header/header.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n  <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n`"
-                }
-            ],
-            "projects/canopy/src/lib/heading/heading.stories.ts": [
-                {
-                    "name": "detailsTemplate",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "Story<LgHeadingComponent>",
-                    "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
-                },
-                {
-                    "name": "standardHeading",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "detailsTemplate.bind({})"
-                },
-                {
-                    "name": "template",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n  <lg-heading [level]=\"level\">{{content}}</lg-heading>\n`"
+                    "defaultValue": "`\n <footer lg-footer\n   [copyright]=\"copyright\"\n   [logo]=\"logo\"\n   [logoAlt]=\"logoAlt\"\n   [primaryLinks]=\"primaryLinks\"\n   [secondaryLinks]=\"secondaryLinks\"\n   (primaryLinkClicked)=\"clickedLink($event)\"\n   (secondaryLinkClicked)=\"clickedLink($event)\">\n </footer>\n`"
                 }
             ],
             "projects/canopy-test-app/src/environments/environment.ts": [
@@ -40022,192 +40042,12 @@
                     "defaultValue": "[\n  LgAccordionModule,\n  LgAlertModule,\n  LgBreadcrumbModule,\n  LgButtonModule,\n  LgBrandIconModule,\n  LgCardModule,\n  LgDataPointModule,\n  LgDetailsModule,\n  LgFeatureToggleModule,\n  LgFocusModule,\n  LgFooterModule,\n  LgCheckboxGroupModule,\n  LgDateFieldModule,\n  LgValidationModule,\n  LgHintModule,\n  LgInputModule,\n  LgLabelModule,\n  LgRadioModule,\n  LgSelectModule,\n  LgSortCodeModule,\n  LgToggleModule,\n  LgGridModule,\n  LgHeaderModule,\n  LgHeadingModule,\n  LgHeroModule,\n  LgHideAtModule,\n  LgIconModule,\n  LgPageModule,\n  LgPipesModule,\n  LgPrefixModule,\n  LgPromoCardModule,\n  LgQuickActionModule,\n  LgSeparatorModule,\n  LgShowAtModule,\n  LgSideNavModule,\n  LgSkeletonModule,\n  LgSpacingModule,\n  LgSpinnerModule,\n  LgSuffixModule,\n  LgTableModule,\n  LgTabsModule,\n  LgVariantModule,\n  LgCarouselModule,\n  LgModalModule,\n  LgPrimaryMessageModule,\n]"
                 }
             ],
-            "projects/canopy/src/lib/brand-icon/brand-icon.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/brand-icon/brand-icon.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/details/details.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/details/details.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/icon/icon.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/icon/icon.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/prefix/prefix.directive.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/prefix/prefix.directive.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/tabs/tabs.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/tabs/tabs.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
             "projects/canopy/src/lib/suffix/suffix.directive.ts": [
                 {
                     "name": "nextUniqueId",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/suffix/suffix.directive.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/hint/hint.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/hint/hint.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/label/label.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/label/label.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/input/input-field.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/input/input.directive.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/select/select-field.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select-field.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/select/select.directive.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select.directive.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/radio/radio-button.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -40226,12 +40066,24 @@
                     "defaultValue": "0"
                 }
             ],
-            "projects/canopy/src/lib/forms/validation/validation.component.ts": [
+            "projects/canopy/src/lib/brand-icon/brand-icon.component.ts": [
                 {
                     "name": "nextUniqueId",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
+                    "file": "projects/canopy/src/lib/brand-icon/brand-icon.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/prefix/prefix.directive.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/prefix/prefix.directive.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -40250,6 +40102,54 @@
                     "defaultValue": "0"
                 }
             ],
+            "projects/canopy/src/lib/forms/radio/radio-button.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/select/select.directive.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select.directive.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/select/select-field.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select-field.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/label/label.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/label/label.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
             "projects/canopy/src/lib/table/table/table.component.ts": [
                 {
                     "name": "nextUniqueId",
@@ -40262,16 +40162,196 @@
                     "defaultValue": "0"
                 }
             ],
-            "projects/canopy/src/styles/color.notes.ts": [
+            "projects/canopy/src/lib/forms/input/input.directive.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/input/input.directive.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/input/input-field.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/input/input-field.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/hint/hint.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/hint/hint.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/details/details.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/details/details.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/icon/icon.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/icon/icon.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/validation/validation.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/tabs/tabs.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/tabs/tabs.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/quick-action/quick-action.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/styles/color.notes.ts",
+                    "file": "projects/canopy/src/lib/quick-action/quick-action.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Colours\n\n## Purpose\nProvides available brand colours and tints via CSS variables\n\n## Usage\nImport the css into the angular.json file of your application, the variables should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\n`"
+                    "defaultValue": "`\n# Quick Action Component\n\n## Purpose\nQuick Actions are small clickable elements that can be used to provide functionality in context, such as editing a form or actions on a card.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgQuickActionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-quick-action>\n  <lg-icon name=\"repeat\"></lg-icon>\n  Load more\n</button>\n~~~\n\nor:\n\n~~~html\n<a lg-quick-action\n  href=\"/mailbox\">\n  <lg-icon name=\"secure-message\"></lg-icon>\n  Send us a message\n</a>\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/icon/icon.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/icon/icon.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Icon Component\n\n## Purpose\nProvides a way of adding common svg icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgIconModule],\n})\n~~~\n\nImport the \\`LgIconRegistry\\` and register your icons:\n\n~~~js\nexport class AppModule {\n  constructor(private iconRegistry: LgIconRegistry) {\n    this.iconRegistry.registerIcons([\n      lgIconEmail\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-icon name=\"email\"></lg-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n\nAll icons have height and width equal to 1em. This means the icons will be as big as the font-size specified by the parent.\n\n*By default the icons have the \\`\\`fill\\`\\` css property set to \\`\\`currentColor\\`\\`.*\n\n> \\`\\`currentColor\\`\\` acts like a variable for the current value of the \\`\\`color\\`\\` property on the element. And the Cascading part of CSS is still effective, so if there’s no defined \\`\\`color\\`\\` property on an element, the cascade will determine the value of \\`\\`currentColor\\`\\`.\n>\n> *Understanding the currentColor Keyword in CSS - https://alligator.io/css/currentcolor/*\n\n*Please note that the 'need-help' and 'question-mark' icons currently don't have the ability to change colour.*\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/input/input.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/input/input.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Input Component\n\n## Purpose\nProvides a common input directive and input field component. The input field component deals with linking the label and field.\nThe width of the input field is controlled by the HTML size attribute, this allows us to provide the user with an indication of the expected length of the value.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgInputModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n</lg-input-field>\n~~~\n\n### Adding input buttons\n\nButtons can be added within input fields to provide functionality linked to the input.\nThe \\`lgSuffix\\` directive needs to be added to the button to place it in the correct place.\nOnly small size buttons should be placed in the input field.\nThere is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.\n\n#### Button suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\">\n    Search\n  </button>\n</lg-input-field>\n~~~\n\n#### Icon Button suffix with add-on class\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\" [iconButton]=\"true\" variant=\"add-on\">\n    <lg-icon name=\"search\" />\n  </button>\n</lg-input-field>\n~~~\n\n### Adding prefixes and suffixes\n\nPrefix and suffix text can be added to input fields using the \\`lgSuffix\\` and \\`lgPrefix\\` directive.\n\n#### Text prefix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgPrefix>£</span>\n</lg-input-field>\n~~~\n\n#### Text suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgSuffix>%</span>\n</lg-input-field>\n~~~\n\n## Inputs\n\n### LgInputDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n\n### LgInputFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the input full width (for small screens only). | boolean | false | no\n| \\`\\`showLabel\\`\\` | Show or visually hide the label | boolean | true | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/hero/hero.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/hero/hero.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "(name: string, modifier?) => `\n# ${name} Group Components\n\n## Purpose\nProvides a set of components to implement ${name} groups in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more Toggle components. The Toggle component represents a single ${name.toLowerCase()}. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the CheckboxGroup Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgCheckboxGroupModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg-toggle value=\"red\">Red</lg-toggle>\n  <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\nor\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"red\">Red</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"yellow\">Yellow</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\n## Inputs\n\n### LgCheckboxGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-checkbox-group-id-\\${this.nextUniqueId}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-checkbox-group-\\${this.nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Sets the default checked ${name.toLowerCase()} buttons, must match the values of the ${name.toLowerCase()} buttons | array of strings | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`inline\\`\\` | If true, displays the ${\n  name.toLowerCase\n}s inline rather than stacked | boolean | false | No |\n\n### LgToggleComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Value that is set when the toggle is checked | string | null | No |\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`focus\\`\\` | Set the focus on the input | boolean | null | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/date/date-field.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/date/date-field.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Date Input Component\n\n## Purpose\nProvides a component for capturing and validating a date. Output is a concatenation of individual string values into a valid ISO 8601 date format 'YYYY-MM-DD'.\n\n## Usage\nImport the Date Input Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgDateFieldModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-date-field formControlName=\"date\">\n    Date of birth\n    <lg-hint>For example, 12 06 1983</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(date, validationForm)\">\n      <ng-container *ngIf=\"date.hasError('invalidField')\">\n        Enter a valid {{ date.errors.invalidField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidFields')\">\n        Enter a valid {{ date.errors.invalidFields[0] }} and\n        {{ date.errors.invalidFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredField')\">\n        Date of birth must include a {{ date.errors.requiredField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredFields')\">\n        Date of birth must include a {{ date.errors.requiredFields[0] }} and\n        {{ date.errors.requiredFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidDate')\">\n        Enter a valid date of birth\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('futureDate')\">\n        Date must be in the past\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('required')\">\n        Enter a date of birth\n      </ng-container>\n    </lg-validation>\n  </lg-date-field>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgDateFieldComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`dateId\\`\\` | HTML ID attribute for the date input, auto generated if not provided | string | 'lg-input-date-\\${nextUniqueId++}' | No |\n| \\`\\`monthId\\`\\` | HTML ID attribute for the month input, auto generated if not provided | string | 'lg-input-month-\\${nextUniqueId++}' | No |\n| \\`\\`yearId\\`\\` | HTML ID attribute for the year input, auto generated if not provided | string | 'lg-input-year-\\${nextUniqueId++}' | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the date field, if not provided it will use the hint field where appropriate | string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n\n## Validation\nDate validation is quite complex with a range of different validation errors, where possible we have encapsulated as much of that complexity into the components as we can.\n\nInternally the date-field can determine if the entered date is a valid date. If additional validation is required such as checking for past or future dates this can be done with external validators.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n### Internal validation\nIn some scenarios there could be multiple fields that are incorrect, to help guide the users to the correct issue the date field only returns the most significant validation error. Only one error should be shown at a time.\n\nOnce the user has rectified the first error the next error will take it's place if there is one. This allows us to write linear lists of validation messages without the need to apply complex logic in the applications.\n\nThe current significance of errors with their recommended messages is as follows.\n\n#### 1. Invalid fields\n\nOne field is invalid, this may be a non numerical character, or a number outside the valid range .e.g 13 for a month.\n\\`Enter a valid month\\`\n\n~~~json\n{ invalidField: 'month'}\n~~~\n\n\nAs above but with two fields displaying an error.\n\\`Enter a valid month and year\\`\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are invalid a generic 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Required fields\n\nIf one field is empty either through form submission or inline deletion of the content.\n\\`Date of birth must include month\\`\n\n~~~json\n{ requiredField: 'month'}\n~~~\n\nAs above but with two fields missing.\n\\`Date of birth must include a month and year\\`\n\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are missing an 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Invalid date\n\nIf all of the individual fields are correct but they do not concatenate to a valid date. e.g. 30 02 2020\n\n~~~json\n{ invalidDate: true }\n~~~\n\\`Enter a valid date of birth\\`\n\n### External validation\n\nIt is also possible to provide your own custom validation messages using [custom validators](https://angular.io/guide/form-validation#custom-validators)\nand the validation component. This is particularly useful for checking things like wether the date is in the past or the future. Under the hood the date field uses the [date-fns](https://date-fns.org/) library as a peer dependency, to keep build size to a minimum it may be worth considering using the same library in your application.\n\n~~~js\nfunction notMondayValidator(): ValidatorFn {\n  return (control: AbstractControl): { [key: string]: any } | null => {\n    return getDay(parseISO(control.value)) === 'monday' ? { notMonday: true } : null;\n  };\n}\n...\nconst date = new FormControl('', [notMondayValidator()])\n~~~\n\n~~~html\n<lg-date-field formControlName=\"date\">\n  Date of appointment\n  <lg-hint>For example, 12 06 1983</lg-hint>\n  <lg-validation *ngIf=\"isControlInvalid(date, validationForm) && date.hasError('notMonday')\">\n    Date cannot be a Monday\n  </lg-validation>\n </lg-date-field>\n~~~\n\n### Additional validators\n\nTo aid with common validation needs some additional reactive form validators are provided.\n\n#### Future date validator\nThis validator checks if the specified date is in the future, if not it returns a futureDate error\n\n~~~js\nimport { futureDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [futureDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('futureDate')\">\n  Date must be in the future\n</ng-container>\n~~~\n\n#### Past date validator\nThis validator checks if the specified date is in the past, if not it returns a pastDate error\n\n~~~js\nimport { pastDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [pastDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('pastDate')\">\n  Date must be in the past\n</ng-container>\n~~~\n\n#### Before date validator\nThis validator checks if the specified date is before another specified date, if not it returns a beforeDate error.\nThe beforeDate error contains the date that it was compared against.\n\n~~~js\nimport { beforeDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [beforeDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('beforeDate')\">\n  Date must be before {{ date.errors.beforeDate.required }}\n</ng-container>\n~~~\n\n#### After date validator\nThis validator checks if the specified date is after another specified date, if not it returns a afterDate error.\nThe afterDate error contains the date that it was compared against.\n\n~~~js\nimport { afterDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [afterDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('afterDate')\">\n  Date must be after {{ date.errors.afterDate.required }}\n</ng-container>\n~~~\n`"
                 }
             ],
             "projects/canopy/src/styles/grid.notes.ts": [
@@ -40298,54 +40378,6 @@
                     "defaultValue": "`\n# Links\n\nThe links styles are applied automatically when adding the global Canopy css.\n\nFor custom components it's possible to override the style of a link by using the \\`lg-unstyled-link\\`.\n`"
                 }
             ],
-            "projects/canopy/src/styles/mixins.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/mixins.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Mixins\n\n## Purpose\nProvides available mixins\n\n## Mixins\n### lg-inner-focus-outline($bg-color, $color: var(--color-white))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\n\\`\\`$color\\`\\`: colour of the outline.\n\nSets the focus outline inside the element, by using multiple box shadows.\n\n### lg-outer-focus-outline($bg-color: var(--default-focus-color))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\nSets the focus outline outside the element, by using box shadows.\n\n### lg-link($default-color, $hover-color, $visited-color, $active-color, $active-bg-color, $focus-color, $focus-bg-color)\n\\`\\`$default-color\\`\\`: the default color of the element (default value: \\`\\`var(--link-color)\\`\\`).\n\n\\`\\`$hover-color\\`\\`: the hover color of the element (default value: \\`\\`var(--link-hover-color)\\`\\`).\n\n\\`\\`$visited-color\\`\\`: the visited color of the element (default value: \\`\\`var(--link-visited-color)\\`\\`).\n\n\\`\\`$active-color\\`\\`: the active color of the element (default value: \\`\\`var(--link-active-color)\\`\\`).\n\n\\`\\`$active-bg-color\\`\\`: the active background color of the element (default value: \\`\\`var(--link-active-bg-color)\\`\\`).\n\n\\`\\`$focus-color\\`\\`: the focus color color of the element (default value: \\`\\`var(--link-focus-color)\\`\\`).\n\n\\`\\`$focus-bg-color\\`\\`: the focus background color of the element (default value: \\`\\`var(--link-focus-bg-color)\\`\\`).\n\nStyles elements with the link style.\n\n### lg-unstyled-link\nRevert the links styles added with \\`\\`lg-link\\`\\`.\n\n### lg-font-size($size)\n\\`\\`$size\\`\\`: The font size, '7' | '6' | '5' | '4' | '3' | '2' | '1' | '-8' | '-6' | .\n\nStyles text to one of the predefined font sizes. '-8' and '-6' are the sub body font sizes.\n\n### lg-visually-hidden()\nProvides styles to hide information intended only for screen readers from the layout of the rendered page.\n\n### lg-breakpoint($breakpoint)\n\\`\\`$breakpoint\\`\\`: string value for the breakpoint screen size.\n\nAllows breakpoints to be added to css blocks.\n\n### lg-variant($variant: 'generic')\n\\`\\`$variant\\`\\`: The variant type, 'generic' | 'info' | 'success' | 'warning' | 'error'.\n\nStyles components and native child elements to the specified variant.\n\n`"
-                }
-            ],
-            "projects/canopy/src/styles/spacing.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/spacing.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Spacing\n\n## Purpose\nProvides available spacing via CSS variables\n\n## Variables\n| Name | Value | Equivalent in px (based on 16px font-size)\n|------|-------------|-------------|\n| \\`\\`--space-unit\\`\\` | 1rem | 16px |\n| \\`\\`--space-xxxs\\`\\` | calc(0.25 * var(--space-unit)) | 4px |\n| \\`\\`--space-xxs\\`\\` | calc(0.5 * var(--space-unit)) | 8px |\n| \\`\\`--space-xs\\`\\` | calc(0.75 * var(--space-unit)) | 12px |\n| \\`\\`--space-sm\\`\\` | var(--space-unit) | 16px |\n| \\`\\`--space-md\\`\\` | calc(1.5 * var(--space-unit)) | 24px |\n| \\`\\`--space-lg\\`\\` | calc(2 * var(--space-unit)) | 32px |\n| \\`\\`--space-xl\\`\\` | calc(2.5 * var(--space-unit)) | 40px |\n| \\`\\`--space-xxl\\`\\` | calc(3 * var(--space-unit)) | 48px |\n| \\`\\`--space-xxxl\\`\\` | calc(4.5 * var(--space-unit)) | 72px |\n| \\`\\`--space-xxxxl\\`\\` | calc(9 * var(--space-unit)) | 144px |\n\n### For components padding:\n| Name | Value from 0 to md breakpoint | Value from md breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-padding\\`\\` | var(--space-sm) | var(--space-lg) |\n\n### For components margin:\n| Name | Value from 0 to lg breakpoint | Value from lg breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-margin\\`\\` | var(--space-md) | var(--space-lg) |\n`"
-                }
-            ],
-            "projects/canopy/src/styles/typography.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/typography.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Typography\n\n## Purpose\nProvides common typographic styles for native elements with additional utility classes.\n\nCanopy consists of two fonts:\n\n* **Roboto**: Productive font, for general use in self serve apps (default)\n* **Lyon**: Expressive font, for headings in promo material (applied by class modifier)\n\n> **IMPORTANT** - Lyon font files are not included in the Canopy package, you have to serve it yourself, see below for details.\n\n## Serving the Lyon font files\n\nDue to commercial licensing agreements the Lyon font is not included in the distributed package. You will need to manually add it to the **assets** directory of your application. Canopy does provide the css to work with the font and no additional code should be required. You will  need to ensure the font is in the directory specified by Canopy.\n\nCanopy's path for Lyon is **/assets/fonts/lyon/**, therefore you need to put the font files in the following location:\n\n~~~bash\nmy-app/\n  src/\n    assets/\n      fonts/\n        lyon/\n          lyon-display-regular.woff\n          lyon-display-regular.woff2\n          lyon-display-bold.woff\n          lyon-display-bold.woff2\n~~~\n\n> This will result in the font being served in your app like this: <br />http://my-app.landg.com/assets/fonts/lyon/LyonDisplay-Regular-Web.woff2\n\nWhen you include the canopy.css file in your project, it will try to load the font from that exact path. If your font files are in the wrong location, or have a typo in the filename, the Lyon font won't load correctly.\n\nPlease ensure you have the correct licensing agreement in place before using the Lyon font in your application.\n\n## Usage\nThe typography styles will provide styling for all native text elements e.g. \\`\\`h1\\`\\`, \\`\\`h2\\`\\`, \\`\\`p\\`\\`, \\`\\`em\\`\\`, \\`\\`b\\`\\`, \\`\\`strong\\`\\` etc.\n\nBy default the font used is Roboto.\n\nIn addition to the native styling, the following utility classes are exposed, allowing you to change the font size and weight where required.\n\n~~~html\n.lg-font-size-7\n.lg-font-size-7--strong\n\n.lg-font-size-6\n.lg-font-size-6--strong\n\n.lg-font-size-5\n.lg-font-size-5--strong\n\n.lg-font-size-4\n.lg-font-size-4--strong\n\n.lg-font-size-3\n.lg-font-size-3--strong\n\n.lg-font-size-2\n.lg-font-size-2--strong\n\n.lg-font-size-1\n.lg-font-size-1--strong\n\n.lg-font-size-0-8\n\n.lg-font-size-0-6\n~~~\n\n\\`.lg-font-size-1\\` is the base font size that is used to style native elements like p and span, as the numbers increase so\ndoes the font size up to the largest \\`.lg-font-size-7.\\` Each of the primary font styles also have a \\`--strong\\` modifier.\n\nThere are two additional styles which are smaller \\`.lg-font-size-0-8\\`\nand \\`.lg-font-size-0-6\\`. The utility classes are particularly useful for when you want to decouple the semantics and styling,\nfor example making an h1 look like an h3:\n\n~~~html\n<h1 class=\"lg-font-size-3\">H1 that looks like a H3</h1>\n~~~\n<br />\n\n### Using the Lyon font\n\nLyon can be applied using the modifier class: \\`\\`lg-font--expressive\\`\\`. For example:\n\n~~~html\n<h1 class=\"lg-font--expressive\">Heading in Lyon</h1>\n~~~\n\nIt can also be used in addition to the above utility classes:\n\n~~~html\n<p class=\"lg-font-size-5 lg-font--expressive\">Paragraph in Lyon and font size 5</p>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/styles/utils.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/utils.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Utils\n\n## Purpose\nProvides available utils classes\n\n## Classes\n| Class | Description |\n|------|-------------|\n| \\`\\`lg-visually-hidden\\`\\` | Hides information intended only for screen readers from the layout of the rendered page. |\n| \\`\\`lg-unstyled-link\\`\\` | Revert the links styles to a more default style. |\n`"
-                }
-            ],
             "projects/canopy/src/lib/accordion/accordion.notes.ts": [
                 {
                     "name": "notes",
@@ -40355,139 +40387,19 @@
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Accordion Component\n\n## Purpose\nAccordions allow users to quickly expand and collapse grouped sections of content.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAccordionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-accordion [headingLevel]=\"2\">\n    <lg-accordion-item [isActive]=\"isActive\" (opened)=\"handleItemOpened()\" (closed)=\"handleItemClosed()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua.</p>\n    </lg-accordion-item>\n    <lg-accordion-item>\n      <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>\n      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\n        ut aliquip ex ea commodo consequat. Duis aute irure dolor in\n        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\n        pariatur.</p>\n      <button lg-button lgMarginTop=\"sm\" variant=\"solid-primary\">\n        Test primary button\n      </button>\n    </lg-accordion-item>\n    <lg-accordion-item (opened)=\"loadDynamicContent()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n\n      <ng-template lgAccordionItemContent>\n        <app-dynamic-component [content]=\"dynamicContentItems$ | async\">\n            An example component that loads data from the network when this panel is opened.\n        </app-dynamic-component>\n      </ng-template>\n    </lg-accordion-item>\n  </lg-accordion>\n~~~\n\n## Accordion Item Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | The active state of the accordion item | boolean | false | No |\n\n\n## Accordion Item Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the accordion item is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the accordion item is closed | EventEmitter<void> | n/a | No |\n\n\n## Lazy content initialisation\n\nWrap the panel content in a \\`ng-template\\` with the \\`lgAccordionContent\\` directive to only initialise and render\nthe panel when it is first opened.\n`"
+                    "defaultValue": "`\nAccordions allow users to quickly expand and collapse grouped sections of content.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAccordionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-accordion [headingLevel]=\"2\">\n    <lg-accordion-item [isActive]=\"isActive\" (opened)=\"handleItemOpened()\" (closed)=\"handleItemClosed()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua.</p>\n    </lg-accordion-item>\n    <lg-accordion-item>\n      <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>\n      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\n        ut aliquip ex ea commodo consequat. Duis aute irure dolor in\n        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\n        pariatur.</p>\n      <button lg-button lgMarginTop=\"sm\" variant=\"solid-primary\">\n        Test primary button\n      </button>\n    </lg-accordion-item>\n    <lg-accordion-item (opened)=\"loadDynamicContent()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n\n      <ng-template lgAccordionItemContent>\n        <app-dynamic-component [content]=\"dynamicContentItems$ | async\">\n            An example component that loads data from the network when this panel is opened.\n        </app-dynamic-component>\n      </ng-template>\n    </lg-accordion-item>\n  </lg-accordion>\n~~~\n\n## Accordion Item Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | The active state of the accordion item | boolean | false | No |\n\n\n## Accordion Item Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the accordion item is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the accordion item is closed | EventEmitter<void> | n/a | No |\n\n\n## Lazy content initialisation\n\nWrap the panel content in a \\`ng-template\\` with the \\`lgAccordionContent\\` directive to only initialise and render\nthe panel when it is first opened.\n`"
                 }
             ],
-            "projects/canopy/src/lib/alert/alert.notes.ts": [
+            "projects/canopy/src/lib/spacing/padding/padding.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/alert/alert.notes.ts",
+                    "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Brand Icon Component\n\n## Purpose\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` and register your brand icons:\n\n~~~js\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n| \\`\\`size\\`\\` | the size of the icon | BrandIconSize | 'sm' | no |\n| \\`\\`colour\\`\\` | the specific colour of the icon (for global colours see the \"Branding\" section below) | css variable as a string | undefined | no |\n\n## Branding\nThe yellow fill colour of the brand icons can be changed by overriding the \\`--brand-icon-fill-primary\\` css variable.\n\nNote that changing that variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input (see details in the table above).\n`"
-                }
-            ],
-            "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/button/button.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/button/button.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Button Component\n\n## Purpose\nProvides common styles and behaviours for buttons and links.\n\n## Usage\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgButtonModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n~~~\n\nor:\n\n~~~html\n<a lg-button href=\"#\" variant=\"primary\">Link</a>\n~~~\n\n## Button with icon with text\n\nIcons can be content projected into the button, the button component will then handle the styling of that icon.\nThe \\`ButtonIconPosition\\` property can be used to locate the icon on the left hand side of the text, the default is to the right hand side.\nContent projection is used as Canopy Icons need loading via the \\`iconRegistry\\` which enables tree shaking of icons.\n\n~~~html\n<button lg-button type=\"button\" iconPosition=\"left\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## Button with icon only\n\nButtons can be setup as icon only buttons, this is done in a similar way to a button with icon and text.\nYou will still need to include text content inside the button as this information is vital to screen readers.\nThe \\`iconButton\\` property is used to visually hide that text.\n\n~~~html\n<button lg-button type=\"button\" iconButton=\"true\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## ButtonComponent inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of button: \\`\\`solid-primary\\`\\`, \\`\\`solid-secondary\\`\\`, \\`\\`outline-primary\\`\\`, \\`\\`outline-secondary\\`\\`, \\`\\`reverse-primary\\`\\`, \\`\\`reverse-secondary\\`\\`, \\`\\`add-on\\`\\`; | string | solid-primary | No |\n| \\`\\`size\\`\\` | The size of the button | ButtonSize [\\`\\`sm\\`\\`, \\`\\`md\\`\\`] | \\`\\`md\\`\\` | No |\n| \\`\\`fullWidth\\`\\` | If the button has to span full width or not. For 'sm' and 'md' sized screens, the button will always be full width and this input has no affect | boolean | false | No |\n| \\`\\`disabled\\`\\` | Programmatically disable the button via this property | boolean | false | No |\n| \\`\\`loading\\`\\` | If the button shows a loading spinner and is also disabled | boolean | false | No |\n| \\`\\`iconPosition\\`\\` | The position of the icon in the button | string | right | No |\n| \\`\\`iconButton\\`\\` | The button displays an icon only | boolean | false | No |\n\n## Button group\n\nButtons can be grouped together by using the \\`\\`ButtonGroupComponent\\`\\`:\n\n~~~html\n<lg-button-group>\n  <button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n  <a lg-button href=\"#\" variant=\"outline-primary\">Link</a>\n</lg-button-group>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/details/details.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/details/details.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\nThe Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgDetailsModule ],\n})\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/data-point/data-point.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\nThis module allows you to enable and disable features by using the \\`lgFeatureToggle\\` directive and passing an observable of the toggle's configuration to the module.\n\n## Usage\n\nImport the module in your core component, e.g.:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n})\n~~~\n\nand also import \\`LgFeatureToggleModule\\` (without the \\`forRoot\\`) in the modules that will need it.\n\n\\`useFactory\\` returns an observable of a config file structured as below:\n\n~~~\n{\n  \"exampleFeature\": true,\n  \"anotherExampleFeature\": false\n}\n~~~\n\nThe default behaviour is to show a feature if it's undefined, but we can override it by passing an optional object with defaultHide set to true like this:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n  },\n  {\n    defaultHide: true\n  }\n)\n~~~\n\nIn your component(s) add the structural directive like in the example below:\n\n~~~\n<div *lgFeatureToggle=\"'exampleFeature'\">\n  <p>The enabled feature</p>\n</div>\n\n<div *lgFeatureToggle=\"'anotherExampleFeature'\">\n  <p>The disabled feature</p>\n</div>\n~~~\n\n## FeatureToggleGuard configuration\n\nTo use the FeatureToggleGuard you need to add it to your routes configuration in the usual canActive, canActivateChild, canLoad, and then add in the data property like\n\n~~~\ndata: {\n  featureToggle: 'myToggle',\n},\n~~~\n\nif you use canActivateChild, child route definitions can add its own featureToggle in their data, and the path is only valid when all the featureToggle flags of each route segment are true\n\nExample with a lazy loading route\n\n~~~\n{\n  path: 'parent',\n  loadChildren: () => import('./parent/parent.module').then(m => m.ParentnModule),\n  canActivate: [ FeatureToggleGuard ],\n  canActivateChild: [ FeatureToggleGuard ],\n  canLoad: [ FeatureToggleGuard ],\n  data: {\n    featureToggle: 'parentToggle',\n  },\n},\n~~~\n\nExample of inner routes (route definition inside ParentModule)\n\n~~~\n{\n  path: 'child',\n  component: ChildContainerComponent,\n  data: {\n    featureToggle: 'childToggle',\n  },\n},\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/card/card.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/card/card.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Card Component\n\n## Purpose\nProvides a generic card component for displaying content. Consists of various card components that are designed to create modular and flexible card layouts, from a basic card with a title, text and buttons to a single-page Form Journey card.\n\n## Usage\n\nFor a basic card, import the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgCardModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-card>\n  <lg-card-header>\n    Your title\n  </lg-card-header>\n  <lg-card-content>\n    Your content\n  </lg-card-content>\n</lg-card>\n~~~\n\n---\n\n### Other card types and templates\n\nYou can extend the basic card component and create specific card implementations.\n\n#### Product card\n\nThis component uses some extra card components, such as \\`LgCardPrincipleDataPoint\\` and \\`LgCardPrincipleDataPointValue\\` to display data points.\n\n~~~html\n<lg-card>\n  <lg-card-content>\n    <div lgRow>\n      <div lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-title headingLevel=\"4\">\n          <a href=\"#\">{{title}}</a>.\n        </lg-card-title>\n        <lg-card-subtitle>\n          Payroll Reference Number P23456\n        </lg-card-subtitle>\n      </div>\n      <lg-card-principle-data-point lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-principle-data-point-label>\n          Last payment (after tax and deductions)\n        </lg-card-principle-data-point-label>\n        <lg-card-principle-data-point-value>\n          <span><span class=\"lg-font-size-3\">£</span>230.20</span>\n        </lg-card-principle-data-point-value>\n        <lg-card-principle-data-point-date>\n          as of 01 Jan 2020\n        </lg-card-principle-data-point-date>\n      </lg-card-principle-data-point>\n    </div>\n  </lg-card-content>\n</lg-card>\n~~~\n\n#### Form Journey card\n\nCreates the Form Journey template, used to display a single page form. Note that the <form> element is a parent of the <lg-card> component, this is because the form inputs and submit button are spread out between the card content and card footer.\n\n~~~html\n<div lgContainer>\n<div lgRow>\n  <div lgCol=\"12\" lgColLg=\"6\" lgColLgOffset=\"3\" lgColMd=\"10\" lgColMdOffset=\"1\">\n    <form [formGroup]=\"form\" (ngSubmit)=\"onSubmit(form)\">\n      <lg-card lgPadding=\"none\">\n        <lg-card-header lgPadding=\"sm\" lgPaddingBottom=\"xs\" lgMarginBottom=\"lg\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\">\n                <lg-icon [name]=\"'chevron-left'\"></lg-icon>\n                Back\n              </a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </lg-card-header>\n        <lg-card-content>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <lg-card-title headingLevel=\"3\" lgPaddingBottom=\"md\">{{ title }}</lg-card-title>\n                <p>{{cardContent}}</p>\n\n                <lg-input-field [block]=\"block\">\n                  {{ label }}\n                  <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n                  <input lgInput formControlName=\"accountNumber\" size=\"8\" />\n                </lg-input-field>\n\n              </div>\n            </div>\n          </div>\n        </lg-card-content>\n        <lg-card-footer>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <button lg-button type=\"button\" variant=\"outline-primary\" lgMarginRight=\"sm\">Back</button>\n                <button lg-button type=\"submit\" variant=\"solid-primary\">Confirm</button>\n                <p *ngIf=\"policy\" lgPaddingBottom=\"md\">{{ policy }}</p>\n              </div>\n            </div>\n          </div>\n        </lg-card-footer>\n      </lg-card>\n    </form>\n  </div>\n</div>\n</div>\n~~~\n\n### Inputs\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`<default>\\`\\` | The main body content of the card\n\n### LgCardHeaderComponent\nThis is the primary layout section of the card component, it is used to contain breadcrumbs or other similar content.\n\n### LgCardContent\nThis is the secondary layout section of the card component, it is used to contain the cards main content and provides the inner padding of the card.\n\n### LgCardTitleComponent\nThis is where the main title should be provided. It should be located inside the card content.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgCardSubtitleComponent\nIf the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.\n\n### LgCardPrincipleDataPoint\nSometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card content which will control it's layout\n\n### LgCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointDate\nThis is where the date for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardFooter\nThis is the footer layout section of the card component, it is used to contain call to action buttons as well as messages or hints.\n`"
-                }
-            ],
-            "projects/canopy/src/lib/focus/focus.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/focus/focus.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\nThis directive allows for focus to be set dynamically on a focusable element.\n\n## Usage\nImport the directive in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgFocusDirective ],\n})\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/footer/footer.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/footer/footer.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/grid/grid.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/grid/grid.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
+                    "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/header/header.notes.ts": [
@@ -40502,16 +40414,16 @@
                     "defaultValue": "`\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/hero/hero.notes.ts": [
+            "projects/canopy/src/lib/card/card.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/hero/hero.notes.ts",
+                    "file": "projects/canopy/src/lib/card/card.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "(productHeroHTML: string, conversationalHeroHTML: string) => `\n# Hero Component\n\n\n## Purpose\nA flexible component that is often used to display the most prominent information about a page. The module consists of lots of smaller presentation components that help to map out the common hero use cases.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML...\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"2\">\n                Good morning, Gene\n              </lg-hero-card-title>\n            </lg-hero-card-header>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n## Other hero types and templates\n\nYou can extend the basic Hero component and create specific Hero layouts and implementations.\n\n### Hero with breadcrumbs\n\nUsing the \\`\\`LgHeroCardHeaderComponent\\`\\` together with \\`\\`LgBreadcrumbComponent\\`\\`, some breadcrumbs can be easily added to the hero. Note that you should use the \"light\" variant of the Breadcrumbs, as it's rendering against a dark blue background.\n\n~~~html\n<lg-hero [overlap]=\"overlap\">\n  <lg-hero-header>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\"><lg-icon [name]=\"'home'\"></lg-icon>Home</a>\n            </lg-breadcrumb-item>\n            <lg-breadcrumb-item>\n              <a href=\"#\" aria-current=\"page\">Product Details</a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </div>\n      </div>\n    </div>\n  </lg-hero-header>\n</lg-hero>\n~~~\n\n### Product details\n\nThis component can used to display product data, for example on a prodcut details page. Note the extensive use of presentation components to acheive the desired layout.\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            <lg-hero-card-header>\n              <lg-hero-card-title [headingLevel]=\"4\">\n                Pension annuity\n              </lg-hero-card-title>\n              <lg-hero-card-subtitle>\n                Payroll Reference Number P23456\n              </lg-hero-card-subtitle>\n              <lg-hero-card-notification>\n                <lg-icon name=\"information-fill\"></lg-icon>\n                <p>Your payments have been suspended, please <a href=\"#\">contact us</a> to learn more.</p>\n              </lg-hero-card-notification>\n              <lg-hero-card-principle-data-point>\n                <lg-hero-card-principle-data-point-label headingLevel=\"5\">\n                  Last payment (after tax and deductions)\n                </lg-hero-card-principle-data-point-label>\n                <lg-hero-card-principle-data-point-value>\n                  £230.20\n                </lg-hero-card-principle-data-point-value>\n              </lg-hero-card-principle-data-point>\n            </lg-hero-card-header>\n            <lg-hero-card-content>\n              <lg-hero-card-data-point-list>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment due\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    15 Jan 2020\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Payment frequency\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    Monthly\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n                <lg-hero-card-data-point>\n                  <lg-hero-card-data-point-label [headingLevel]=\"6\">\n                    Tax code\n                  </lg-hero-card-data-point-label>\n                  <lg-hero-card-data-point-value>\n                    2T <span lgMarginLeft=\"sm\" class=\"lg-font-size-1\">Received on 12 Mar 2019</span>\n                  </lg-hero-card-data-point-value>\n                </lg-hero-card-data-point>\n              </lg-hero-card-data-point-list>\n            </lg-hero-card-content>\n            <lg-hero-card-footer>\n              <small class=\"lg-font-size-0-6\">* This is not a guaranteed amount and could be subject to change.</small>\n            </lg-hero-card-footer>\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n\n### LgHeroComponent\nThis is the branded bar which runs across\nthe top of the page. It also controls the functionality to create the 'overlap' between the page content.\n\n#### Configure Overlap\n\n~~~html\n<lg-hero [overlap]=\"2\"></lg-hero>\n~~~\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`overlap\\`\\` | The amount that the page content overlaps the hero component (rem) | number | 2 | No |\n\n\n### LgHeroContent\nThis is the main section of the hero bar, it stretches the full width and is agnostic of grid system. You will need to configure the grid in the contents of this component to match your page layout.\n\n#### Configure Grid\n\n~~~html\n<lg-hero [overlap]=\"2\">\n  <lg-hero-content>\n    <div lgContainer>\n      <div lgRow>\n        <div [lgCol]=\"12\">\n          <lg-hero-card>\n            ...\n          </lg-hero-card>\n        </div>\n      </div>\n    </div>\n  </lg-hero-content>\n</lg-hero>\n~~~\n\n### LgHeroContent\nThis is the top section of the hero bar, it stretches the full width and is agnostic of grid system. It is generally used to home the breadcrumb component if there is one. Similar to LgHeroContent you will need to configure the grid in the contents of this component to match your page layout.\n\n### LgHeroCard\nA container component for displaying content within the hero area. The hero and hero card components are agnostic of the grid layout of the page. You will need to wrap the hero card component with the specific grid that is required.\n\n### LgHeroCardHeaderComponent\nThis is the primary layout section of the hero component, it is used to contain the title, subtitle and principle value.\n\n### LgHeroCardTitleComponent\nThis is where the main hero title should be provided. It should be located inside the hero header.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the hero card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardSubtitleComponent\nIf the hero has a subtitle it should be located within this component. If a hero has a subtitle it is expected to also implicitly have a title. It should be located inside the hero header.\n\n### LgHeroCardNotificationComponent\nDisplays a notification associated with a product, for example if the product's payments are in 'suspended' state.\n\n### LgHeroCardPrincipleDataPoint\nSometimes the hero card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the hero header which will controls it's layout\n\n### LgHeroCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero principle data point\n\n### LgHeroCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero principle data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardContent\nThis is the secondary layout section of the hero component, it is used to contain secondary information.\n\n### LgHeroCardDataPointList\nWhen the hero card is being used to display secondary data points, those data points should be wrapped in a list. This element provides the list semantics, it should be contained inside the hero content.\n\n### LgHeroCardDataPoint\nSometimes the hero card will be displaying one or more secondary data points. In that case this layout component should be used. It should be located inside the hero content which will controls it's layout. One or more data points can be supported.\n\n### LgHeroCardDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the hero data point\n\n### LgHeroCardDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the hero data point\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the heading in the label: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgHeroCardFooter\nThis where any extra text related to the hero card can be displayed, such as a small print.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgHeroModule ],\n})\n~~~\n\nand in your HTML:\n\nProduct data\n\n~~~html\n  ${productHeroHTML}\n~~~\n\nConversational ui\n\n~~~html\n  ${conversationalHeroHTML}\n~~~\n`"
+                    "defaultValue": "`\n# Card Component\n\n## Purpose\nProvides a generic card component for displaying content. Consists of various card components that are designed to create modular and flexible card layouts, from a basic card with a title, text and buttons to a single-page Form Journey card.\n\n## Usage\n\nFor a basic card, import the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgCardModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-card>\n  <lg-card-header>\n    Your title\n  </lg-card-header>\n  <lg-card-content>\n    Your content\n  </lg-card-content>\n</lg-card>\n~~~\n\n---\n\n### Other card types and templates\n\nYou can extend the basic card component and create specific card implementations.\n\n#### Product card\n\nThis component uses some extra card components, such as \\`LgCardPrincipleDataPoint\\` and \\`LgCardPrincipleDataPointValue\\` to display data points.\n\n~~~html\n<lg-card>\n  <lg-card-content>\n    <div lgRow>\n      <div lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-title headingLevel=\"4\">\n          <a href=\"#\">{{title}}</a>.\n        </lg-card-title>\n        <lg-card-subtitle>\n          Payroll Reference Number P23456\n        </lg-card-subtitle>\n      </div>\n      <lg-card-principle-data-point lgCol=\"12\" lgColMd=\"6\">\n        <lg-card-principle-data-point-label>\n          Last payment (after tax and deductions)\n        </lg-card-principle-data-point-label>\n        <lg-card-principle-data-point-value>\n          <span><span class=\"lg-font-size-3\">£</span>230.20</span>\n        </lg-card-principle-data-point-value>\n        <lg-card-principle-data-point-date>\n          as of 01 Jan 2020\n        </lg-card-principle-data-point-date>\n      </lg-card-principle-data-point>\n    </div>\n  </lg-card-content>\n</lg-card>\n~~~\n\n#### Form Journey card\n\nCreates the Form Journey template, used to display a single page form. Note that the <form> element is a parent of the <lg-card> component, this is because the form inputs and submit button are spread out between the card content and card footer.\n\n~~~html\n<div lgContainer>\n<div lgRow>\n  <div lgCol=\"12\" lgColLg=\"6\" lgColLgOffset=\"3\" lgColMd=\"10\" lgColMdOffset=\"1\">\n    <form [formGroup]=\"form\" (ngSubmit)=\"onSubmit(form)\">\n      <lg-card lgPadding=\"none\">\n        <lg-card-header lgPadding=\"sm\" lgPaddingBottom=\"xs\" lgMarginBottom=\"lg\">\n          <lg-breadcrumb lgMarginBottom=\"none\">\n            <lg-breadcrumb-item>\n              <a href=\"#\">\n                <lg-icon [name]=\"'chevron-left'\"></lg-icon>\n                Back\n              </a>\n            </lg-breadcrumb-item>\n          </lg-breadcrumb>\n        </lg-card-header>\n        <lg-card-content>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <lg-card-title headingLevel=\"3\" lgPaddingBottom=\"md\">{{ title }}</lg-card-title>\n                <p>{{cardContent}}</p>\n\n                <lg-input-field [block]=\"block\">\n                  {{ label }}\n                  <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n                  <input lgInput formControlName=\"accountNumber\" size=\"8\" />\n                </lg-input-field>\n\n              </div>\n            </div>\n          </div>\n        </lg-card-content>\n        <lg-card-footer>\n          <div lgContainer>\n            <div lgRow>\n              <div lgCol=\"12\" lgColMd=\"10\" lgColMdOffset=\"1\">\n                <button lg-button type=\"button\" variant=\"outline-primary\" lgMarginRight=\"sm\">Back</button>\n                <button lg-button type=\"submit\" variant=\"solid-primary\">Confirm</button>\n                <p *ngIf=\"policy\" lgPaddingBottom=\"md\">{{ policy }}</p>\n              </div>\n            </div>\n          </div>\n        </lg-card-footer>\n      </lg-card>\n    </form>\n  </div>\n</div>\n</div>\n~~~\n\n### Inputs\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`<default>\\`\\` | The main body content of the card\n\n### LgCardHeaderComponent\nThis is the primary layout section of the card component, it is used to contain breadcrumbs or other similar content.\n\n### LgCardContent\nThis is the secondary layout section of the card component, it is used to contain the cards main content and provides the inner padding of the card.\n\n### LgCardTitleComponent\nThis is where the main title should be provided. It should be located inside the card content.\n\n#### Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the card heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n### LgCardSubtitleComponent\nIf the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.\n\n### LgCardPrincipleDataPoint\nSometimes the card will be displaying a principle data point. In that case this layout component should be used. It should be located inside the card content which will control it's layout\n\n### LgCardPrincipleDataPointValue\nThis is where the value for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointLabel\nThis is where the label for the data point should be projected. A data point should always have a value, but it may not have a label. It should be located inside the card principle data point\n\n### LgCardPrincipleDataPointDate\nThis is where the date for the data point should be projected. It should be located inside the card principle data point\n\n### LgCardFooter\nThis is the footer layout section of the card component, it is used to contain call to action buttons as well as messages or hints.\n`"
                 }
             ],
             "projects/canopy/src/lib/heading/heading.notes.ts": [
@@ -40526,16 +40438,136 @@
                     "defaultValue": "`\nThis component allows for headings to be set dynamically.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeadingModule ],\n})\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/icon/icon.notes.ts": [
+            "projects/canopy/src/lib/carousel/carousel.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/icon/icon.notes.ts",
+                    "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Icon Component\n\n## Purpose\nProvides a way of adding common svg icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgIconModule],\n})\n~~~\n\nImport the \\`LgIconRegistry\\` and register your icons:\n\n~~~js\nexport class AppModule {\n  constructor(private iconRegistry: LgIconRegistry) {\n    this.iconRegistry.registerIcons([\n      lgIconEmail\n    ]);\n  }\n}\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-icon name=\"email\"></lg-icon>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`name\\`\\` | the name of the icon | string | undefined | yes |\n\nAll icons have height and width equal to 1em. This means the icons will be as big as the font-size specified by the parent.\n\n*By default the icons have the \\`\\`fill\\`\\` css property set to \\`\\`currentColor\\`\\`.*\n\n> \\`\\`currentColor\\`\\` acts like a variable for the current value of the \\`\\`color\\`\\` property on the element. And the Cascading part of CSS is still effective, so if there’s no defined \\`\\`color\\`\\` property on an element, the cascade will determine the value of \\`\\`currentColor\\`\\`.\n>\n> *Understanding the currentColor Keyword in CSS - https://alligator.io/css/currentcolor/*\n\n*Please note that the 'need-help' and 'question-mark' icons currently don't have the ability to change colour.*\n`"
+                    "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/details/details.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/details/details.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nThe Details component reduces page clutter and cognitive load by letting users reveal more information as and when they need it. It can also be used to communicate important imformation in a collapsed layout, similar to an Alert.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgDetailsModule ],\n})\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/spacing/margin/margin.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/select/select.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
+                }
+            ],
+            "projects/canopy/src/lib/data-point/data-point.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/data-point/data-point.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Data Point Component\n\n## Purpose\nTo display data organised by heading and value. A Data Point can be used on it's own, or grouped into a Data Point List where each one will be displayed horizontally and given a list-item role.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgDataPointModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-data-point-list>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Name on account\n    </lg-data-point-label>\n    <lg-data-point-value>\n      Joe Bloggs\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Account number\n    </lg-data-point-label>\n    <lg-data-point-value>\n      ***5678\n    </lg-data-point-value>\n  </lg-data-point>\n  <lg-data-point>\n    <lg-data-point-label [headingLevel]=\"headingLevel\">\n      Bank sort code\n    </lg-data-point-label>\n    <lg-data-point-value>\n      00 - 00 - **\n    </lg-data-point-value>\n  </lg-data-point>\n</lg-data-point-list>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| headingLevel | Allows the heading level to be set | number | n/a | Yes |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/focus/focus.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/focus/focus.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nThis directive allows for focus to be set dynamically on a focusable element.\n\n## Usage\nImport the directive in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgFocusDirective ],\n})\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Kebab case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into kebab case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgKebabCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | kebabCase}}</p>\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/validation/validation.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/validation/validation.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Error Component\n\n\n## Purpose\nThe validation component is used to provide contextual information for a form input field. The most common use case is to display validation errors however it can also be used to show additional information.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgValidationModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-validation>Enter a valid postcode</lg-validation>\n\n<lg-validation variant=\"success\">Username is available</lg-validation>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of the validation: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'error' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display | boolean | true | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/feature-toggle/feature-toggle.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nThis module allows you to enable and disable features by using the \\`lgFeatureToggle\\` directive and passing an observable of the toggle's configuration to the module.\n\n## Usage\n\nImport the module in your core component, e.g.:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n})\n~~~\n\nand also import \\`LgFeatureToggleModule\\` (without the \\`forRoot\\`) in the modules that will need it.\n\n\\`useFactory\\` returns an observable of a config file structured as below:\n\n~~~\n{\n  \"exampleFeature\": true,\n  \"anotherExampleFeature\": false\n}\n~~~\n\nThe default behaviour is to show a feature if it's undefined, but we can override it by passing an optional object with defaultHide set to true like this:\n\n~~~\nLgFeatureToggleModule.forRoot({\n  deps: [Store],\n  useFactory: (store: Store<CoreState>) => store.select(getFeatureToggles)\n  },\n  {\n    defaultHide: true\n  }\n)\n~~~\n\nIn your component(s) add the structural directive like in the example below:\n\n~~~\n<div *lgFeatureToggle=\"'exampleFeature'\">\n  <p>The enabled feature</p>\n</div>\n\n<div *lgFeatureToggle=\"'anotherExampleFeature'\">\n  <p>The disabled feature</p>\n</div>\n~~~\n\n## FeatureToggleGuard configuration\n\nTo use the FeatureToggleGuard you need to add it to your routes configuration in the usual canActive, canActivateChild, canLoad, and then add in the data property like\n\n~~~\ndata: {\n  featureToggle: 'myToggle',\n},\n~~~\n\nif you use canActivateChild, child route definitions can add its own featureToggle in their data, and the path is only valid when all the featureToggle flags of each route segment are true\n\nExample with a lazy loading route\n\n~~~\n{\n  path: 'parent',\n  loadChildren: () => import('./parent/parent.module').then(m => m.ParentnModule),\n  canActivate: [ FeatureToggleGuard ],\n  canActivateChild: [ FeatureToggleGuard ],\n  canLoad: [ FeatureToggleGuard ],\n  data: {\n    featureToggle: 'parentToggle',\n  },\n},\n~~~\n\nExample of inner routes (route definition inside ParentModule)\n\n~~~\n{\n  path: 'child',\n  component: ChildContainerComponent,\n  data: {\n    featureToggle: 'childToggle',\n  },\n},\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/variant/variant.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/variant/variant.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/page/page.notes.ts": [
@@ -40550,16 +40582,158 @@
                     "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/modal/modal.notes.ts": [
+            "projects/canopy/src/styles/mixins.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/modal/modal.notes.ts",
+                    "file": "projects/canopy/src/styles/mixins.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Modal Component\n\n\n## Purpose\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Lorem ipsum</lg-modal-header>\n  <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nfor a timout modal you can use the following structure:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Logout</lg-modal-header>\n  <lg-modal-body>\n    For your security, we'll log yuo out in:\n    <lg-modal-body-timer timer=\"0:58\"></lg-modal-body-timer>\n  </lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nOpening and closing the modal is also possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
+                    "defaultValue": "`\n# Mixins\n\n## Purpose\nProvides available mixins\n\n## Mixins\n### lg-inner-focus-outline($bg-color, $color: var(--color-white))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\n\\`\\`$color\\`\\`: colour of the outline.\n\nSets the focus outline inside the element, by using multiple box shadows.\n\n### lg-outer-focus-outline($bg-color: var(--default-focus-color))\n\\`\\`$bg-color\\`\\`: background color of the element.\n\nSets the focus outline outside the element, by using box shadows.\n\n### lg-link($default-color, $hover-color, $visited-color, $active-color, $active-bg-color, $focus-color, $focus-bg-color)\n\\`\\`$default-color\\`\\`: the default color of the element (default value: \\`\\`var(--link-color)\\`\\`).\n\n\\`\\`$hover-color\\`\\`: the hover color of the element (default value: \\`\\`var(--link-hover-color)\\`\\`).\n\n\\`\\`$visited-color\\`\\`: the visited color of the element (default value: \\`\\`var(--link-visited-color)\\`\\`).\n\n\\`\\`$active-color\\`\\`: the active color of the element (default value: \\`\\`var(--link-active-color)\\`\\`).\n\n\\`\\`$active-bg-color\\`\\`: the active background color of the element (default value: \\`\\`var(--link-active-bg-color)\\`\\`).\n\n\\`\\`$focus-color\\`\\`: the focus color color of the element (default value: \\`\\`var(--link-focus-color)\\`\\`).\n\n\\`\\`$focus-bg-color\\`\\`: the focus background color of the element (default value: \\`\\`var(--link-focus-bg-color)\\`\\`).\n\nStyles elements with the link style.\n\n### lg-unstyled-link\nRevert the links styles added with \\`\\`lg-link\\`\\`.\n\n### lg-font-size($size)\n\\`\\`$size\\`\\`: The font size, '7' | '6' | '5' | '4' | '3' | '2' | '1' | '-8' | '-6' | .\n\nStyles text to one of the predefined font sizes. '-8' and '-6' are the sub body font sizes.\n\n### lg-visually-hidden()\nProvides styles to hide information intended only for screen readers from the layout of the rendered page.\n\n### lg-breakpoint($breakpoint)\n\\`\\`$breakpoint\\`\\`: string value for the breakpoint screen size.\n\nAllows breakpoints to be added to css blocks.\n\n### lg-variant($variant: 'generic')\n\\`\\`$variant\\`\\`: The variant type, 'generic' | 'info' | 'success' | 'warning' | 'error'.\n\nStyles components and native child elements to the specified variant.\n\n`"
+                }
+            ],
+            "projects/canopy/src/lib/button/button.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/button/button.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Button Component\n\n## Purpose\nProvides common styles and behaviours for buttons and links.\n\n## Usage\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgButtonModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n~~~\n\nor:\n\n~~~html\n<a lg-button href=\"#\" variant=\"primary\">Link</a>\n~~~\n\n## Button with icon with text\n\nIcons can be content projected into the button, the button component will then handle the styling of that icon.\nThe \\`ButtonIconPosition\\` property can be used to locate the icon on the left hand side of the text, the default is to the right hand side.\nContent projection is used as Canopy Icons need loading via the \\`iconRegistry\\` which enables tree shaking of icons.\n\n~~~html\n<button lg-button type=\"button\" iconPosition=\"left\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## Button with icon only\n\nButtons can be setup as icon only buttons, this is done in a similar way to a button with icon and text.\nYou will still need to include text content inside the button as this information is vital to screen readers.\nThe \\`iconButton\\` property is used to visually hide that text.\n\n~~~html\n<button lg-button type=\"button\" iconButton=\"true\" >\n  Add item\n  <lg-icon name=\"add\" />\n</button>\n~~~\n\n## ButtonComponent inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of button: \\`\\`solid-primary\\`\\`, \\`\\`solid-secondary\\`\\`, \\`\\`outline-primary\\`\\`, \\`\\`outline-secondary\\`\\`, \\`\\`reverse-primary\\`\\`, \\`\\`reverse-secondary\\`\\`, \\`\\`add-on\\`\\`; | string | solid-primary | No |\n| \\`\\`size\\`\\` | The size of the button | ButtonSize [\\`\\`sm\\`\\`, \\`\\`md\\`\\`] | \\`\\`md\\`\\` | No |\n| \\`\\`fullWidth\\`\\` | If the button has to span full width or not. For 'sm' and 'md' sized screens, the button will always be full width and this input has no affect | boolean | false | No |\n| \\`\\`disabled\\`\\` | Programmatically disable the button via this property | boolean | false | No |\n| \\`\\`loading\\`\\` | If the button shows a loading spinner and is also disabled | boolean | false | No |\n| \\`\\`iconPosition\\`\\` | The position of the icon in the button | string | right | No |\n| \\`\\`iconButton\\`\\` | The button displays an icon only | boolean | false | No |\n\n## Button group\n\nButtons can be grouped together by using the \\`\\`ButtonGroupComponent\\`\\`:\n\n~~~html\n<lg-button-group>\n  <button lg-button type=\"button\" variant=\"solid-primary\">Button</button>\n  <a lg-button href=\"#\" variant=\"outline-primary\">Link</a>\n</lg-button-group>\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/grid/grid.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/grid/grid.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/validation/form.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/validation/form.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Form Validation\n\n## Purpose\nTo provide a consistent approach to form validation.\n\n## Usage\nThe rules to display the error states are incorporated into the individual Canopy\nform components. When used in conjunction with standard [Angular form validation](https://angular.io/guide/form-validation)\nthe error styles will be displayed automatically.\n\nError messages need to be handled by the individual applications by utilising the\n[Validation](/?path=/story/components-form-validation--component) component and\nthe LgErrorStateMatcher.\n\nImport the module in your core component, e.g.:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgValidationModule]\n})\n~~~\n\nIn your component file set up the relevant validators :\n\n~~~js\nconstructor(public fb: FormBuilder, private errorState: LgErrorStateMatcher) {\n  this.form = this.fb.group({\n    text: ['', [Validators.required, Validators.minLength(4)]]\n  });\n}\n\nisControlInvalid(control: NgControl, form: FormGroupDirective) {\n  return this.errorState.isControlInvalid(control, form);\n}\n~~~\n\nIn your HTML add the validation components with the appropriate structural\ndirectives to determine if they should be visible. The error state matcher will\ndetermine wether the form field is in an error state.\n\n~~~html\n<form\n  [formGroup]=\"form\"\n  (ngSubmit)=\"onSubmit(form)\"\n  #userForm=\"ngForm\">\n  <lg-input-field>\n    Text\n    <input lgInput formControlName=\"username\" />\n    <lg-hint>This is a standard input field</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(text, userForm) && text.hasError('required')\">\n      Username is a required field\n    </lg-validation>\n    <lg-validation *ngIf=\"isControlInvalid(text, validationForm) && text.hasError('minlength')\">\n      Username needs to be at least 4 characters\n    </lg-validation>\n  </lg-input-field>\n</form>\n~~~\n\n## Using only the SCSS files\n\nGenerate the markup as show in the example below, you will need to ensure the aria\nattributes are correctly labelled.\n\n### Examples:\n\n## Input field\nFor a select field replace the input field with a select option.\n\n~~~html\n<div class=\"lg-input-field\">\n  <label class=\"lg-label\" for=\"lg-input-1\">\n    Username\n  </label>\n  <div id=\"lg-hint-1\" class=\"lg-hint\">\n    Please enter a username\n  </div>\n  <input\n    name=\"username\"\n    class=\"lg-input lg-input--error\" aria-invalid=\"true\" name=\"lg-input-2\" id=\"lg-input-1\" aria-describedby=\"lg-hint-1 lg-validation-1\">\n  <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-1\">\n    Text is a required field\n  </div>\n</div>\n~~~\n\n## Radio group\n\n~~~html\n<div class=\"lg-radio-group lg-radio-group--error\">\n  <fieldset aria-describedby=\"lg-hint-2 lg-validation-2\">\n    <legend class=\"lg-label\" id=\"lg-label-2\">\n      Color\n    </legend>\n    <div id=\"lg-hint-2\" class=\"lg-hint\">\n      Choose a colour\n    </div>\n    <div value=\"yellow\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-1\" name=\"lg-radio-group-1\" value=\"yellow\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-1\">Yellow</label>\n    </div>\n    <div value=\"red\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-2\" name=\"lg-radio-group-1\" value=\"red\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-2\">Red</label>\n    </div>\n    <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-2\">\n      Please select a colour\n    </div>\n  </fieldset>\n</div>\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Breadcrumb Component\n\n\n## Purpose\nDisplays the path of the user's journey from top-level through to child. Note that there is different behavior on mobile vs desktop. Crumbs above the current level should be styled as links, and link to the previous level on desktop. It should display the root, current and previous levels of hierarchy.\nOn mobile the crumb should take the user back to the previous level, but should be hidden at the top-level.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  declarations: [ ..., LgBreadcrumbModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-breadcrumb>\n  <lg-breadcrumb-item>\n    <a href=\"#\">\n      <lg-icon [name]=\"'home'\"></lg-icon>\n      Home\n    </a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    <a href=\"#\">Products</a>\n  </lg-breadcrumb-item>\n  <lg-breadcrumb-item>\n    Pension\n  </lg-breadcrumb-item>\n</lg-breadcrumb>\n~~~\n\n## Configure Text Colour\n\n~~~html\n<lg-breadcrumb-item [variant]=\"'light'\"></lg-breadcrumb-item>\n~~~\n\n## Adding an ellipsis\n\nIf there are more than 3 levels of hierarchy, a collapsed breadcrumb should be used. This is achieved with the breadcrumb elipsis.\n\n~~~html\n<lg-breadcrumb-item-ellipsis></lg-breadcrumb-item-ellipsis>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The colour variants available: \\`\\`light\\`\\`, \\`\\`dark\\`\\` | string | dark | No |\n`"
+                }
+            ],
+            "projects/canopy/src/styles/spacing.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/styles/spacing.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Spacing\n\n## Purpose\nProvides available spacing via CSS variables\n\n## Variables\n| Name | Value | Equivalent in px (based on 16px font-size)\n|------|-------------|-------------|\n| \\`\\`--space-unit\\`\\` | 1rem | 16px |\n| \\`\\`--space-xxxs\\`\\` | calc(0.25 * var(--space-unit)) | 4px |\n| \\`\\`--space-xxs\\`\\` | calc(0.5 * var(--space-unit)) | 8px |\n| \\`\\`--space-xs\\`\\` | calc(0.75 * var(--space-unit)) | 12px |\n| \\`\\`--space-sm\\`\\` | var(--space-unit) | 16px |\n| \\`\\`--space-md\\`\\` | calc(1.5 * var(--space-unit)) | 24px |\n| \\`\\`--space-lg\\`\\` | calc(2 * var(--space-unit)) | 32px |\n| \\`\\`--space-xl\\`\\` | calc(2.5 * var(--space-unit)) | 40px |\n| \\`\\`--space-xxl\\`\\` | calc(3 * var(--space-unit)) | 48px |\n| \\`\\`--space-xxxl\\`\\` | calc(4.5 * var(--space-unit)) | 72px |\n| \\`\\`--space-xxxxl\\`\\` | calc(9 * var(--space-unit)) | 144px |\n\n### For components padding:\n| Name | Value from 0 to md breakpoint | Value from md breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-padding\\`\\` | var(--space-sm) | var(--space-lg) |\n\n### For components margin:\n| Name | Value from 0 to lg breakpoint | Value from lg breakpoint |\n|------|-------------|-------------|\n| \\`\\`--component-margin\\`\\` | var(--space-md) | var(--space-lg) |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/radio/radio.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/radio/radio.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "(name: string) => `\n# ${name} Group and ${name} Button Components\n\n## Purpose\nProvides a set of components to implement ${name} buttons in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more ${name} Button components. The ${name} Button component represents a single ${name} button. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the Radio Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgRadioModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${name.toLowerCase()}-group ${\n  name === 'Radio' ? '[inline]=\"true\"' : ''\n} formControlName=\"color\">\n  Colour\n  <lg-hint>Please select a colour</lg-hint>\n  <lg-${name.toLowerCase()}-button value=\"red\">Red</lg-${name.toLowerCase()}-button>\n  <lg-${name.toLowerCase()}-button value=\"yellow\">Yellow</lg-${name.toLowerCase()}-button>\n</lg-${name.toLowerCase()}-group>\n~~~\n\\\n${\n  name === 'Segment' &&\n  `### Displaying the buttons at different breakpoints\n\nRadios are displayed inline, unless given a \\`RadioStackBreakpoint\\`, which tells them at which breakpoint should they appear stacked on top of each other:\n\n~~~html\n<lg-segment-group [stack]=\"sm\" formControlName=\"color\">\n  Colour\n  <lg-segment-button value=\"red\">Red</lg-segment-button>\n  <lg-segment-button value=\"yellow\">Yellow</lg-segment-button>\n</lg-segment-group>\n~~~\n    `\n}\n\n## Inputs\n\n### LgRadioGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\\${nextUniqueId++}' | No |\n| \\`\\`value\\`\\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n${\n  name === 'Radio'\n    ? `| \\`\\`inline\\`\\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`\n    : name === 'Segment'\n    ? `| \\`\\`stack\\`\\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`\n    : ''\n}\n\n### LgRadioButtonComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML name attribute | string | null | Yes |\n| \\`\\`value\\`\\` | HTML value attribute | string | null | Yes |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/forms/toggle/toggle.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/toggle/toggle.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "(name: string) => `\n# ${name} Component\n\n## Purpose\nProvides a ${name} component for boolean form controls. The ${name} component is a variant of the Toggle component.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgToggleModule ],\n})\n~~~\n\nand in your HTML for a regular *checkbox*:\n\n~~~html\n<lg-toggle formControlName=\"confirm\" value=\"yes\" variant=\"${name.toLowerCase()}\">Do you agree?</lg-toggle>\n~~~\n\nor\n\n~~~html\n<lg-${name.toLowerCase()} formControlName=\"confirm\" value=\"yes\">Do you agree?</lg-${name.toLowerCase()}>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`value\\`\\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`variant\\`\\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |\n| \\`\\`focus\\`\\` | Set the focus on the input field | boolean | null | No |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/tabs/tabs.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
+                },
+                {
+                    "name": "tabbedNavNotes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Tab Navigation Bar Component\n\n## Purpose\nThe tabbed navigation bar provides a tab-like UI for navigating between routes or urls. The tabbed navigatiom bar is router agnostic, so you will need to place the \\`router-outlet\\` anywhere in your view. Don't forget to add the \\`aria-labelledby\\` attribute to the content output by the \\`router-outlet\\`.\nThe \\`isActive\\` property is used to select the current active tab.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tab-nav-bar label=\"Tabbed navigtion label\">\n  <a lgTabNavBarLink id=\"tabbed-nav-1\" [isActive]=\"true\" [routerLink]=\"\">Tab 1</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-2\" [routerLink]=\"\">Tab 2</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-3\" [routerLink]=\"\">Tab 3</a>\n</lg-tab-nav-bar>\n<lg-tab-nav-content [selectedTabId]=\"tabbed-nav-1\">\n  <p>Insert router-outlet here.</p>\n</lg-tab-nav-content>\n~~~\n\n## \\`lg-tab-nav-bar\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | Label for the tab list| string | Tabs | No |\n\n## \\`lgTabNavBarLink\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`index\\`\\` | Sets the tab index position in tab list | number | 0 | No |\n| \\`\\`isActive\\`\\` | Sets the active state of the tab | boolean | false | No |\n| \\`\\`isFocused\\`\\` | Sets the focus state of the tab | boolean | false | No |\n\n## \\`lgTabNavBarLink\\` Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Sets the current actve tab | boolean | undefined | No |\n\n## \\`lg-tab-nav-content\\` Inputs\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`selectedTabId\\`\\` | Sets the id of the current selected tab | string | undefined | No |\n\n`"
+                }
+            ],
+            "projects/canopy/src/lib/footer/footer.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/footer/footer.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/styles/typography.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/styles/typography.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Typography\n\n## Purpose\nProvides common typographic styles for native elements with additional utility classes.\n\nCanopy consists of two fonts:\n\n* **Roboto**: Productive font, for general use in self serve apps (default)\n* **Lyon**: Expressive font, for headings in promo material (applied by class modifier)\n\n> **IMPORTANT** - Lyon font files are not included in the Canopy package, you have to serve it yourself, see below for details.\n\n## Serving the Lyon font files\n\nDue to commercial licensing agreements the Lyon font is not included in the distributed package. You will need to manually add it to the **assets** directory of your application. Canopy does provide the css to work with the font and no additional code should be required. You will  need to ensure the font is in the directory specified by Canopy.\n\nCanopy's path for Lyon is **/assets/fonts/lyon/**, therefore you need to put the font files in the following location:\n\n~~~bash\nmy-app/\n  src/\n    assets/\n      fonts/\n        lyon/\n          lyon-display-regular.woff\n          lyon-display-regular.woff2\n          lyon-display-bold.woff\n          lyon-display-bold.woff2\n~~~\n\n> This will result in the font being served in your app like this: <br />http://my-app.landg.com/assets/fonts/lyon/LyonDisplay-Regular-Web.woff2\n\nWhen you include the canopy.css file in your project, it will try to load the font from that exact path. If your font files are in the wrong location, or have a typo in the filename, the Lyon font won't load correctly.\n\nPlease ensure you have the correct licensing agreement in place before using the Lyon font in your application.\n\n## Usage\nThe typography styles will provide styling for all native text elements e.g. \\`\\`h1\\`\\`, \\`\\`h2\\`\\`, \\`\\`p\\`\\`, \\`\\`em\\`\\`, \\`\\`b\\`\\`, \\`\\`strong\\`\\` etc.\n\nBy default the font used is Roboto.\n\nIn addition to the native styling, the following utility classes are exposed, allowing you to change the font size and weight where required.\n\n~~~html\n.lg-font-size-7\n.lg-font-size-7--strong\n\n.lg-font-size-6\n.lg-font-size-6--strong\n\n.lg-font-size-5\n.lg-font-size-5--strong\n\n.lg-font-size-4\n.lg-font-size-4--strong\n\n.lg-font-size-3\n.lg-font-size-3--strong\n\n.lg-font-size-2\n.lg-font-size-2--strong\n\n.lg-font-size-1\n.lg-font-size-1--strong\n\n.lg-font-size-0-8\n\n.lg-font-size-0-6\n~~~\n\n\\`.lg-font-size-1\\` is the base font size that is used to style native elements like p and span, as the numbers increase so\ndoes the font size up to the largest \\`.lg-font-size-7.\\` Each of the primary font styles also have a \\`--strong\\` modifier.\n\nThere are two additional styles which are smaller \\`.lg-font-size-0-8\\`\nand \\`.lg-font-size-0-6\\`. The utility classes are particularly useful for when you want to decouple the semantics and styling,\nfor example making an h1 look like an h3:\n\n~~~html\n<h1 class=\"lg-font-size-3\">H1 that looks like a H3</h1>\n~~~\n<br />\n\n### Using the Lyon font\n\nLyon can be applied using the modifier class: \\`\\`lg-font--expressive\\`\\`. For example:\n\n~~~html\n<h1 class=\"lg-font--expressive\">Heading in Lyon</h1>\n~~~\n\nIt can also be used in addition to the above utility classes:\n\n~~~html\n<p class=\"lg-font-size-5 lg-font--expressive\">Paragraph in Lyon and font size 5</p>\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` service and register your brand icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgBrandIconSun } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    // register the icon using the \\`brandIconRegistry\\` service\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<!-- with default size and colour -->\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n\n<!-- with a size set -->\n<lg-brand-icon name=\"sun\" size=\"sm\"></lg-brand-icon>\n\n<!-- with a colour set -->\n<lg-brand-icon name=\"sun\" colour=\"--color-lily-green\"></lg-brand-icon>\n~~~\n\n## Branding / Colours\nThe yellow fill colour of the brand icons can be changed globally  by overriding the \\`--brand-icon-fill-primary\\` css variable. Note that changing this variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input on the component.\n`"
                 }
             ],
             "projects/canopy/src/lib/promo-card/promo-card.notes.ts": [
@@ -40574,16 +40748,40 @@
                     "defaultValue": "`\n# Promo Card List Component\n\n## Purpose\n\nPromo Cards allow you to arrange content in a card-like manner for promotional purposes. Promo Cards are organised by a\nPromo Card List and will be displayed in columns on desktops and stacked on mobile devices.\n\n### Content guidelines\n\nEach Promo Card should respect the following conventions:\n\n- Title - max 33 characters (with spaces)\n- Content - max 140 characters (with spaces)\n- Button - max 20 characters (with spaces)\n- Image - max 620px x 620px\n\nThis is not enforced in the code, but it should be followed as close as possible to ensure optimal user experience.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPromoCardModule ],\n})\n~~~\n\nand in your HTML, place your Promo Cards in your Promo Card List:\n\n~~~html\n<lg-promo-card-list>\n  <lg-separator [variant]=\"dotted\" lgMargin=\"none\"></lg-separator>\n  <lg-promo-card-list-title [headingLevel]=\"headingLevel\">\n    Get more from Legal &amp; General\n  </lg-promo-card-list-title>\n  <lg-promo-card\n    [variant]=\"variant\">\n    <lg-promo-card-image [imageUrl]=\"imageUrl\"></lg-promo-card-image>\n    <lg-promo-card-title [headingLevel]=\"headingLevelInner\">\n      Need help with Care?\n    </lg-promo-card-title>\n    <lg-promo-card-content>\n      <p>Our care service can help you understand, find and fund care for you or a loved one.</p>\n    </lg-promo-card-content>\n    <lg-promo-card-footer>\n      <button\n        lgMarginBottom=\"none\"\n        lg-button\n        type=\"button\"\n        [variant]=\"variant\">\n        Find out more\n      </button>\n    </lg-promo-card-footer>\n  </lg-promo-card>\n</lg-promo-card-list>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | Allows the card (list) heading level to be set | number | n/a | Yes |\n| \\`\\`variant\\`\\` | The variant of promo card: \\`\\`solid-white\\`\\`, \\`\\`solid-green\\`\\` | PromoCardVariant | 'solid-white' | No |\n| \\`\\`imageUrl\\`\\` | Identifies the card image | string | n/a | Yes |\n`"
                 }
             ],
-            "projects/canopy/src/lib/quick-action/quick-action.notes.ts": [
+            "projects/canopy/src/lib/table/table.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/quick-action/quick-action.notes.ts",
+                    "file": "projects/canopy/src/lib/table/table.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Quick Action Component\n\n## Purpose\nQuick Actions are small clickable elements that can be used to provide functionality in context, such as editing a form or actions on a card.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgQuickActionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lg-quick-action>\n  <lg-icon name=\"repeat\"></lg-icon>\n  Load more\n</button>\n~~~\n\nor:\n\n~~~html\n<a lg-quick-action\n  href=\"/mailbox\">\n  <lg-icon name=\"secure-message\"></lg-icon>\n  Send us a message\n</a>\n~~~\n`"
+                    "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
+                }
+            ],
+            "projects/canopy/src/styles/utils.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/styles/utils.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Utils\n\n## Purpose\nProvides available utils classes\n\n## Classes\n| Class | Description |\n|------|-------------|\n| \\`\\`lg-visually-hidden\\`\\` | Hides information intended only for screen readers from the layout of the rendered page. |\n| \\`\\`lg-unstyled-link\\`\\` | Revert the links styles to a more default style. |\n`"
+                }
+            ],
+            "projects/canopy/src/lib/modal/modal.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/modal/modal.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Modal Component\n\n\n## Purpose\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Lorem ipsum</lg-modal-header>\n  <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nfor a timout modal you can use the following structure:\n\n~~~html\n<button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n\n<lg-modal id=\"modal-story\">\n  <lg-modal-header>Logout</lg-modal-header>\n  <lg-modal-body>\n    For your security, we'll log yuo out in:\n    <lg-modal-body-timer timer=\"0:58\"></lg-modal-body-timer>\n  </lg-modal-body>\n  <lg-modal-footer>\n    <lg-button-group>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Primary CTA</button>\n      <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Cancel</button>\n    </lg-button-group>\n  </lg-modal-footer>\n</lg-modal>\n~~~\n\nOpening and closing the modal is also possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
                 }
             ],
             "projects/canopy/src/lib/primary-message/primary-message.notes.ts": [
@@ -40596,6 +40794,30 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Primary Message Component\n\n\n## Purpose\nThe Primary Message is used to communicate key information to the user.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPrimaryMessageModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-primary-message>\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title>\n      This is a primary message\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">Call to action</button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`hasRole\\`\\` | If false, removes the role \\`\\`alert\\`\\` from the component | boolean | true | No |\n\n`"
+                }
+            ],
+            "projects/canopy/src/lib/spinner/spinner.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spinner/spinner.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Spinner Component\n\n## Purpose\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<lg-spinner></lg-spinner>\n~~~\n\n## Inputs\n\n### LgSpinnerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The spinner variant | SpinnerVariant ['dark', 'light', 'color', 'inherit'] | 'dark' | No |\n| \\`\\`size\\`\\` | The size of the spinner | SpinnerSize ['sm', 'md'] | 'md' | No |\n| \\`\\`text\\`\\` | The text to show under the spinner | string | undefined | No |\n\n\nIf the \\`\\`variant\\`\\` is set to  \\`\\`'inherit'\\`\\`, then it will inherit the font colour of it's parent element. This is used on the loading button, where the spinner inherits the font colour of the button.\n`"
+                }
+            ],
+            "projects/canopy/src/lib/alert/alert.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/alert/alert.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/separator/separator.notes.ts": [
@@ -40646,42 +40868,6 @@
                     "defaultValue": "`\n# Side Nav Component\n\n## Purpose\n\nSide Navs are components that allow the user to define a series of navigation items that display content in a predefined area.\n\n### Side Nav Bar\n\nHere is where the navigation menu items are put. The links, once clicked on, will display their routes'\ncontent in the Side Nav Content component.\nOn mobile devices, the menu is below the content area, instead of to the left.\n\n### Side Nav Bar Link\nThis \\`lgSideNavBarLink\\` directive applies the appropriate styling to the links. It also emits an event when the link is activated.\n\n### Side Nav Bar Footer\n\nThe footer is below the navigation items and can hold different kinds of content (e.g. a button).\n\n### Side Nav Content\n\nThis is the predefined area where content is shown. It should always contain a router outlet to be able to display\nthe different nav item routes.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgSideNavModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-side-nav>\n    <lg-side-nav-bar label=\"Side Nav Demo\">\n      <a id=\"side-nav-0\"\n         [routerLink]=\"'firstPage'\"\n         [isActive]=\"true\"\n         lgSideNavBarLink\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Overview</lg-side-nav-bar-item-heading>\n        </lg-side-nav-bar-item>\n      </a>\n      <a id=\"side-nav-1\"\n         [routerLink]=\"'secondPage'\"\n         lgSideNavBarLink\n        >\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Personal details</lg-side-nav-bar-item-heading>\n            <lg-side-nav-bar-item-content>Your name, date of birth, marital status and National Insurance Number.</lg-side-nav-bar-item-content>\n        </lg-side-nav-bar-item>\n      </a>\n      <lg-side-nav-bar-footer>\n        <a lg-button lgMarginTop=\"xxl\" variant=\"outline-primary\" [fullWidth]=\"false\" href=\"#\">Logout</a>\n      </lg-side-nav-bar-footer>\n    </lg-side-nav-bar>\n    <lg-side-nav-content tabindex=\"0\">\n      <router-outlet></router-outlet>\n    </lg-side-nav-content>\n</lg-side-nav>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-------:|:--------:|\n| isActive | specifies whether or not the navigation link is in an active state | boolean | false | No\n`"
                 }
             ],
-            "projects/canopy/src/lib/carousel/carousel.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/carousel/carousel.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Carousel Component\n\n## Purpose\n\nCarousels allow customers to quickly navigate through grouped sections of content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgCarouselModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-carousel [description]=\"description\" [headingLevel]=\"headingLevel\" [loopMode]=\"true\">\n  <lg-carousel-item>\n    Carousel item 1 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 2 content goes here\n  </lg-carousel-item>\n\n  <lg-carousel-item>\n    Carousel item 3 content goes here\n  </lg-carousel-item>\n</lg-carousel>\n~~~\n\n## Carousel Inputs\n\n| Name                  | Description                                                                                              |  Type   |  Default  | Required |\n| --------------------- | -------------------------------------------------------------------------------------------------------- | :-----: | :-------: | :------: |\n| \\`\\`loopMode\\`\\`      | Allows the carousel to navigation to loop when the first or last item is active.                         | boolean |   false   |   No     |\n| \\`\\`slideDuration\\`\\` | Duration in milliseconds of the transition between slides.                                               | number  |   500     |   No     |\n| \\`\\`description\\`\\`   | Text used to describe the carousel content for screen readers. This is visually hidden.                  | string  | undefined |   Yes    |\n| \\`\\`headingLevel\\`\\`  | The heading level of the description: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\`   | number  | undefined |   Yes    |\n| \\`\\`autoPlay\\`\\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |\n| \\`\\`autoPlayDelay\\`\\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/spinner/spinner.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spinner/spinner.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Spinner Component\n\n## Purpose\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<lg-spinner></lg-spinner>\n~~~\n\n## Inputs\n\n### LgSpinnerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The spinner variant | SpinnerVariant ['dark', 'light', 'color', 'inherit'] | 'dark' | No |\n| \\`\\`size\\`\\` | The size of the spinner | SpinnerSize ['sm', 'md'] | 'md' | No |\n| \\`\\`text\\`\\` | The text to show under the spinner | string | undefined | No |\n\n\nIf the \\`\\`variant\\`\\` is set to  \\`\\`'inherit'\\`\\`, then it will inherit the font colour of it's parent element. This is used on the loading button, where the spinner inherits the font colour of the button.\n`"
-                }
-            ],
-            "projects/canopy/src/lib/table/table.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/table/table.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
-                }
-            ],
             "projects/canopy/src/lib/show-at/show-at.notes.ts": [
                 {
                     "name": "notes",
@@ -40692,40 +40878,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Show At Directive\n\n## Purpose\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShowAt=\"md\">\n  <lg-card-content>\n    I get dispalayed at the \"md\" breakpoint\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available breakpoints are 'sm', md', 'lg', 'xl', and 'xxl'.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgShowAt\\`\\` | The name of the breakpoint applied | string | null | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/tabs/tabs.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
-                },
-                {
-                    "name": "tabbedNavNotes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/tabs/tabs.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Tab Navigation Bar Component\n\n## Purpose\nThe tabbed navigation bar provides a tab-like UI for navigating between routes or urls. The tabbed navigatiom bar is router agnostic, so you will need to place the \\`router-outlet\\` anywhere in your view. Don't forget to add the \\`aria-labelledby\\` attribute to the content output by the \\`router-outlet\\`.\nThe \\`isActive\\` property is used to select the current active tab.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tab-nav-bar label=\"Tabbed navigtion label\">\n  <a lgTabNavBarLink id=\"tabbed-nav-1\" [isActive]=\"true\" [routerLink]=\"\">Tab 1</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-2\" [routerLink]=\"\">Tab 2</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-3\" [routerLink]=\"\">Tab 3</a>\n</lg-tab-nav-bar>\n<lg-tab-nav-content [selectedTabId]=\"tabbed-nav-1\">\n  <p>Insert router-outlet here.</p>\n</lg-tab-nav-content>\n~~~\n\n## \\`lg-tab-nav-bar\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | Label for the tab list| string | Tabs | No |\n\n## \\`lgTabNavBarLink\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`index\\`\\` | Sets the tab index position in tab list | number | 0 | No |\n| \\`\\`isActive\\`\\` | Sets the active state of the tab | boolean | false | No |\n| \\`\\`isFocused\\`\\` | Sets the focus state of the tab | boolean | false | No |\n\n## \\`lgTabNavBarLink\\` Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Sets the current actve tab | boolean | undefined | No |\n\n## \\`lg-tab-nav-content\\` Inputs\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`selectedTabId\\`\\` | Sets the id of the current selected tab | string | undefined | No |\n\n`"
-                }
-            ],
-            "projects/canopy/src/lib/variant/variant.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/variant/variant.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n\n# Variant Directive\n\n## Purpose\nThis directive allows you to add one of the five common colour variants to any Canopy component, such as \\`\\`info\\`\\` and \\`\\`success\\`\\`.\n\nThey are already applied to existing Canopy components which use these variants out of the box, such as [Alert](/?path=/story/components-alert--standard), [Detail](?path=/story/components-details--standard) and [Form Validation](?path=/story/components-form-validation--standard), but this directive allows you to use them anywhere where required.\n\nThis can be useful where you need the particular colour treatment (like the \\`\\`success\\`\\` variant for example), but your use-case does not fit one of the existing components.\n\n## Usage\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgVariantModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgVariant=\"warning\">\n  <lg-card-content>\n    I have the warning variant colours, yay!\n    <a href=\"#\">Links are included</a>\n    <button lg-button variant=\"outline-primary\">\n      Outline primary buttons too\n    </button>\n  </lg-card-content>\n</lg-card>\n~~~\n\n## Inputs\n\nThe current available variants are:\n* \\`\\`generic\\`\\`\n* \\`\\`info\\`\\`\n* \\`\\`success\\`\\`\n* \\`\\`warning\\`\\`\n* \\`\\`error\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgVariant\\`\\` | The name of variant desired | string | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/skeleton/skeleton.notes.ts": [
@@ -40740,102 +40892,6 @@
                     "defaultValue": "`\n# Skeleton Loading Directive\n\n## Purpose\nThe skeleton directive adds a skeleton loading state to a component or element.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSkeletonModule],\n})\n~~~\n\nThe directive works on components that output text or projected content. On composite components that\nare made up of other child components, it is best to add the skeleton loading directive to the child\ncomponents or even wrap the projected content inside another element. E.g. In the example,\nthe \\`lg-data-point-label\\` projects the content into an \\`lg-heading\\` component,\nso the directive is added to a span wrapping the content. However, the \\`lg-data-point-value\\` component\nsimply projects the content only so the directive can be applied to the component itself.\n\n~~~html\n<lg-data-point>\n  <lg-data-point-label [headingLevel]=\"4\">\n    <span lgSkeleton lgSkeletonWidth=\"10\">{{ data?.label }}</span>\n  </lg-data-point-label>\n  <lg-data-point-value lgSkeleton lgSkeletonWidth=\"8\">\n    {{ data?.value }}\n  </lg-data-point-value>\n</lg-data-point>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgSkeletonWidth\\`\\` | Override the default width with the desired value in ems | string | 100% | No |\n| \\`\\`lgSkeletonHeight\\`\\` | Override the default height with the desired value in ems | string | auto | No |\n\n`"
                 }
             ],
-            "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "(name: string, modifier?) => `\n# ${name} Group Components\n\n## Purpose\nProvides a set of components to implement ${name} groups in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more Toggle components. The Toggle component represents a single ${name.toLowerCase()}. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the CheckboxGroup Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgCheckboxGroupModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg-toggle value=\"red\">Red</lg-toggle>\n  <lg-toggle value=\"yellow\">Yellow</lg-toggle>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\nor\n\n~~~html\n<lg-${\n  modifier ? modifier : name.toLowerCase()\n}-group [inline]=\"true\" formControlName=\"colors\">\n  Colour\n  <lg-hint>Please select all colours that apply</lg-hint>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"red\">Red</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n  <lg${modifier ? '-filter' : ''}-checkbox value=\"yellow\">Yellow</lg${\n  modifier ? '-filter' : ''\n}-checkbox>\n</lg-${modifier ? modifier : name.toLowerCase()}-group>\n~~~\n\n## Inputs\n\n### LgCheckboxGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-checkbox-group-id-\\${this.nextUniqueId}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-checkbox-group-\\${this.nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Sets the default checked ${name.toLowerCase()} buttons, must match the values of the ${name.toLowerCase()} buttons | array of strings | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`inline\\`\\` | If true, displays the ${\n  name.toLowerCase\n}s inline rather than stacked | boolean | false | No |\n\n### LgToggleComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${++nextUniqueId}' | No |\n| \\`\\`value\\`\\` | HTML value attribute. Value that is set when the toggle is checked | string | null | No |\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`focus\\`\\` | Set the focus on the input | boolean | null | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/date/date-field.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/date/date-field.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Date Input Component\n\n## Purpose\nProvides a component for capturing and validating a date. Output is a concatenation of individual string values into a valid ISO 8601 date format 'YYYY-MM-DD'.\n\n## Usage\nImport the Date Input Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgDateFieldModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-date-field formControlName=\"date\">\n    Date of birth\n    <lg-hint>For example, 12 06 1983</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(date, validationForm)\">\n      <ng-container *ngIf=\"date.hasError('invalidField')\">\n        Enter a valid {{ date.errors.invalidField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidFields')\">\n        Enter a valid {{ date.errors.invalidFields[0] }} and\n        {{ date.errors.invalidFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredField')\">\n        Date of birth must include a {{ date.errors.requiredField }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('requiredFields')\">\n        Date of birth must include a {{ date.errors.requiredFields[0] }} and\n        {{ date.errors.requiredFields[1] }}\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('invalidDate')\">\n        Enter a valid date of birth\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('futureDate')\">\n        Date must be in the past\n      </ng-container>\n      <ng-container *ngIf=\"date.hasError('required')\">\n        Enter a date of birth\n      </ng-container>\n    </lg-validation>\n  </lg-date-field>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgDateFieldComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`dateId\\`\\` | HTML ID attribute for the date input, auto generated if not provided | string | 'lg-input-date-\\${nextUniqueId++}' | No |\n| \\`\\`monthId\\`\\` | HTML ID attribute for the month input, auto generated if not provided | string | 'lg-input-month-\\${nextUniqueId++}' | No |\n| \\`\\`yearId\\`\\` | HTML ID attribute for the year input, auto generated if not provided | string | 'lg-input-year-\\${nextUniqueId++}' | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the date field, if not provided it will use the hint field where appropriate | string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n\n## Validation\nDate validation is quite complex with a range of different validation errors, where possible we have encapsulated as much of that complexity into the components as we can.\n\nInternally the date-field can determine if the entered date is a valid date. If additional validation is required such as checking for past or future dates this can be done with external validators.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n### Internal validation\nIn some scenarios there could be multiple fields that are incorrect, to help guide the users to the correct issue the date field only returns the most significant validation error. Only one error should be shown at a time.\n\nOnce the user has rectified the first error the next error will take it's place if there is one. This allows us to write linear lists of validation messages without the need to apply complex logic in the applications.\n\nThe current significance of errors with their recommended messages is as follows.\n\n#### 1. Invalid fields\n\nOne field is invalid, this may be a non numerical character, or a number outside the valid range .e.g 13 for a month.\n\\`Enter a valid month\\`\n\n~~~json\n{ invalidField: 'month'}\n~~~\n\n\nAs above but with two fields displaying an error.\n\\`Enter a valid month and year\\`\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are invalid a generic 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Required fields\n\nIf one field is empty either through form submission or inline deletion of the content.\n\\`Date of birth must include month\\`\n\n~~~json\n{ requiredField: 'month'}\n~~~\n\nAs above but with two fields missing.\n\\`Date of birth must include a month and year\\`\n\n\n~~~json\n{ invalidFields: ['day', 'month']}\n~~~\n\nIf all three fields are missing an 'invalidDate' message is provided.\n\\`Enter a valid date of birth\\`\n\n~~~json\n{ invalidDate: true }\n~~~\n\n#### 2. Invalid date\n\nIf all of the individual fields are correct but they do not concatenate to a valid date. e.g. 30 02 2020\n\n~~~json\n{ invalidDate: true }\n~~~\n\\`Enter a valid date of birth\\`\n\n### External validation\n\nIt is also possible to provide your own custom validation messages using [custom validators](https://angular.io/guide/form-validation#custom-validators)\nand the validation component. This is particularly useful for checking things like wether the date is in the past or the future. Under the hood the date field uses the [date-fns](https://date-fns.org/) library as a peer dependency, to keep build size to a minimum it may be worth considering using the same library in your application.\n\n~~~js\nfunction notMondayValidator(): ValidatorFn {\n  return (control: AbstractControl): { [key: string]: any } | null => {\n    return getDay(parseISO(control.value)) === 'monday' ? { notMonday: true } : null;\n  };\n}\n...\nconst date = new FormControl('', [notMondayValidator()])\n~~~\n\n~~~html\n<lg-date-field formControlName=\"date\">\n  Date of appointment\n  <lg-hint>For example, 12 06 1983</lg-hint>\n  <lg-validation *ngIf=\"isControlInvalid(date, validationForm) && date.hasError('notMonday')\">\n    Date cannot be a Monday\n  </lg-validation>\n </lg-date-field>\n~~~\n\n### Additional validators\n\nTo aid with common validation needs some additional reactive form validators are provided.\n\n#### Future date validator\nThis validator checks if the specified date is in the future, if not it returns a futureDate error\n\n~~~js\nimport { futureDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [futureDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('futureDate')\">\n  Date must be in the future\n</ng-container>\n~~~\n\n#### Past date validator\nThis validator checks if the specified date is in the past, if not it returns a pastDate error\n\n~~~js\nimport { pastDateValidator } from '@legal-and-general/canopy';\n\nconst control = new FormControl('', {\n  validators: [pastDateValidator()]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('pastDate')\">\n  Date must be in the past\n</ng-container>\n~~~\n\n#### Before date validator\nThis validator checks if the specified date is before another specified date, if not it returns a beforeDate error.\nThe beforeDate error contains the date that it was compared against.\n\n~~~js\nimport { beforeDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [beforeDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('beforeDate')\">\n  Date must be before {{ date.errors.beforeDate.required }}\n</ng-container>\n~~~\n\n#### After date validator\nThis validator checks if the specified date is after another specified date, if not it returns a afterDate error.\nThe afterDate error contains the date that it was compared against.\n\n~~~js\nimport { afterDateValidator } from '@legal-and-general/canopy';\nimport parseISO from 'date-fns/parseISO';\n\nconst control = new FormControl('', {\n  validators: [afterDateValidator(parseISO('2010-01-15'))]\n});\n~~~\n\n~~~html\n<ng-container *ngIf=\"date.hasError('afterDate')\">\n  Date must be after {{ date.errors.afterDate.required }}\n</ng-container>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/input/input.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/input/input.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Input Component\n\n## Purpose\nProvides a common input directive and input field component. The input field component deals with linking the label and field.\nThe width of the input field is controlled by the HTML size attribute, this allows us to provide the user with an indication of the expected length of the value.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgInputModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n</lg-input-field>\n~~~\n\n### Adding input buttons\n\nButtons can be added within input fields to provide functionality linked to the input.\nThe \\`lgSuffix\\` directive needs to be added to the button to place it in the correct place.\nOnly small size buttons should be placed in the input field.\nThere is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.\n\n#### Button suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\">\n    Search\n  </button>\n</lg-input-field>\n~~~\n\n#### Icon Button suffix with add-on class\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\" [iconButton]=\"true\" variant=\"add-on\">\n    <lg-icon name=\"search\" />\n  </button>\n</lg-input-field>\n~~~\n\n### Adding prefixes and suffixes\n\nPrefix and suffix text can be added to input fields using the \\`lgSuffix\\` and \\`lgPrefix\\` directive.\n\n#### Text prefix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgPrefix>£</span>\n</lg-input-field>\n~~~\n\n#### Text suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgSuffix>%</span>\n</lg-input-field>\n~~~\n\n## Inputs\n\n### LgInputDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n\n### LgInputFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the input full width (for small screens only). | boolean | false | no\n| \\`\\`showLabel\\`\\` | Show or visually hide the label | boolean | true | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/select/select.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/radio/radio.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/radio/radio.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "(name: string) => `\n# ${name} Group and ${name} Button Components\n\n## Purpose\nProvides a set of components to implement ${name} buttons in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more ${name} Button components. The ${name} Button component represents a single ${name} button. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the Radio Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgRadioModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-${name.toLowerCase()}-group ${\n  name === 'Radio' ? '[inline]=\"true\"' : ''\n} formControlName=\"color\">\n  Colour\n  <lg-hint>Please select a colour</lg-hint>\n  <lg-${name.toLowerCase()}-button value=\"red\">Red</lg-${name.toLowerCase()}-button>\n  <lg-${name.toLowerCase()}-button value=\"yellow\">Yellow</lg-${name.toLowerCase()}-button>\n</lg-${name.toLowerCase()}-group>\n~~~\n\\\n${\n  name === 'Segment' &&\n  `### Displaying the buttons at different breakpoints\n\nRadios are displayed inline, unless given a \\`RadioStackBreakpoint\\`, which tells them at which breakpoint should they appear stacked on top of each other:\n\n~~~html\n<lg-segment-group [stack]=\"sm\" formControlName=\"color\">\n  Colour\n  <lg-segment-button value=\"red\">Red</lg-segment-button>\n  <lg-segment-button value=\"yellow\">Yellow</lg-segment-button>\n</lg-segment-group>\n~~~\n    `\n}\n\n## Inputs\n\n### LgRadioGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\\${nextUniqueId++}' | No |\n| \\`\\`value\\`\\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n${\n  name === 'Radio'\n    ? `| \\`\\`inline\\`\\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`\n    : name === 'Segment'\n    ? `| \\`\\`stack\\`\\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`\n    : ''\n}\n\n### LgRadioButtonComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML name attribute | string | null | Yes |\n| \\`\\`value\\`\\` | HTML value attribute | string | null | Yes |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/toggle/toggle.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/toggle/toggle.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "(name: string) => `\n# ${name} Component\n\n## Purpose\nProvides a ${name} component for boolean form controls. The ${name} component is a variant of the Toggle component.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgToggleModule ],\n})\n~~~\n\nand in your HTML for a regular *checkbox*:\n\n~~~html\n<lg-toggle formControlName=\"confirm\" value=\"yes\" variant=\"${name.toLowerCase()}\">Do you agree?</lg-toggle>\n~~~\n\nor\n\n~~~html\n<lg-${name.toLowerCase()} formControlName=\"confirm\" value=\"yes\">Do you agree?</lg-${name.toLowerCase()}>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`checked\\`\\` | Check status of the toggle | boolean | false | No |\n| \\`\\`value\\`\\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\\${nextUniqueId++}' | No |\n| \\`\\`variant\\`\\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |\n| \\`\\`focus\\`\\` | Set the focus on the input field | boolean | null | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/validation/form.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/validation/form.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Form Validation\n\n## Purpose\nTo provide a consistent approach to form validation.\n\n## Usage\nThe rules to display the error states are incorporated into the individual Canopy\nform components. When used in conjunction with standard [Angular form validation](https://angular.io/guide/form-validation)\nthe error styles will be displayed automatically.\n\nError messages need to be handled by the individual applications by utilising the\n[Validation](/?path=/story/components-form-validation--component) component and\nthe LgErrorStateMatcher.\n\nImport the module in your core component, e.g.:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgValidationModule]\n})\n~~~\n\nIn your component file set up the relevant validators :\n\n~~~js\nconstructor(public fb: FormBuilder, private errorState: LgErrorStateMatcher) {\n  this.form = this.fb.group({\n    text: ['', [Validators.required, Validators.minLength(4)]]\n  });\n}\n\nisControlInvalid(control: NgControl, form: FormGroupDirective) {\n  return this.errorState.isControlInvalid(control, form);\n}\n~~~\n\nIn your HTML add the validation components with the appropriate structural\ndirectives to determine if they should be visible. The error state matcher will\ndetermine wether the form field is in an error state.\n\n~~~html\n<form\n  [formGroup]=\"form\"\n  (ngSubmit)=\"onSubmit(form)\"\n  #userForm=\"ngForm\">\n  <lg-input-field>\n    Text\n    <input lgInput formControlName=\"username\" />\n    <lg-hint>This is a standard input field</lg-hint>\n    <lg-validation *ngIf=\"isControlInvalid(text, userForm) && text.hasError('required')\">\n      Username is a required field\n    </lg-validation>\n    <lg-validation *ngIf=\"isControlInvalid(text, validationForm) && text.hasError('minlength')\">\n      Username needs to be at least 4 characters\n    </lg-validation>\n  </lg-input-field>\n</form>\n~~~\n\n## Using only the SCSS files\n\nGenerate the markup as show in the example below, you will need to ensure the aria\nattributes are correctly labelled.\n\n### Examples:\n\n## Input field\nFor a select field replace the input field with a select option.\n\n~~~html\n<div class=\"lg-input-field\">\n  <label class=\"lg-label\" for=\"lg-input-1\">\n    Username\n  </label>\n  <div id=\"lg-hint-1\" class=\"lg-hint\">\n    Please enter a username\n  </div>\n  <input\n    name=\"username\"\n    class=\"lg-input lg-input--error\" aria-invalid=\"true\" name=\"lg-input-2\" id=\"lg-input-1\" aria-describedby=\"lg-hint-1 lg-validation-1\">\n  <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-1\">\n    Text is a required field\n  </div>\n</div>\n~~~\n\n## Radio group\n\n~~~html\n<div class=\"lg-radio-group lg-radio-group--error\">\n  <fieldset aria-describedby=\"lg-hint-2 lg-validation-2\">\n    <legend class=\"lg-label\" id=\"lg-label-2\">\n      Color\n    </legend>\n    <div id=\"lg-hint-2\" class=\"lg-hint\">\n      Choose a colour\n    </div>\n    <div value=\"yellow\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-1\" name=\"lg-radio-group-1\" value=\"yellow\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-1\">Yellow</label>\n    </div>\n    <div value=\"red\" class=\"lg-radio-button lg-radio-button--error\">\n      <input class=\"lg-radio-button__input\" type=\"radio\" id=\"lg-radio-button-2\" name=\"lg-radio-group-1\" value=\"red\">\n      <label class=\"lg-radio-button__label\" for=\"lg-radio-button-2\">Red</label>\n    </div>\n    <div class=\"lg-validation--error lg-validation\" id=\"lg-validation-2\">\n      Please select a colour\n    </div>\n  </fieldset>\n</div>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/forms/validation/validation.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/validation/validation.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Error Component\n\n\n## Purpose\nThe validation component is used to provide contextual information for a form input field. The most common use case is to display validation errors however it can also be used to show additional information.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgValidationModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-validation>Enter a valid postcode</lg-validation>\n\n<lg-validation variant=\"success\">Username is available</lg-validation>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of the validation: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'error' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display | boolean | true | No |\n`"
-                }
-            ],
             "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts": [
                 {
                     "name": "notes",
@@ -40848,52 +40904,16 @@
                     "defaultValue": "`\n# Sort Code Component\n\n## Purpose\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
                 }
             ],
-            "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts": [
+            "projects/canopy/src/styles/color.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                    "file": "projects/canopy/src/styles/color.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Camel case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgCamelCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | camelCase}}</p>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Kebab case pipe\n\n## Purpose\nThis pipe allows for a string to be transformed into kebab case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  declarations: [ ..., LgKebabCasePipe ],\n})\n~~~\n\nor all the pipes:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgPipesModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~\n<p>{{stringToTransform | kebabCase}}</p>\n~~~\n`"
-                }
-            ],
-            "projects/canopy/src/lib/spacing/margin/margin.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/spacing/padding/padding.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/padding/padding.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
+                    "defaultValue": "`\n# Colours\n\n## Purpose\nProvides available brand colours and tints via CSS variables\n\n## Usage\nImport the css into the angular.json file of your application, the variables should now be available for use.\n\n~~~json\n  \"styles\": [\n    \"node_modules/@legal-and-general/canopy/canopy.css\"\n  ],\n~~~\n\nIf IE11 support is required you will need to polyfill CSS variable functionality.\nThis can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.\n\n`"
                 }
             ],
             "projects/canopy/src/lib/pipes/pipes.module.ts": [
@@ -40956,28 +40976,6 @@
                     "defaultValue": "() => ({\n  template: `\n    <p><strong>Change viewport width to see the card appear at specified breakpoint</strong></p>\n    <pre>lgShowAt=\"{{breakpoint}}\"</pre>\n    <lg-separator></lg-separator>\n    <lg-card [lgShowAt]=\"breakpoint\">\n      <lg-card-content>\n        Now you see me...\n      </lg-card-content>\n    </lg-card>\n  `,\n  props: {\n    breakpoint: select('breakpoints', ['sm', 'md', 'lg', 'xl', 'xxl'], 'md'),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/spacing/margin/margin.stories.ts": [
-                {
-                    "name": "spaces",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[\n  'undefined',\n  'none',\n  'xxxs',\n  'xxs',\n  'xs',\n  'sm',\n  'md',\n  'lg',\n  'xl',\n  'xxl',\n  'xxxl',\n  'xxxxl',\n]"
-                },
-                {
-                    "name": "stories",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "storiesOf('Directives', module)"
-                }
-            ],
             "projects/canopy/src/lib/spacing/padding/padding.stories.ts": [
                 {
                     "name": "spaces",
@@ -41000,6 +40998,28 @@
                     "defaultValue": "storiesOf('Directives', module)"
                 }
             ],
+            "projects/canopy/src/lib/spacing/margin/margin.stories.ts": [
+                {
+                    "name": "spaces",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[\n  'undefined',\n  'none',\n  'xxxs',\n  'xxs',\n  'xs',\n  'sm',\n  'md',\n  'lg',\n  'xl',\n  'xxl',\n  'xxxl',\n  'xxxxl',\n]"
+                },
+                {
+                    "name": "stories",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "storiesOf('Directives', module)"
+                }
+            ],
             "projects/canopy/src/styles/spacing.stories.ts": [
                 {
                     "name": "spacing",
@@ -41010,42 +41030,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "() => ({\n  template: ``,\n})"
-                }
-            ],
-            "projects/canopy/src/lib/canopy.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/canopy.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `<app-root></app-root>`,\n})"
-                }
-            ],
-            "projects/canopy/src/lib/modal/modal.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/modal/modal.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n    <lg-modal id=\"modal-story\">\n      <lg-modal-header [headingLevel]=\"headingLevel\">Lorem ipsum</lg-modal-header>\n      <lg-modal-body>\n        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n        <lg-modal-body-timer timer=\"90\"></lg-modal-body-timer>\n      </lg-modal-body>\n      <lg-modal-footer>\n        <lg-button-group>\n          <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Button</button>\n          <button lg-button lgMarginBottom=\"none\" variant=\"outline-primary\" type=\"button\">Close</button>\n        </lg-button-group>\n      </lg-modal-footer>\n    </lg-modal>\n  `,\n  props: {\n    headingLevel: select('heading level', [1, 2, 3, 4, 5, 6], 2),\n  },\n})"
-                }
-            ],
-            "projects/canopy/src/lib/primary-message/primary-message.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/primary-message/primary-message.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-primary-message-story [hasRole]=\"hasRole\"></lg-primary-message-story>\n  `,\n  props: {\n    hasRole: boolean('Set role attribute to alert', true),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/separator/separator.stories.ts": [
@@ -41072,54 +41056,6 @@
                     "defaultValue": "() => ({\n  template: `\n    <lg-spinner [size]=\"size\" [variant]=\"variant\" [text]=\"text ? text : null\"></lg-spinner>\n  `,\n  props: {\n    variant: select('variant', ['dark', 'light', 'color', 'inherit'], 'dark'),\n    size: select('size', ['sm', 'md'], 'md'),\n    text: text('text', ''),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n  <lg-tab-nav-bar label=\"Tabbed navigation demo\">\n    <a *ngFor=\"let tab of tabs; index as i\" lgTabNavBarLink href=\"\" (click)=\"onClick($event)\" id=\"tabbed-nav-{{i}}\" [isActive]=\"i === selectedTabNavIndex\">{{tab}}</a>\n  </lg-tab-nav-bar>\n\n  <lg-tab-nav-content [selectedTabId]=\"'tabbed-nav-' + selectedTabNavIndex\">\n    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n  </lg-tab-nav-content>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    selectedTabNavIndex: 1,\n    onClick: (event: MouseEvent) => event.preventDefault(),\n  },\n})"
-                }
-            ],
-            "projects/canopy/src/lib/tabs/tabs.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/tabs/tabs.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n  <lg-tabs [headingLevel]=\"headingLevel\"\n    label=\"Annuities\"\n    (tabEvent)=\"tabEvent($event)\"\n    [lgMarginRight]=\"'none'\"\n    [lgMarginBottom]=\"'none'\"\n    [lgMarginLeft]=\"'none'\"\n  >\n    <lg-tab-item *ngFor=\"let tab of tabs\">\n      <lg-tab-item-heading>{{ tab.header }}</lg-tab-item-heading>\n      <lg-tab-item-content>\n        <div class=\"lg-tabs__content-section\">{{ tab.content }}</div>\n      </lg-tab-item-content>\n    </lg-tab-item>\n  </lg-tabs>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 2),\n    tabEvent: action('tab selected'),\n  },\n})"
-                }
-            ],
-            "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select all colors that apply'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
-                }
-            ],
-            "projects/canopy/src/lib/forms/date/date-field.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/date/date-field.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n})"
-                }
-            ],
             "projects/canopy/src/lib/forms/select/select.stories.ts": [
                 {
                     "name": "standard",
@@ -41132,16 +41068,40 @@
                     "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/forms/radio/radio.stories.ts": [
+            "projects/canopy/src/lib/forms/validation/form.stories.ts": [
                 {
                     "name": "standard",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/radio/radio.stories.ts",
+                    "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-radio\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [label]=\"label\"\n    (radioChange)=\"radioChange($event)\">\n  </lg-reactive-form-radio>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    radioChange: action('radioChange'),\n    disabled: boolean('disabled', false),\n  },\n})"
+                    "defaultValue": "() => ({\n  template: `\n    <lg-validation-form\n      (formSubmit)=\"formSubmit($event)\">\n    </lg-validation-form>\n  `,\n  props: {\n    formSubmit: action('formSubmit'),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/modal/modal.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/modal/modal.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n    <button lgModalTrigger=\"modal-story\" lg-button type=\"button\" variant=\"outline-primary\">Open modal</button>\n    <lg-modal id=\"modal-story\">\n      <lg-modal-header [headingLevel]=\"headingLevel\">Lorem ipsum</lg-modal-header>\n      <lg-modal-body>\n        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n        <lg-modal-body-timer timer=\"90\"></lg-modal-body-timer>\n      </lg-modal-body>\n      <lg-modal-footer>\n        <lg-button-group>\n          <button lg-button lgMarginBottom=\"none\" variant=\"solid-primary\" type=\"button\">Button</button>\n          <button lg-button lgMarginBottom=\"none\" variant=\"outline-primary\" type=\"button\">Close</button>\n        </lg-button-group>\n      </lg-modal-footer>\n    </lg-modal>\n  `,\n  props: {\n    headingLevel: select('heading level', [1, 2, 3, 4, 5, 6], 2),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/forms/validation/validation.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/validation/validation.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/forms/radio/segment.stories.ts": [
@@ -41168,28 +41128,76 @@
                     "defaultValue": "() => createToggleStory('switch')"
                 }
             ],
-            "projects/canopy/src/lib/forms/validation/form.stories.ts": [
+            "projects/canopy/src/lib/forms/radio/radio.stories.ts": [
                 {
                     "name": "standard",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
+                    "file": "projects/canopy/src/lib/forms/radio/radio.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-validation-form\n      (formSubmit)=\"formSubmit($event)\">\n    </lg-validation-form>\n  `,\n  props: {\n    formSubmit: action('formSubmit'),\n  },\n})"
+                    "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-radio\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [label]=\"label\"\n    (radioChange)=\"radioChange($event)\">\n  </lg-reactive-form-radio>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    radioChange: action('radioChange'),\n    disabled: boolean('disabled', false),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/forms/validation/validation.stories.ts": [
+            "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts": [
                 {
                     "name": "standard",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/validation/validation.stories.ts",
+                    "file": "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
+                    "defaultValue": "() => ({\n  template: `\n  <lg-tab-nav-bar label=\"Tabbed navigation demo\">\n    <a *ngFor=\"let tab of tabs; index as i\" lgTabNavBarLink href=\"\" (click)=\"onClick($event)\" id=\"tabbed-nav-{{i}}\" [isActive]=\"i === selectedTabNavIndex\">{{tab}}</a>\n  </lg-tab-nav-bar>\n\n  <lg-tab-nav-content [selectedTabId]=\"'tabbed-nav-' + selectedTabNavIndex\">\n    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n  </lg-tab-nav-content>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    selectedTabNavIndex: 1,\n    onClick: (event: MouseEvent) => event.preventDefault(),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/forms/date/date-field.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/date/date-field.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/primary-message/primary-message.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/primary-message/primary-message.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n    <lg-primary-message-story [hasRole]=\"hasRole\"></lg-primary-message-story>\n  `,\n  props: {\n    hasRole: boolean('Set role attribute to alert', true),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [inline]=\"inline\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    (checkboxChange)=\"checkboxChange($event)\">\n  </lg-reactive-form>\n  `,\n  props: {\n    inline: boolean('inline', false),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select all colors that apply'),\n    checkboxChange: action('checkboxChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
+                }
+            ],
+            "projects/canopy/src/lib/tabs/tabs.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/tabs/tabs.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `\n  <lg-tabs [headingLevel]=\"headingLevel\"\n    label=\"Annuities\"\n    (tabEvent)=\"tabEvent($event)\"\n    [lgMarginRight]=\"'none'\"\n    [lgMarginBottom]=\"'none'\"\n    [lgMarginLeft]=\"'none'\"\n  >\n    <lg-tab-item *ngFor=\"let tab of tabs\">\n      <lg-tab-item-heading>{{ tab.header }}</lg-tab-item-heading>\n      <lg-tab-item-content>\n        <div class=\"lg-tabs__content-section\">{{ tab.content }}</div>\n      </lg-tab-item-content>\n    </lg-tab-item>\n  </lg-tabs>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 2),\n    tabEvent: action('tab selected'),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/forms/toggle/checkbox.stories.ts": [
@@ -41216,16 +41224,16 @@
                     "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [focus]=\"focus\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/skeleton/skeleton.stories.ts": [
+            "projects/canopy/src/lib/canopy.stories.ts": [
                 {
-                    "name": "stories",
+                    "name": "standard",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/skeleton/skeleton.stories.ts",
+                    "file": "projects/canopy/src/lib/canopy.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "storiesOf('Directives', module)"
+                    "defaultValue": "() => ({\n  template: `<app-root></app-root>`,\n})"
                 }
             ],
             "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts": [
@@ -41250,6 +41258,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "storiesOf('Pipes', module)"
+                }
+            ],
+            "projects/canopy/src/lib/skeleton/skeleton.stories.ts": [
+                {
+                    "name": "stories",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/skeleton/skeleton.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "storiesOf('Directives', module)"
                 }
             ],
             "projects/canopy/src/lib/table/test.data.ts": [
@@ -41286,24 +41306,24 @@
                     "defaultValue": "new InjectionToken<LgFeatureToggleOptions>(\n  'Toggles options',\n)"
                 }
             ],
-            "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts": [
-                {
-                    "name": "uniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
             "projects/canopy/src/lib/forms/radio/radio-group.component.ts": [
                 {
                     "name": "uniqueId",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/forms/radio/radio-group.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts": [
+                {
+                    "name": "uniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -42804,6 +42824,16 @@
                 "type": "variable",
                 "linktype": "miscellaneous",
                 "linksubtype": "variable",
+                "name": "brandIconsTemplate",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
                 "name": "colours",
                 "coveragePercent": 0,
                 "coverageCount": "0/1",
@@ -42824,7 +42854,7 @@
                 "type": "variable",
                 "linktype": "miscellaneous",
                 "linksubtype": "variable",
-                "name": "standard",
+                "name": "standardBrandIcons",
                 "coveragePercent": 0,
                 "coverageCount": "0/1",
                 "status": "low"

--- a/projects/canopy/src/lib/brand-icon/brand-icon.notes.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.notes.ts
@@ -1,7 +1,4 @@
 export const notes = `
-# Brand Icon Component
-
-## Purpose
 Provides a way of adding common brand icons.
 
 ## Usage
@@ -14,11 +11,15 @@ Import the component in your application:
 })
 ~~~
 
-Import the \`LgBrandIconRegistry\` and register your brand icons:
+Import the \`LgBrandIconRegistry\` service and register your brand icons inside your module:
 
 ~~~js
+// import the desired icon
+import { lgBrandIconSun } from '@legal-and-general/canopy';
+
 export class AppModule {
   constructor(private brandIconRegistry: LgBrandIconRegistry) {
+    // register the icon using the \`brandIconRegistry\` service
     this.brandIconRegistry.registerBrandIcon([
       lgBrandIconSun
     ]);
@@ -26,24 +27,21 @@ export class AppModule {
 }
 ~~~
 
-and in your HTML:
+Your HTML:
 
 ~~~html
+<!-- with default size and colour -->
 <lg-brand-icon name="sun"></lg-brand-icon>
+
+<!-- with a size set -->
+<lg-brand-icon name="sun" size="sm"></lg-brand-icon>
+
+<!-- with a colour set -->
+<lg-brand-icon name="sun" colour="--color-lily-green"></lg-brand-icon>
 ~~~
 
-## Inputs
+## Branding / Colours
+The yellow fill colour of the brand icons can be changed globally  by overriding the \`--brand-icon-fill-primary\` css variable. Note that changing this variable will update the fill colour of all the icons.
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| \`\`name\`\` | the name of the icon | string | undefined | yes |
-| \`\`size\`\` | the size of the icon | BrandIconSize | 'sm' | no |
-| \`\`colour\`\` | the specific colour of the icon (for global colours see the "Branding" section below) | css variable as a string | undefined | no |
-
-## Branding
-The yellow fill colour of the brand icons can be changed by overriding the \`--brand-icon-fill-primary\` css variable.
-
-Note that changing that variable will update the fill colour of all the icons.
-
-To change the colour of a specific icon use the \`colour\` input (see details in the table above).
+To change the colour of a specific icon use the \`colour\` input on the component.
 `;

--- a/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
@@ -1,15 +1,15 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 
-import { select, withKnobs } from '@storybook/addon-knobs';
-import { moduleMetadata } from '@storybook/angular';
+import { moduleMetadata, Story } from '@storybook/angular';
 
 import { LgBrandIconComponent } from './brand-icon.component';
 import { notes } from './brand-icon.notes';
 import { LgBrandIconRegistry } from './brand-icon.registry';
+
 import * as brandIconSet from './brand-icons.interface';
 
-export const brandIconsArray: Array<brandIconSet.BrandIcon> = [
+const brandIconsArray: Array<brandIconSet.BrandIcon> = [
   brandIconSet.lgBrandIconCalendar,
   brandIconSet.lgBrandIconChangeExistingHoldings,
   brandIconSet.lgBrandIconChangeFutureContributions,
@@ -33,7 +33,6 @@ export const brandIconsArray: Array<brandIconSet.BrandIcon> = [
   brandIconSet.lgBrandIconQuickAndEasy,
   brandIconSet.lgBrandIconHandFlower,
 ];
-
 @Component({
   selector: 'lg-swatch-brand-icon',
   template: `
@@ -42,7 +41,7 @@ export const brandIconsArray: Array<brandIconSet.BrandIcon> = [
         class="swatch__svg"
         [name]="icon.name"
         [size]="size"
-        [colour]="i === 0 ? specificColour : null"
+        [colour]="i === 0 ? colour : null"
         [attr.style]="cssVar"
       ></lg-brand-icon>
       <span class="swatch__name">{{ icon.name }}</span>
@@ -76,7 +75,7 @@ export const brandIconsArray: Array<brandIconSet.BrandIcon> = [
 class SwatchBrandIconComponent implements OnChanges {
   @Input() size: string;
   @Input() colour: string;
-  @Input() specificColour: string;
+  @Input() globalColour: string;
 
   icons = brandIconsArray;
   cssVar: SafeStyle;
@@ -85,32 +84,16 @@ class SwatchBrandIconComponent implements OnChanges {
     this.registry.registerBrandIcon(this.icons);
   }
 
-  ngOnChanges({ colour }: SimpleChanges) {
-    if (colour && colour.currentValue) {
+  ngOnChanges({ globalColour }: SimpleChanges) {
+    if (globalColour && globalColour.currentValue) {
       this.cssVar = this.sanitizer.bypassSecurityTrustStyle(
-        `--brand-icon-fill-primary: var(${colour.currentValue})`,
+        `--brand-icon-fill-primary: var(${globalColour.currentValue})`,
       );
     }
   }
 }
 
 const sizes = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'];
-
-export default {
-  title: 'Components/Brand Icon',
-  excludeStories: ['brandIconsArray'],
-  parameters: {
-    decorators: [
-      withKnobs,
-      moduleMetadata({
-        declarations: [SwatchBrandIconComponent, LgBrandIconComponent],
-      }),
-    ],
-    notes: {
-      markdown: notes,
-    },
-  },
-};
 
 const colours = [
   '--color-dandelion-yellow',
@@ -120,21 +103,93 @@ const colours = [
   '--color-poppy-red-dark',
 ];
 
-export const standard = () => ({
-  template: `
-    <lg-swatch-brand-icon [size]="size" [colour]="colour" [specificColour]="specificColour"></lg-swatch-brand-icon>
-  `,
-  props: {
-    size: select('size', sizes, 'xs'),
-    colour: select(
-      'example of applying colour globally',
-      colours,
-      '--color-dandelion-yellow',
-    ),
-    specificColour: select(
-      'example of applying colour specifically to an icon',
-      colours,
-      '--color-super-blue',
-    ),
+export default {
+  title: 'Components/Brand Icon',
+  decorators: [
+    moduleMetadata({
+      declarations: [SwatchBrandIconComponent, LgBrandIconComponent],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: notes,
+      },
+    },
   },
+  argTypes: {
+    size: {
+      options: sizes,
+      description: 'The size of the icon',
+      table: {
+        type: {
+          summary: sizes,
+        },
+        defaultValue: {
+          summary: 'sm',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+    },
+    globalColour: {
+      options: colours,
+      description:
+        'The primary colour of icons globally. Can be changed by overriding the `--brand-icon-fill-primary` CSS variable.',
+      table: {
+        defaultValue: {
+          summary: '--color-dandelion-yellow',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+    },
+    colour: {
+      options: colours,
+      description: 'The colour of a specific icon, using the `colour` input',
+      table: {
+        type: {
+          summary: colours,
+        },
+        defaultValue: {
+          summary: '--color-dandelion-yellow',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+    },
+  },
+};
+
+const exampleTemplate = `
+<lg-brand-icon
+  [name]="sun"
+  size="sm"
+  colour="--color-dandelion-yellow"
+></lg-brand-icon>
+`;
+
+const brandIconsTemplate: Story<LgBrandIconComponent> = (args: LgBrandIconComponent) => ({
+  props: args,
+  template:
+    '<lg-swatch-brand-icon [size]="size" [colour]="colour" [globalColour]="globalColour"></lg-swatch-brand-icon>',
 });
+
+export const standardBrandIcons = brandIconsTemplate.bind({});
+standardBrandIcons.storyName = 'Standard';
+standardBrandIcons.args = {
+  size: 'sm',
+};
+standardBrandIcons.parameters = {
+  docs: {
+    description: {
+      component: notes,
+    },
+    source: {
+      code: exampleTemplate,
+    },
+  },
+};


### PR DESCRIPTION
# Description

Upgrades the Brand Icon to CSF format. Makes the brand icon story work in Storybook v6.

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
