### PR TITLE
fix(table): remove align attribute from html

### DIFF
--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.spec.ts
@@ -38,9 +38,9 @@ describe('LgTableHeadCellComponent', () => {
     expect(fixture.debugElement.children[0].nativeElement.innerText).toEqual('Hello');
   });
 
-  it('should have the align attribute set to right', () => {
-    expect(fixture.debugElement.children[0].nativeElement.getAttribute('align')).toBe(
-      'right',
+  it('should have the text-align style set to right', () => {
+    expect(fixture.debugElement.children[0].nativeElement.getAttribute('style')).toBe(
+      'text-align: right;',
     );
   });
 });

--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.ts
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.ts
@@ -19,7 +19,7 @@ import { AlignmentOptions } from '../table.interface';
 export class LgTableHeadCellComponent {
   @HostBinding('class') class = 'lg-table-head-cell';
 
-  @HostBinding('attr.align')
+  @HostBinding('style.text-align')
   get alignment() {
     return this.align === AlignmentOptions.End ? 'right' : 'left';
   }


### PR DESCRIPTION
# Description
Update the code to use `style.text-align` which fixes the error logged by the `w3 html validator`:
```
The align attribute on the th element is obsolete. Use CSS instead.
```

https://user-images.githubusercontent.com/8397116/147654033-1dea9dad-8604-4850-9f9a-e76a7072fcdb.mov



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
