### PR TITLE
fix(modal): update event to close on overlay click

### DIFF
--- a/projects/canopy/src/lib/modal/modal.component.html
+++ b/projects/canopy/src/lib/modal/modal.component.html
@@ -9,7 +9,7 @@
     [attr.aria-describedby]="'lg-modal-body-' + id"
     aria-modal="true"
     tabindex="-1"
-    (click)="onModalClick($event)"
+    (mousedown)="onModalClick($event)"
     [lgFocus]="isOpen"
   >
     <lg-card-content>

--- a/projects/canopy/src/lib/modal/modal.component.ts
+++ b/projects/canopy/src/lib/modal/modal.component.ts
@@ -80,7 +80,10 @@ export class LgModalComponent implements OnInit, AfterContentInit, OnDestroy {
   // onOverlayClick and onModalClick add the following functionality:
   // clicking outside the modal closes the modal unless specified
   // otherwise using closeOnOverlayClick.
-  @HostListener('click') onOverlayClick(): void {
+  // We specifically listen to the `mousedown` event because with
+  // the `click` event a user could click inside the modal and
+  // drag the mouse on the overlay causing the modal to close.
+  @HostListener('mousedown') onOverlayClick(): void {
     this.modalService.close(this.id);
   }
 


### PR DESCRIPTION
# Description

Update code to use the `mousedown` event instead of the `click` so that if a user clicks inside the modal and
drags the mouse on the overlay the modal doesn't close.

Fixes #666

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
