### PR TITLE
Add extra content projection inside the radio buttons

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-button.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.html
@@ -6,6 +6,7 @@
   [attr.name]="name"
   [attr.value]="value"
   [attr.aria-invalid]="errorClass"
+  [attr.aria-describedby]="ariaDescribedBy || null"
   class="lg-radio-button__input"
   type="radio"
 />
@@ -13,3 +14,7 @@
 <label [attr.for]="id" class="lg-radio-button__label">
   <ng-content></ng-content>
 </label>
+
+<div *ngIf="hintPresent" class="lg-radio-button__hint">
+  <ng-content select="lg-hint"></ng-content>
+</div>

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -1,5 +1,10 @@
 @import '../../../styles/mixins';
 
+.lg-radio-button__hint {
+  margin-top: var(--space-xs);
+  padding-left: calc(var(--space-lg) + var(--space-xxxs));
+}
+
 .lg-radio-button--radio {
   display: block;
   margin-bottom: var(--space-sm);

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  ContentChild,
   ElementRef,
   forwardRef,
   Host,
@@ -18,6 +19,8 @@ import { FormGroupDirective, NgControl } from '@angular/forms';
 import { LgErrorStateMatcher } from '../validation/error-state-matcher';
 import { LgRadioGroupComponent } from './radio-group.component';
 import type { RadioStackBreakpoint, RadioVariant } from './radio.interface';
+import { LgHintComponent } from '../hint';
+import { LgDomService } from '../../utils/dom.service';
 
 let nextUniqueId = 0;
 
@@ -33,6 +36,7 @@ let nextUniqueId = 0;
 })
 export class LgRadioButtonComponent implements OnInit {
   checked = false;
+  hintPresent = false;
   _variant: RadioVariant;
   set variant(variant: RadioVariant) {
     if (this._variant) {
@@ -51,6 +55,7 @@ export class LgRadioButtonComponent implements OnInit {
   @Input() id = `lg-radio-button-${++nextUniqueId}`;
   @Input() name: string;
   @Input() value: boolean | string;
+  @Input() ariaDescribedBy: string;
 
   _stacked: RadioStackBreakpoint;
   set stacked(stacked: RadioStackBreakpoint) {
@@ -82,6 +87,18 @@ export class LgRadioButtonComponent implements OnInit {
     return this.errorState.isControlInvalid(this.control, this.controlContainer);
   }
 
+  _hintElement: LgHintComponent;
+  @ContentChild(LgHintComponent)
+  set hintElement(element: LgHintComponent) {
+    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
+      this.ariaDescribedBy,
+      this._hintElement,
+      element,
+    );
+    this._hintElement = element;
+    this.hintPresent = !!element;
+  }
+
   constructor(
     @Self() @Optional() public control: NgControl,
     @Inject(forwardRef(() => LgRadioGroupComponent))
@@ -93,6 +110,7 @@ export class LgRadioButtonComponent implements OnInit {
     private controlContainer: FormGroupDirective,
     private renderer: Renderer2,
     private hostElement: ElementRef,
+    private domService: LgDomService,
   ) {}
 
   ngOnInit() {

--- a/projects/canopy/src/lib/forms/radio/radio.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.stories.ts
@@ -17,7 +17,10 @@ import { LgHintModule } from '../hint/hint.module';
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
         <lg-radio-button value="red">Red</lg-radio-button>
-        <lg-radio-button value="yellow">Yellow</lg-radio-button>
+        <lg-radio-button value="yellow"
+          >Yellow
+          <lg-hint>Internal custom text</lg-hint>
+        </lg-radio-button>
       </lg-radio-group>
     </form>
   `,


### PR DESCRIPTION
# Description

This PR: 
- adds an extra content projection element `<ng-content select="lg-hint">` so that we're able to add text below the radio button for the cases where design dictates so.

Check the PS below: 

<img width="538" alt="internal_custom_text" src="https://user-images.githubusercontent.com/20334064/148251188-7f428f51-a69c-47f6-a867-ddea314abda6.png">


# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
