### PR TITLE
Update size attribute for sortcode

### DIFF
--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
@@ -77,7 +77,7 @@ describe('LgSortCodeDirective', () => {
 
   it('adds a size attribute', () => {
     fixture.detectChanges();
-    expect(inputDebugElement.nativeElement.getAttribute('size')).toBe('11');
+    expect(inputDebugElement.nativeElement.getAttribute('size')).toBe('7');
   });
 
   describe('#format', () => {

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.ts
@@ -10,7 +10,7 @@ export class LgSortCodeDirective implements OnInit {
   @HostBinding('attr.inputmode') inputmode = 'numeric';
   // 8 because we allow for the two dashes
   @HostBinding('attr.maxlength') maxlength = '8';
-  @HostBinding('attr.size') size = '11';
+  @HostBinding('attr.size') size = '7';
   @HostListener('focusout', ['$event.target.value']) onBlur(value) {
     if (this.ngControl.valid) {
       this.ngControl.control.setValue(this.format(value), { emitEvent: false });


### PR DESCRIPTION
# Description

Updated the size of the input based on new design.

Before:
![Screenshot 2021-11-08 at 19 17 55](https://user-images.githubusercontent.com/8397116/141338440-6d4c4f32-1be8-4c33-ac05-8cb4dced1871.png)

After:
![Screenshot 2021-11-11 at 16 59 59](https://user-images.githubusercontent.com/8397116/141338409-d11f9202-5006-4dc6-ac62-744f1ad6e379.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
