### PR TITLE
Single field sort code

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -500,10 +500,11 @@
                 <lg-filter-checkbox value="blue">Blue</lg-filter-checkbox>
               </lg-filter-multiple-group>
 
-              <lg-sort-code formControlName="sortCode">
+              <lg-input-field>
                 Sort Code
                 <lg-hint>Must be 6 digits long</lg-hint>
-              </lg-sort-code>
+                <input lgInput lgSortCode formControlName="sortCode" />
+              </lg-input-field>
 
               <button lg-button type="submit" variant="solid-primary">Submit</button>
             </form>

--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -65,7 +65,6 @@
     }
 
     #{$block}--error & {
-      color: var(--form-error-color);
       border-color: var(--form-error-border-color);
     }
 
@@ -116,5 +115,9 @@
 
   &:-webkit-autofill {
     -webkit-background-clip: text;
+  }
+
+  &--error {
+    color: var(--form-error-color);
   }
 }

--- a/projects/canopy/src/lib/forms/sort-code/index.ts
+++ b/projects/canopy/src/lib/forms/sort-code/index.ts
@@ -1,2 +1,3 @@
 export * from './sort-code.component';
+export * from './sort-code.directive';
 export * from './sort-code.module';

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.component.ts
@@ -40,6 +40,10 @@ let nextUniqueId = 0;
   styleUrls: ['./sort-code.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
+/**
+ * @deprecated LgSortCodeComponent is deprecated.
+ * Please use the LgSortCodeDirective instead.
+ */
 export class LgSortCodeComponent
   implements OnInit, ControlValueAccessor, Validator, OnDestroy
 {

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
@@ -83,6 +83,8 @@ describe('LgSortCodeDirective', () => {
   describe('#format', () => {
     it('should add dashes between the numbers', () => {
       expect(inputInstance['format']('000000')).toEqual('00-00-00');
+      expect(inputInstance['format']('00 00 00')).toEqual('00-00-00');
+      expect(inputInstance['format']('00-00-00')).toEqual('00-00-00');
     });
 
     it('should be called on a focusout event', () => {

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
@@ -1,0 +1,98 @@
+import { ChangeDetectionStrategy, Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  NgControl,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+import { instance, mock } from 'ts-mockito';
+
+import { LgSortCodeDirective } from '../sort-code/sort-code.directive';
+
+@Component({
+  template: `
+    <form (ngSubmit)="login()" [formGroup]="form">
+      <input lgInput lgSortCode formControlName="sortCode" />
+    </form>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestInputComponent {
+  form = new FormGroup({
+    sortCode: new FormControl('', [Validators.required]),
+  });
+}
+
+describe('LgSortCodeDirective', () => {
+  let fixture: ComponentFixture<TestInputComponent>;
+  let component: TestInputComponent;
+  let inputDebugElement: DebugElement;
+  let inputInstance: LgSortCodeDirective;
+  let control: NgControl;
+
+  beforeEach(
+    waitForAsync(() => {
+      control = mock(NgControl);
+
+      TestBed.configureTestingModule({
+        imports: [FormsModule, ReactiveFormsModule],
+        declarations: [LgSortCodeDirective, TestInputComponent],
+        providers: [{ provide: NgControl, useValue: instance(control) }],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestInputComponent);
+      component = fixture.componentInstance;
+
+      inputDebugElement = fixture.debugElement.query(By.directive(LgSortCodeDirective));
+
+      inputInstance =
+        inputDebugElement.injector.get<LgSortCodeDirective>(LgSortCodeDirective);
+    }),
+  );
+
+  it('adds a placeholder', () => {
+    fixture.detectChanges();
+    expect(inputDebugElement.nativeElement.placeholder).toContain('00-00-00');
+  });
+
+  it('adds a required attribute', () => {
+    fixture.detectChanges();
+    expect(inputDebugElement.nativeElement.required).toBe(true);
+  });
+
+  it('adds a numeric inputmode attribute', () => {
+    fixture.detectChanges();
+    expect(inputDebugElement.nativeElement.getAttribute('inputmode')).toBe('numeric');
+  });
+
+  it('adds a maxlength attribute', () => {
+    fixture.detectChanges();
+    expect(inputDebugElement.nativeElement.getAttribute('maxlength')).toBe('8');
+  });
+
+  it('adds a size attribute', () => {
+    fixture.detectChanges();
+    expect(inputDebugElement.nativeElement.getAttribute('size')).toBe('11');
+  });
+
+  describe('#format', () => {
+    it('should add dashes between the numbers', () => {
+      expect(inputInstance['format']('000000')).toEqual('00-00-00');
+    });
+
+    it('should be called on a focusout event', () => {
+      component.form.get('sortCode').setValue('000');
+      const spy = spyOn<any>(inputInstance, 'format');
+
+      fixture.detectChanges();
+      inputDebugElement.nativeElement.dispatchEvent(new Event('focusout'));
+
+      expect(spy).toHaveBeenCalledOnceWith('000');
+    });
+  });
+});

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.ts
@@ -1,0 +1,40 @@
+import { Directive, HostBinding, HostListener, OnInit } from '@angular/core';
+import { NgControl, Validators } from '@angular/forms';
+
+@Directive({
+  selector: '[lgSortCode]',
+})
+export class LgSortCodeDirective implements OnInit {
+  @HostBinding('placeholder') placeholder = '00-00-00';
+  @HostBinding('required') required = true;
+  @HostBinding('attr.inputmode') inputmode = 'numeric';
+  // 8 because we allow for the two dashes
+  @HostBinding('attr.maxlength') maxlength = '8';
+  @HostBinding('attr.size') size = '11';
+  @HostListener('focusout', ['$event.target.value']) onBlur(value) {
+    if (this.ngControl.valid) {
+      this.ngControl.valueAccessor.writeValue(this.format(value));
+    }
+  }
+
+  constructor(private ngControl: NgControl) {}
+
+  ngOnInit(): void {
+    const validators = [
+      Validators.required,
+      Validators.pattern(/^(?:\d{6}|\d\d-\d\d-\d\d)$/),
+    ];
+
+    if (this.ngControl.control.validator) {
+      validators.push(this.ngControl.control.validator);
+    }
+    this.ngControl.control.setValidators(validators);
+  }
+
+  private format(value: string): string {
+    return value
+      .replace(/\-/g, '')
+      .match(/.{1,2}/g)
+      .join('-');
+  }
+}

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.ts
@@ -13,7 +13,7 @@ export class LgSortCodeDirective implements OnInit {
   @HostBinding('attr.size') size = '11';
   @HostListener('focusout', ['$event.target.value']) onBlur(value) {
     if (this.ngControl.valid) {
-      this.ngControl.valueAccessor.writeValue(this.format(value));
+      this.ngControl.control.setValue(this.format(value), { emitEvent: false });
     }
   }
 
@@ -22,7 +22,7 @@ export class LgSortCodeDirective implements OnInit {
   ngOnInit(): void {
     const validators = [
       Validators.required,
-      Validators.pattern(/^(?:\d{6}|\d\d-\d\d-\d\d)$/),
+      Validators.pattern(/^(?:\d{6}|\d\d-\d\d-\d\d|\d\d\s\d\d\s\d\d)$/),
     ];
 
     if (this.ngControl.control.validator) {
@@ -33,7 +33,7 @@ export class LgSortCodeDirective implements OnInit {
 
   private format(value: string): string {
     return value
-      .replace(/\-/g, '')
+      .replace(/-|\s/g, '')
       .match(/.{1,2}/g)
       .join('-');
   }

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.module.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.module.ts
@@ -8,6 +8,7 @@ import { LgInputModule } from '../input/input.module';
 import { LgSortCodeComponent } from './sort-code.component';
 import { LgMarginModule } from '../../spacing/margin';
 import { LgFocusModule } from '../../focus/focus.module';
+import { LgSortCodeDirective } from './sort-code.directive';
 
 @NgModule({
   imports: [
@@ -19,7 +20,7 @@ import { LgFocusModule } from '../../focus/focus.module';
     LgMarginModule,
     LgFocusModule,
   ],
-  declarations: [LgSortCodeComponent],
-  exports: [LgSortCodeComponent],
+  declarations: [LgSortCodeComponent, LgSortCodeDirective],
+  exports: [LgSortCodeComponent, LgSortCodeDirective],
 })
 export class LgSortCodeModule {}

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
@@ -2,7 +2,7 @@ export const notes = `
 # Sort Code Directive
 
 ## Purpose
-Provides a directive to apply formatting and specific validators to the input component.
+Provides a directive to apply formatting and specific validators to the input component for entering a sort code.
 
 ## Usage
 Import the Sort Code Module into your application:
@@ -24,10 +24,14 @@ and in your HTML:
 </lg-input-field>
 ~~~
 
-**Note: both the lgInput and lgSortCode directives have to be present on the input element.**
+**Note: both the \`lgInput\` and \`lgSortCode\` directives have to be present on the input element.**
 
 ## Validators
 The sort code directive automatically adds the \`required\` and \`pattern\` validators by default.
+The \`pattern\` validator checks that the sort code value has the following patterns: \`000000\`, \`00 00 00\` or \`00-00-00\`.
+
+## Format of the control value
+On blur of the input we auto-format the value of the control to \`00-00-00\`.
 
 -----------------------------------------------------
 

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts
@@ -1,7 +1,41 @@
 export const notes = `
-# Sort Code Component
+# Sort Code Directive
 
 ## Purpose
+Provides a directive to apply formatting and specific validators to the input component.
+
+## Usage
+Import the Sort Code Module into your application:
+
+~~~js
+@NgModule({
+  ...
+  imports: [LgSortCodeModule],
+})
+~~~
+
+and in your HTML:
+
+~~~html
+<lg-input-field>
+  Sort Code
+  <lg-hint *ngIf="hint">Must be 6 digits long</lg-hint>
+  <input lgInput lgSortCode formControlName="sortCode" />
+</lg-input-field>
+~~~
+
+**Note: both the lgInput and lgSortCode directives have to be present on the input element.**
+
+## Validators
+The sort code directive automatically adds the \`required\` and \`pattern\` validators by default.
+
+-----------------------------------------------------
+
+# Deprecated: Sort Code Component
+
+## Purpose
+**Please use the directive above instead.**
+
 Provides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.
 
 ## Usage

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts
@@ -5,25 +5,25 @@ import { moduleMetadata } from '@storybook/angular';
 import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-import { LgSortCodeComponent } from './sort-code.component';
 import { CanopyModule } from '../../canopy.module';
 import { notes } from './sort-code.notes';
+import { LgSortCodeDirective } from './sort-code.directive';
 
 @Component({
   selector: 'lg-reactive-form',
   template: `
     <form [formGroup]="form">
-      <lg-sort-code formControlName="sortCode" [focus]="focus">
+      <lg-input-field>
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
-      </lg-sort-code>
+        <input lgInput lgSortCode formControlName="sortCode" />
+      </lg-input-field>
     </form>
   `,
 })
 class ReactiveFormComponent {
   @Input() hint: string;
   @Input() label: string;
-  @Input() focus: boolean;
 
   @Input()
   set disabled(disabled: boolean) {
@@ -51,7 +51,7 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Form/Sort Code',
-  component: LgSortCodeComponent,
+  components: [LgSortCodeDirective],
   decorators: [
     withKnobs,
     moduleMetadata({
@@ -72,13 +72,11 @@ export const standard = () => ({
     [disabled]="disabled"
     [hint]="hint"
     [label]="label"
-    [focus]="focus"
   ></lg-reactive-form>`,
   props: {
     inputChange: action('inputChange'),
     label: text('label', 'Sort code'),
     hint: text('hint', 'Must be 6 digits long'),
     disabled: boolean('disabled', false),
-    focus: boolean('focus', false),
   },
 });

--- a/projects/canopy/src/lib/forms/validation/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/form.stories.ts
@@ -189,18 +189,19 @@ function invalidValidator(): ValidatorFn {
         </lg-validation>
       </lg-date-field>
 
-      <lg-sort-code formControlName="sortCode">
+      <lg-input-field>
         Sort Code
         <lg-hint>Must be 6 digits long</lg-hint>
+        <input lgInput lgSortCode formControlName="sortCode" />
         <lg-validation *ngIf="isControlInvalid(sortCode, validationForm)">
-          <ng-container *ngIf="sortCode.hasError('requiredField')">
+          <ng-container *ngIf="sortCode.hasError('required')">
             Enter a sort code
           </ng-container>
-          <ng-container *ngIf="sortCode.hasError('invalidField')">
+          <ng-container *ngIf="sortCode.hasError('pattern')">
             Enter a valid sort code
           </ng-container>
         </lg-validation>
-      </lg-sort-code>
+      </lg-input-field>
 
       <button lg-button type="submit" variant="solid-primary">Submit</button>
     </form>

--- a/projects/canopy/src/lib/forms/validation/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/form.stories.ts
@@ -87,44 +87,6 @@ function invalidValidator(): ValidatorFn {
         </lg-validation>
       </lg-select-field>
 
-      <lg-radio-group formControlName="radio">
-        Radio option
-        <lg-hint>This is a standard radio group</lg-hint>
-        <lg-radio-button value="yellow">Yellow</lg-radio-button>
-        <lg-radio-button value="red">Red</lg-radio-button>
-        <lg-radio-button value="blue">Blue</lg-radio-button>
-        <lg-radio-button value="invalid">Invalid</lg-radio-button>
-        <lg-validation
-          *ngIf="isControlInvalid(radio, validationForm) && radio.hasError('invalid')"
-        >
-          Please select a valid option
-        </lg-validation>
-        <lg-validation
-          *ngIf="isControlInvalid(radio, validationForm) && radio.hasError('required')"
-        >
-          Please select an option
-        </lg-validation>
-      </lg-radio-group>
-
-      <lg-segment-group formControlName="segment">
-        Segment option
-        <lg-hint>This is a standard segment group</lg-hint>
-        <lg-segment-button value="yellow">Yellow</lg-segment-button>
-        <lg-segment-button value="red">Red</lg-segment-button>
-        <lg-segment-button value="blue">Blue</lg-segment-button>
-        <lg-segment-button value="invalid">Invalid</lg-segment-button>
-        <lg-validation
-          *ngIf="isControlInvalid(segment, validationForm) && segment.hasError('invalid')"
-        >
-          Please select a valid option
-        </lg-validation>
-        <lg-validation
-          *ngIf="isControlInvalid(radio, validationForm) && radio.hasError('required')"
-        >
-          Please select an option
-        </lg-validation>
-      </lg-segment-group>
-
       <lg-checkbox-group formControlName="colors">
         Checkbox group
         <lg-hint>This is a standard checkbox group</lg-hint>
@@ -228,14 +190,6 @@ class ReactiveFormComponent {
     return this.form.get('select');
   }
 
-  get radio() {
-    return this.form.get('radio');
-  }
-
-  get segment() {
-    return this.form.get('segment');
-  }
-
   get colors() {
     return this.form.get('colors');
   }
@@ -254,8 +208,6 @@ class ReactiveFormComponent {
     this.form = this.fb.group({
       text: ['', [Validators.required, Validators.minLength(4), invalidValidator()]],
       select: ['', [Validators.required, invalidValidator()]],
-      radio: ['', [Validators.required, invalidValidator()]],
-      segment: ['', [Validators.required, invalidValidator()]],
       colors: this.fb.control([], [Validators.required]),
       checkbox: ['', [Validators.requiredTrue]],
       switch: ['', [Validators.requiredTrue]],

--- a/projects/canopy/src/styles/variables/_variants.scss
+++ b/projects/canopy/src/styles/variables/_variants.scss
@@ -49,6 +49,6 @@
   --error-link-focus-color: var(--color-white);
   --error-link-focus-bg-color: var(--color-earth-brown-darkest);
 
-  --form-error-color: var(--color-poppy-red);
+  --form-error-color: var(--color-terracotta);
   --form-error-border-color: var(--color-poppy-red);
 }


### PR DESCRIPTION
# Description

This PR implements the sort code as a single field via a new directive.
The component is still available but will be deprecated in the next major release.

![Screenshot 2021-11-08 at 19 17 55](https://user-images.githubusercontent.com/8397116/140803998-4894a2fe-d589-4548-8d19-69d18314f58d.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
