### PR TITLE
fix(carousel): pause on action and fix carousel item break on tab switch

### DIFF
--- a/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.spec.ts
+++ b/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.spec.ts
@@ -1,10 +1,18 @@
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { MockedComponentFixture, MockRender } from 'ng-mocks';
 
 import { LgCarouselItemComponent } from './carousel-item.component';
 
 describe('LgCarouselItemComponent', () => {
   let component: LgCarouselItemComponent;
   let fixture: ComponentFixture<LgCarouselItemComponent>;
+  let mockFixture: MockedComponentFixture<LgCarouselItemComponent>;
+  let debugElement: DebugElement;
+  let eventSpy: jasmine.Spy;
+  const mockRender = `<div><button>Click me</button></div>`;
 
   beforeEach(
     waitForAsync(() => {
@@ -17,7 +25,14 @@ describe('LgCarouselItemComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LgCarouselItemComponent);
     component = fixture.componentInstance;
+
     fixture.detectChanges();
+
+    mockFixture = MockRender(mockRender);
+    debugElement = mockFixture.debugElement.children[0].query(By.css('button'));
+    eventSpy = spyOn(component.pauseEmit, 'emit');
+
+    mockFixture.detectChanges();
   });
 
   it('should create', () => {
@@ -40,5 +55,19 @@ describe('LgCarouselItemComponent', () => {
     expect(component.element.nativeElement.attributes['aria-selected'].nodeValue).toBe(
       'true',
     );
+  });
+
+  it('should pause carousel if any button element clicked', () => {
+    const el = debugElement.name;
+    component.onClick(el);
+
+    expect(eventSpy).toHaveBeenCalledWith(el);
+  });
+
+  it('should not pause carousel if any element other than button clicked', () => {
+    const el = 'div';
+    component.onClick(el);
+
+    expect(eventSpy).not.toHaveBeenCalled();
   });
 });

--- a/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel-item/carousel-item.component.ts
@@ -2,7 +2,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  EventEmitter,
   HostBinding,
+  HostListener,
+  Output,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -17,6 +20,15 @@ export class LgCarouselItemComponent {
   @HostBinding('class.lg-carousel-item') class = true;
   @HostBinding('attr.role') role = 'tabpanel';
   @HostBinding('attr.aria-selected') public selected = false;
+
+  @Output() pauseEmit = new EventEmitter<string>();
+
+  @HostListener('click', ['$event.target.type'])
+  onClick(btn: string): void {
+    if (btn === 'button') {
+      this.pauseEmit.emit(btn);
+    }
+  }
 
   constructor(public element: ElementRef) {}
 

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChildren,
+  HostListener,
   Input,
   OnDestroy,
   QueryList,
@@ -24,6 +25,8 @@ import { LgCarouselItemComponent } from './carousel-item/carousel-item.component
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LgCarouselComponent implements AfterContentInit, OnDestroy {
+
+  constructor(private cd: ChangeDetectorRef) {}
   @Input() description: string;
   @Input() headingLevel: HeadingLevel;
   @Input() loopMode = false;
@@ -41,6 +44,19 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   pause = new BehaviorSubject<boolean>(false);
   pausableTimer$: Observable<void>;
 
+  @HostListener('document:keydown.tab', ['$event'])
+  onKeydownHandler(event: KeyboardEvent) {
+    const target = event.target as HTMLElement;
+    const parent = target.parentElement as HTMLElement;
+    const el = parent.className;
+
+    if (el === 'lg-carousel-item') {
+      this.nextCarouselItem();
+      event.preventDefault();
+      this.cd.detectChanges();
+    }
+  }
+
   selectCarouselItem(index: number): void {
     this.selectedItemIndex = index;
     this.selectedItem = this.carouselItems.get(index);
@@ -48,6 +64,12 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
 
     this.carouselItems.forEach((carouselItem: LgCarouselItemComponent) => {
       carouselItem.selected = false;
+      carouselItem.pauseEmit.subscribe((el: string) => {
+        if (el === 'button') {
+          this.pause.next(true);
+          this.cd.detectChanges();
+        }
+      });
     });
     this.selectedItem.selected = true;
     this.cd.detectChanges();
@@ -94,6 +116,4 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
     this.unsubscribe.next();
     this.unsubscribe.complete();
   }
-
-  constructor(private cd: ChangeDetectorRef) {}
 }

--- a/projects/canopy/src/lib/carousel/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/carousel.stories.ts
@@ -28,6 +28,7 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+  <button type="button" variant="outline-primary">Click me</button>
 </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
@@ -35,6 +36,7 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+  <button type="button" variant="outline-primary">Click me</button>
 </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #028844; color: #FFFFFF">
@@ -42,6 +44,7 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+  <button type="button" variant="outline-primary">Click me</button>
 </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
@@ -49,6 +52,7 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+  <button type="button" variant="outline-primary">Click me</button>
 </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
@@ -56,6 +60,7 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+  <button type="button" variant="outline-primary">Click me</button>
 </lg-carousel-item>
 `;
 


### PR DESCRIPTION
### Stop carousel when any button inside carousel item has been clicked and fix broken view on tab switch

# Description

If there are any buttons in the carousel item, we assume there is an action such as routing to another page or opening a modal interface. In this case we want to prevent carousel running and we should trigger an event that will pause the carousel on the current item. Once we switch back to the page with carousel we can click on play button and run the carousel again.

If we try to switch between the carousel items with tab key, we want our carousel item to be fully visible. Currently that view is broken, since there are previous and next carousel items broken in half. With this change it should switch though the items pressing tab key on keyboard without any issues.

Fixes #622

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Storybook link: https://legal-and-general.github.io/canopy/?path=/story/components-carousel--auto-play-enabled
Screenshot:

1. Pause on CTA
https://user-images.githubusercontent.com/19712379/142638021-fe7e1e7d-f369-42ac-b020-d7d2cc169d40.mov

2. Switch items on tab
https://user-images.githubusercontent.com/19712379/142638100-7d9fae7e-e340-44aa-89fd-67c95a3c8e33.mov

# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
