### PR TITLE
fix(enums): revert enums back to types for CSF stories

### DIFF
--- a/projects/canopy/src/lib/alert/alert.component.spec.ts
+++ b/projects/canopy/src/lib/alert/alert.component.spec.ts
@@ -5,7 +5,7 @@ import { MockComponents } from 'ng-mocks';
 
 import { LgAlertComponent } from './alert.component';
 import { LgIconComponent } from '../icon';
-import { Variant } from '../variant/variant.interface';
+import type { Variant } from '../variant/variant.interface';
 
 describe('LgAlertComponent', () => {
   let component: LgAlertComponent;
@@ -32,19 +32,19 @@ describe('LgAlertComponent', () => {
   });
 
   it('adds the variant class to the alert component', () => {
-    component.variant = Variant.Success;
+    component.variant = 'success';
     fixture.detectChanges();
     expect(fixture.nativeElement.getAttribute('class')).toContain('success');
   });
 
   it('does not add a Aria role for the info variant', () => {
-    component.variant = Variant.Info;
+    component.variant = 'info';
     fixture.detectChanges();
     expect(fixture.nativeElement.getAttribute('role')).toBeNull();
   });
 
   it('adds the Aria role "alert" for all other variants', () => {
-    component.variant = Variant.Warning;
+    component.variant = 'warning';
     fixture.detectChanges();
     expect(fixture.nativeElement.getAttribute('role')).toBe('alert');
   });
@@ -62,13 +62,13 @@ describe('LgAlertComponent', () => {
   });
 
   [
-    { variant: Variant.Error, icon: 'crossmark-spot-fill' },
-    { variant: Variant.Info, icon: 'information-fill' },
-    { variant: Variant.Warning, icon: 'warning-fill' },
-    { variant: Variant.Success, icon: 'checkmark-spot-fill' },
+    { variant: 'error', icon: 'crossmark-spot-fill' },
+    { variant: 'info', icon: 'information-fill' },
+    { variant: 'warning', icon: 'warning-fill' },
+    { variant: 'success', icon: 'checkmark-spot-fill' },
   ].forEach(({ variant, icon }) => {
     it(`renders the correct icon for the ${variant} alert`, () => {
-      component.variant = variant;
+      component.variant = variant as Variant;
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css(`[name="${icon}"]`))).not.toBeNull();
     });

--- a/projects/canopy/src/lib/alert/alert.component.ts
+++ b/projects/canopy/src/lib/alert/alert.component.ts
@@ -7,7 +7,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { Variant } from '../variant/variant.interface';
+import type { Variant } from '../variant/variant.interface';
 
 @Component({
   selector: 'lg-alert',
@@ -38,12 +38,12 @@ export class LgAlertComponent {
   }
 
   @HostBinding('attr.role') get role(): string {
-    if (this.variant !== Variant.Info && this.variant !== Variant.Generic) {
+    if (this.variant !== 'info' && this.variant !== 'generic') {
       return 'alert';
     }
   }
 
   constructor(private renderer: Renderer2, private hostElement: ElementRef) {
-    this.variant = Variant.Generic;
+    this.variant = 'generic';
   }
 }

--- a/projects/canopy/src/lib/alert/alert.stories.ts
+++ b/projects/canopy/src/lib/alert/alert.stories.ts
@@ -1,11 +1,11 @@
 import { Meta, Story } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 
-import { Variant } from '../variant/variant.interface';
-
 import { LgAlertModule } from './alert.module';
 import { LgAlertComponent } from './alert.component';
 import { notes } from './alert.notes';
+
+const variantTypes = ['generic', 'info', 'success', 'warning', 'error'];
 
 // This default export determines where your story goes in the story list
 export default {
@@ -40,14 +40,14 @@ export default {
       },
     },
     variant: {
-      options: Object.values(Variant),
+      options: variantTypes,
       description: 'Applies colour treatment and ARIA role if applicable.',
       table: {
         type: {
-          summary: Object.values(Variant),
+          summary: variantTypes,
         },
         defaultValue: {
-          summary: Variant.Generic,
+          summary: 'generic',
         },
       },
       control: {
@@ -79,7 +79,7 @@ export const standardAlert = alertTemplate.bind({});
 standardAlert.storyName = 'Standard';
 standardAlert.args = {
   content: 'This is an alert.',
-  variant: Variant.Generic,
+  variant: 'generic',
 };
 standardAlert.parameters = {
   docs: {

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 
 import { lgIconChevronDown } from '../../icon';
-import { Variant } from '../../variant';
+import type { Variant } from '../../variant';
 
 let nextUniqueId = 0;
 @Component({
@@ -33,7 +33,7 @@ export class LgDetailsPanelHeadingComponent {
     return this._showIcon;
   }
 
-  _variant: Variant = Variant.Generic;
+  _variant: Variant = 'generic';
   @Input()
   set variant(variant: Variant) {
     this._variant = variant;

--- a/projects/canopy/src/lib/details/details.component.spec.ts
+++ b/projects/canopy/src/lib/details/details.component.spec.ts
@@ -5,7 +5,6 @@ import { MockComponent, MockRender, MockedComponentFixture } from 'ng-mocks';
 
 import { LgDetailsPanelHeadingComponent } from './details-panel-heading/details-panel-heading.component';
 import { LgDetailsComponent } from './details.component';
-import { Variant } from '../variant';
 
 describe('LgDetailsComponent', () => {
   let component: LgDetailsComponent;
@@ -65,24 +64,24 @@ describe('LgDetailsComponent', () => {
     });
 
     it('does not add an Aria role for the info variant', () => {
-      component.variant = Variant.Info;
+      component.variant = 'info';
       expect(detailsEl.getAttribute('role')).toBeNull();
     });
 
     it('adds an Aria role "alert" for the warning variant', () => {
-      component.variant = Variant.Warning;
+      component.variant = 'warning';
       fixture.detectChanges();
       expect(detailsEl.getAttribute('role')).toBe('alert');
     });
 
     it('adds an Aria role "alert" for the error variant', () => {
-      component.variant = Variant.Error;
+      component.variant = 'error';
       fixture.detectChanges();
       expect(detailsEl.getAttribute('role')).toBe('alert');
     });
 
     it('adds an Aria role "success" for the error variant', () => {
-      component.variant = Variant.Success;
+      component.variant = 'success';
       fixture.detectChanges();
       expect(detailsEl.getAttribute('role')).toBe('alert');
     });

--- a/projects/canopy/src/lib/details/details.component.ts
+++ b/projects/canopy/src/lib/details/details.component.ts
@@ -16,7 +16,7 @@ import {
 
 import { Subscription } from 'rxjs';
 
-import { Variant } from '../variant';
+import type { Variant } from '../variant';
 import { LgDetailsPanelHeadingComponent } from './details-panel-heading/details-panel-heading.component';
 
 let nextUniqueId = 0;
@@ -68,7 +68,7 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
   }
 
   @HostBinding('attr.role') get role(): string {
-    if (this.variant !== Variant.Info && this.variant !== Variant.Generic) {
+    if (this.variant !== 'info' && this.variant !== 'generic') {
       return 'alert';
     }
   }
@@ -87,7 +87,7 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
     private hostElement: ElementRef,
     private cdr: ChangeDetectorRef,
   ) {
-    this.variant = Variant.Generic;
+    this.variant = 'generic';
   }
 
   ngAfterContentInit(): void {

--- a/projects/canopy/src/lib/details/details.stories.ts
+++ b/projects/canopy/src/lib/details/details.stories.ts
@@ -4,8 +4,9 @@ import { LgHeadingModule } from '../heading';
 import { LgDetailsModule } from './details.module';
 import { notes } from './details.notes';
 import { LgIconModule } from '../icon';
-import { Variant } from '../variant';
 import { LgDetailsComponent } from './details.component';
+
+const variantTypes = ['generic', 'info', 'success', 'warning', 'error'];
 
 export default {
   title: 'Components/Details',
@@ -39,14 +40,14 @@ export default {
       },
     },
     variant: {
-      options: Object.values(Variant),
+      options: variantTypes,
       description: 'Applies colour treatment and ARIA role if applicable.',
       table: {
         type: {
-          summary: Object.values(Variant),
+          summary: variantTypes,
         },
         defaultValue: {
-          summary: Variant.Generic,
+          summary: 'generic',
         },
       },
       control: {
@@ -154,7 +155,7 @@ const detailsTemplate: Story<LgDetailsComponent> = (args: LgDetailsComponent) =>
 export const standardDetails = detailsTemplate.bind({});
 standardDetails.storyName = 'Standard';
 standardDetails.args = {
-  variant: Variant.Generic,
+  variant: 'generic',
   headingLevel: 5,
 };
 standardDetails.parameters = {

--- a/projects/canopy/src/lib/forms/validation/validation.component.spec.ts
+++ b/projects/canopy/src/lib/forms/validation/validation.component.spec.ts
@@ -5,7 +5,7 @@ import { CanopyModule } from '../../canopy.module';
 import { LgValidationComponent } from './validation.component';
 
 import { LgIconComponent } from '../../icon';
-import { Variant } from '../../variant';
+import type { Variant } from '../../variant';
 
 describe('LgValidationComponent', () => {
   let component: LgValidationComponent;
@@ -45,12 +45,12 @@ describe('LgValidationComponent', () => {
 
   it('renders the correct icon for the variant', () => {
     [
-      { variant: Variant.Error, icon: 'crossmark-spot-fill' },
-      { variant: Variant.Info, icon: 'information-fill' },
-      { variant: Variant.Warning, icon: 'warning-fill' },
-      { variant: Variant.Success, icon: 'checkmark-spot-fill' },
+      { variant: 'error', icon: 'crossmark-spot-fill' },
+      { variant: 'info', icon: 'information-fill' },
+      { variant: 'warning', icon: 'warning-fill' },
+      { variant: 'success', icon: 'checkmark-spot-fill' },
     ].forEach(({ variant, icon }) => {
-      component.variant = variant;
+      component.variant = variant as Variant;
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css(`[name="${icon}"]`))).not.toBeNull();
     });

--- a/projects/canopy/src/lib/forms/validation/validation.component.ts
+++ b/projects/canopy/src/lib/forms/validation/validation.component.ts
@@ -7,7 +7,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { Variant } from '../../variant';
+import type { Variant } from '../../variant';
 
 let nextUniqueId = 0;
 
@@ -44,6 +44,6 @@ export class LgValidationComponent {
   id = `lg-validation-${nextUniqueId++}`;
 
   constructor(private renderer: Renderer2, private hostElement: ElementRef) {
-    this.variant = Variant.Error;
+    this.variant = 'error';
   }
 }

--- a/projects/canopy/src/lib/variant/variant.directive.spec.ts
+++ b/projects/canopy/src/lib/variant/variant.directive.spec.ts
@@ -3,13 +3,13 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { LgVariantDirective } from './variant.directive';
-import { Variant } from './variant.interface';
+import type { Variant } from './variant.interface';
 
 @Component({
   template: ` <div [lgVariant]="lgVariant">Test</div> `,
 })
 class TestComponent {
-  @Input() lgVariant: Variant = Variant.Generic;
+  @Input() lgVariant: Variant = 'generic';
 }
 
 describe('LgVariant', () => {
@@ -44,13 +44,13 @@ describe('LgVariant', () => {
   });
 
   it('adds the info variant class', () => {
-    component.lgVariant = Variant.Info;
+    component.lgVariant = 'info';
     fixture.detectChanges();
     expect(testElement.nativeElement.getAttribute('class')).toContain('lg-variant--info');
   });
 
   it('adds the success variant class', () => {
-    component.lgVariant = Variant.Success;
+    component.lgVariant = 'success';
     fixture.detectChanges();
     expect(testElement.nativeElement.getAttribute('class')).toContain(
       'lg-variant--success',
@@ -58,7 +58,7 @@ describe('LgVariant', () => {
   });
 
   it('adds the warning variant class', () => {
-    component.lgVariant = Variant.Warning;
+    component.lgVariant = 'warning';
     fixture.detectChanges();
     expect(testElement.nativeElement.getAttribute('class')).toContain(
       'lg-variant--warning',
@@ -66,7 +66,7 @@ describe('LgVariant', () => {
   });
 
   it('adds the error variant class', () => {
-    component.lgVariant = Variant.Error;
+    component.lgVariant = 'error';
     fixture.detectChanges();
     expect(testElement.nativeElement.getAttribute('class')).toContain(
       'lg-variant--error',

--- a/projects/canopy/src/lib/variant/variant.interface.ts
+++ b/projects/canopy/src/lib/variant/variant.interface.ts
@@ -1,7 +1,1 @@
-export enum Variant {
-  Generic = 'generic',
-  Info = 'info',
-  Success = 'success',
-  Warning = 'warning',
-  Error = 'error',
-}
+export type Variant = 'generic' | 'info' | 'success' | 'warning' | 'error';


### PR DESCRIPTION
# Description

After discussion, we have agreed t revert the use of enums for CSF stories. This PR reverts the ones created thus far.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
