### PR TITLE
Add option to co-brand the footer

### DIFF
--- a/projects/canopy/src/lib/footer/footer.component.html
+++ b/projects/canopy/src/lib/footer/footer.component.html
@@ -28,23 +28,44 @@
     <h2 class="lg-visually-hidden" id="secondary-links">Secondary links</h2>
     <ul class="lg-footer__secondary-nav-list">
       <li *ngFor="let link of secondaryLinks" class="lg-footer__secondary-nav-item">
-        <a
+        <button
+          *ngIf="link.type === 'button'; else linkItem"
           (click)="handleSecondaryLinkClick($event)"
           [attr.id]="link.id"
-          [attr.href]="link.href"
-          [attr.target]="link.target || '_blank'"
-          class="lg-footer__nav-link"
-          rel="noopener"
+          type="button"
+          class="lg-footer__nav-button"
+          [ngClass]="link.class"
           [innerHTML]="link.text"
-        >
-        </a>
+        ></button>
+
+        <ng-template #linkItem>
+          <a
+            (click)="handleSecondaryLinkClick($event)"
+            [attr.id]="link.id"
+            [attr.href]="link.href"
+            [attr.target]="link.target || '_blank'"
+            class="lg-footer__nav-link"
+            [ngClass]="link.class"
+            rel="noopener"
+            [innerHTML]="link.text"
+          >
+          </a>
+        </ng-template>
       </li>
     </ul>
   </nav>
 </div>
 
 <div class="lg-footer__org">
-  <img [attr.alt]="logoAlt" [attr.src]="logo" class="lg-footer__logo" *ngIf="logo" />
+  <div class="lg-footer__logos-wrapper">
+    <img [attr.alt]="logoAlt" [attr.src]="logo" class="lg-footer__logo" *ngIf="logo" />
+    <img
+      [attr.alt]="secondLogoAlt"
+      [attr.src]="secondLogo"
+      class="lg-footer__logo lg-footer__second-logo"
+      *ngIf="secondLogo"
+    />
+  </div>
   <span class="lg-footer__copyright">
     {{ copyright }}
   </span>

--- a/projects/canopy/src/lib/footer/footer.component.scss
+++ b/projects/canopy/src/lib/footer/footer.component.scss
@@ -6,14 +6,14 @@
   display: flex;
   flex-direction: column;
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     flex-direction: row;
     padding: var(--space-lg);
   }
 }
 
 .lg-footer__links {
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -25,7 +25,7 @@
 .lg-footer__primary-nav {
   margin-bottom: var(--component-margin);
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     margin-right: var(--space-xl);
   }
 }
@@ -34,7 +34,7 @@
   margin-bottom: var(--space-lg);
   margin-left: 0;
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     margin-top: var(--space-md);
     display: flex;
     flex-wrap: wrap;
@@ -49,7 +49,7 @@
     margin-bottom: 0;
   }
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     margin-top: var(--space-sm);
     margin-bottom: 0;
     flex: 0 0 50%;
@@ -60,7 +60,7 @@
   margin-bottom: var(--space-xxl);
   margin-left: 0;
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     margin-bottom: 0;
   }
 }
@@ -75,7 +75,7 @@
     margin-bottom: 0;
   }
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     display: inline-block;
     margin-right: var(--space-xs);
     margin-bottom: 0;
@@ -91,12 +91,33 @@
   }
 }
 
-.lg-footer__logo {
+.lg-footer__logos-wrapper {
+  display: flex;
+  align-items: center;
   margin-bottom: var(--component-margin);
-  height: var(--footer-logo-height);
+}
 
-  @include lg-breakpoint('md') {
-    height: var(--footer-logo-height-lg);
+.lg-footer__logo,
+.lg-footer__second-logo {
+  height: auto;
+  max-height: 100%;
+}
+
+.lg-footer__logo {
+  width: var(--footer-logo-width);
+
+  @include lg-breakpoint('lg') {
+    width: var(--footer-logo-width-lg);
+  }
+}
+
+.lg-footer__second-logo {
+  margin-left: var(--space-sm);
+  width: var(--footer-second-logo-width);
+
+  @include lg-breakpoint('lg') {
+    margin-left: var(--space-lg);
+    width: var(--footer-second-logo-width-lg);
   }
 }
 
@@ -105,13 +126,15 @@
 
   @include lg-font-size('-6');
 
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     text-align: right;
   }
 }
 
-.lg-footer__nav-link {
+.lg-footer__nav-link,
+.lg-footer__nav-button {
   @include lg-unstyled-link;
+
   text-decoration: none;
   color: var(--footer-text-color);
 
@@ -120,8 +143,14 @@
   }
 }
 
+.lg-footer__nav-button {
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
 .lg-footer__org {
-  @include lg-breakpoint('md') {
+  @include lg-breakpoint('lg') {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;

--- a/projects/canopy/src/lib/footer/footer.component.spec.ts
+++ b/projects/canopy/src/lib/footer/footer.component.spec.ts
@@ -16,6 +16,8 @@ describe('FooterComponent', () => {
   const text2 = 'test2';
   const href2 = 'https://b.c';
   const id2 = 'test-2';
+  const class2 = 'test-2-class';
+  const type = 'button';
 
   beforeEach(
     waitForAsync(() => {
@@ -43,7 +45,9 @@ describe('FooterComponent', () => {
     it('renders the logo when the property is set', () => {
       component.logo = logo;
       fixture.detectChanges();
-      const image = fixture.debugElement.query(By.css('img'));
+      const image = fixture.debugElement.query(
+        By.css('.lg-footer__logo:not(.lg-footer__second-logo)'),
+      );
       expect(image).toBeTruthy();
       expect(image.attributes.src).toBe(logo);
     });
@@ -51,14 +55,18 @@ describe('FooterComponent', () => {
     it('does not render a logo when the property is not set', () => {
       component.logo = null;
       fixture.detectChanges();
-      const image = fixture.debugElement.query(By.css('img'));
+      const image = fixture.debugElement.query(
+        By.css('.lg-footer__logo:not(.lg-footer__second-logo)'),
+      );
       expect(image).toBeFalsy();
     });
 
     it('adds a silent alt when there is a logo', () => {
       component.logo = logo;
       fixture.detectChanges();
-      const image = fixture.debugElement.query(By.css('img'));
+      const image = fixture.debugElement.query(
+        By.css('.lg-footer__logo:not(.lg-footer__second-logo)'),
+      );
       expect(image).toBeTruthy();
       expect(image.attributes.alt).toBe('');
     });
@@ -67,7 +75,43 @@ describe('FooterComponent', () => {
       component.logo = logo;
       component.logoAlt = logoAlt;
       fixture.detectChanges();
-      const image = fixture.debugElement.query(By.css('img'));
+      const image = fixture.debugElement.query(
+        By.css('.lg-footer__logo:not(.lg-footer__second-logo)'),
+      );
+      expect(image).toBeTruthy();
+      expect(image.attributes.alt).toBe(logoAlt);
+    });
+  });
+
+  describe('second logo', () => {
+    it('renders the logo when the property is set', () => {
+      component.secondLogo = logo;
+      fixture.detectChanges();
+      const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
+      expect(image).toBeTruthy();
+      expect(image.attributes.src).toBe(logo);
+    });
+
+    it('does not render a logo when the property is not set', () => {
+      component.secondLogo = null;
+      fixture.detectChanges();
+      const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
+      expect(image).toBeFalsy();
+    });
+
+    it('adds a silent alt when there is a logo', () => {
+      component.secondLogo = logo;
+      fixture.detectChanges();
+      const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
+      expect(image).toBeTruthy();
+      expect(image.attributes.alt).toBe('');
+    });
+
+    it('adds a standard alt when alt and logo are set', () => {
+      component.secondLogo = logo;
+      component.secondLogoAlt = logoAlt;
+      fixture.detectChanges();
+      const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
       expect(image).toBeTruthy();
       expect(image.attributes.alt).toBe(logoAlt);
     });
@@ -117,11 +161,22 @@ describe('FooterComponent', () => {
   });
 
   describe('for secondary links', () => {
-    it('renders', () => {
+    it('renders a link when no type is specified', () => {
       const link = fixture.debugElement.query(By.css(`[href="${href2}"]`));
       expect(link).toBeTruthy();
       expect(link.attributes.href).toBe(href2);
       expect(link.attributes.id).toBe(id2);
+      expect(link.attributes.class).toBe('lg-footer__nav-link');
+    });
+
+    it('renders a button when the type is specified', () => {
+      component.secondaryLinks[0].type = type;
+      component.secondaryLinks[0].class = class2;
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('button'));
+      expect(button).toBeTruthy();
+      expect(button.attributes.id).toBe(id2);
+      expect(button.properties.className).toBe(`lg-footer__nav-button ${class2}`);
     });
 
     it('does not throw an error when no links are provided', () => {

--- a/projects/canopy/src/lib/footer/footer.component.ts
+++ b/projects/canopy/src/lib/footer/footer.component.ts
@@ -7,7 +7,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { Link } from './footer.model';
+import { Link, SecondaryLink } from './footer.interface';
 
 @Component({
   selector: '[lg-footer]',
@@ -19,16 +19,14 @@ export class LgFooterComponent {
   @HostBinding('class.lg-footer') class = true;
   @HostBinding('attr.role') role = 'contentinfo';
 
-  @Output() primaryLinkClicked = new EventEmitter<any>();
-  @Output() secondaryLinkClicked = new EventEmitter<any>();
+  @Output() primaryLinkClicked = new EventEmitter<Event>();
+  @Output() secondaryLinkClicked = new EventEmitter<Event>();
 
   private _logo: string;
-
   @Input()
   get logo(): string | null {
     return this._logo;
   }
-
   set logo(logo) {
     this._logo = logo;
     if (!this.logoAlt) {
@@ -36,16 +34,29 @@ export class LgFooterComponent {
     }
   }
 
+  private _secondLogo: string;
+  @Input()
+  get secondLogo(): string | null {
+    return this._secondLogo;
+  }
+  set secondLogo(secondLogo) {
+    this._secondLogo = secondLogo;
+    if (!this.secondLogoAlt) {
+      this.secondLogoAlt = '';
+    }
+  }
+
   @Input() logoAlt: string | null;
+  @Input() secondLogoAlt: string | null;
   @Input() copyright: string;
   @Input() primaryLinks: Array<Link> | null;
-  @Input() secondaryLinks: Array<Link> | null;
+  @Input() secondaryLinks: Array<SecondaryLink> | null;
 
-  handlePrimaryLinkClick(event) {
+  handlePrimaryLinkClick(event: Event): void {
     this.primaryLinkClicked.emit(event);
   }
 
-  handleSecondaryLinkClick(event) {
+  handleSecondaryLinkClick(event: Event): void {
     this.secondaryLinkClicked.emit(event);
   }
 }

--- a/projects/canopy/src/lib/footer/footer.interface.ts
+++ b/projects/canopy/src/lib/footer/footer.interface.ts
@@ -4,3 +4,8 @@ export interface Link {
   id?: string;
   target?: string;
 }
+
+export interface SecondaryLink extends Link {
+  class?: string;
+  type?: 'button';
+}

--- a/projects/canopy/src/lib/footer/footer.notes.ts
+++ b/projects/canopy/src/lib/footer/footer.notes.ts
@@ -33,15 +33,27 @@ and in your HTML:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`logo\`\` | A url link to the logo | string | null | Yes |
-| \`\`logoAlt\`\` | alt text to display alongside the logo | string | '2rem' | Yes |
-| \`\`copyright\`\` | Copyright text to display in footer | string | null | No |
+| \`\`logoAlt\`\` | alt text to display alongside the logo | string | '' | Yes |
+| \`\`secondLogo\`\` | A url link to the second logo | string | null | No |
+| \`\`secondLogoAlt\`\` | alt text to display alongside the second logo | string | '' | No |
+| \`\`copyright\`\` | Copyright text to display in footer | string | undefined | No |
 | \`\`primaryLinks\`\` | The primary footer links | \`[{ text: string, href: string, id?: string, target?: string }]\` | null | No |
-| \`\`secondaryLinks\`\` | The secondary footer links | \`[{ text: string, href: string, id?: string, target?: string }]\` | null | No |
+| \`\`secondaryLinks\`\` | The secondary footer links | \`[{ text: string, href: string, id?: string, class?: string, target?: string, type?: 'button' }]\` | null | No |
 
 ## Outputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| \`\`primaryLinkClicked\`\` | Event emitted when a primary link is clicked | EventEmitter<any> | n/a | No |
-| \`\`secondaryLinkClicked\`\` | Event emitted when a secondary link is clicked | EventEmitter<any> | n/a | No |
+| \`\`primaryLinkClicked\`\` | Event emitted when a primary link is clicked | EventEmitter<Event> | n/a | No |
+| \`\`secondaryLinkClicked\`\` | Event emitted when a secondary link is clicked | EventEmitter<Event> | n/a | No |
+
+## Changing the width of the logos
+The width of the logos can be changed by overriding the values of the below css variables:
+
+~~~css
+--footer-logo-width
+--footer-logo-width-lg
+--footer-second-logo-width
+--footer-second-logo-width-lg
+~~~
 `;

--- a/projects/canopy/src/lib/footer/footer.stories.ts
+++ b/projects/canopy/src/lib/footer/footer.stories.ts
@@ -47,6 +47,12 @@ export const secondaryLinks = [
     text: 'Legal and regulatory',
     href: 'https://somecompany.com/legal',
   },
+  {
+    id: 'secondary-button-4',
+    text: 'Cookie settings',
+    type: 'button',
+    class: 'secondary-button-class',
+  },
 ];
 
 const groupId = 'footer';
@@ -85,6 +91,33 @@ export const compact = () => ({
   props: {
     copyright: text('copyright', '© Some Company plc 2018', groupId),
     secondaryLinks: object('secondaryLinks', secondaryLinks, groupId),
+    secondaryLinkClicked: action('secondaryLinkClicked'),
+  },
+});
+
+export const coBranded = () => ({
+  template: `
+    <footer lg-footer
+      [copyright]="copyright"
+      [logo]="logo"
+      [logoAlt]="logoAlt"
+      [secondLogo]="secondLogo"
+      [secondLogoAlt]="secondLogoAlt"
+      [primaryLinks]="primaryLinks"
+      [secondaryLinks]="secondaryLinks"
+      (primaryLinkClicked)="primaryLinkClicked($event)"
+      (secondaryLinkClicked)="secondaryLinkClicked($event)">
+    </footer>
+  `,
+  props: {
+    logo: text('logo', 'legal-and-general-logo.svg', groupId),
+    logoAlt: text('logoAlt', 'Company name', groupId),
+    secondLogo: text('secondLogo', 'dummy-logo.svg', groupId),
+    secondLogoAlt: text('secondLogoAlt', 'Second company name', groupId),
+    copyright: text('copyright', '© Some Company plc 2018', groupId),
+    secondaryLinks: object('secondaryLinks', secondaryLinks, groupId),
+    primaryLinks: object('primaryLinks', primaryLinks, groupId),
+    primaryLinkClicked: action('primaryLinkClicked'),
     secondaryLinkClicked: action('secondaryLinkClicked'),
   },
 });

--- a/projects/canopy/src/lib/footer/index.ts
+++ b/projects/canopy/src/lib/footer/index.ts
@@ -1,3 +1,3 @@
 export * from './footer.component';
 export * from './footer.module';
-export * from './footer.model';
+export * from './footer.interface';

--- a/projects/canopy/src/lib/header/header.component.html
+++ b/projects/canopy/src/lib/header/header.component.html
@@ -43,7 +43,6 @@
   <img
     [attr.alt]="img?.logoAlt"
     [attr.src]="img?.logo"
-    class="lg-header__logo"
     [ngClass]="{
       'lg-header__logo': !img?.isSecondLogo,
       'lg-header__second-logo': img?.isSecondLogo

--- a/projects/canopy/src/lib/modal/modal.module.ts
+++ b/projects/canopy/src/lib/modal/modal.module.ts
@@ -2,15 +2,13 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { A11yModule } from '@angular/cdk/a11y';
 
-import {
-  LgModalBodyComponent,
-  LgModalBodyTimerComponent,
-  LgModalComponent,
-  LgModalFooterComponent,
-  LgModalHeaderComponent,
-  LgModalService,
-  LgModalTriggerDirective,
-} from './';
+import { LgModalBodyComponent } from './modal-body/modal-body.component';
+import { LgModalBodyTimerComponent } from './modal-body-timer/modal-body-timer.component';
+import { LgModalComponent } from './modal.component';
+import { LgModalFooterComponent } from './modal-footer/modal-footer.component';
+import { LgModalService } from './modal.service';
+import { LgModalTriggerDirective } from './modal-trigger/modal-trigger.directive';
+import { LgModalHeaderComponent } from './modal-header/modal-header.component';
 import { LgSeparatorModule } from '../separator';
 import { lgIconClose, LgIconModule, LgIconRegistry } from '../icon';
 import { LgFocusModule } from '../focus';

--- a/projects/canopy/src/styles/variables/components/_footer.scss
+++ b/projects/canopy/src/styles/variables/components/_footer.scss
@@ -1,6 +1,8 @@
 :root {
-  --footer-logo-height: 4.5rem;
-  --footer-logo-height-lg: 7.25rem;
+  --footer-logo-width: 4.5rem;
+  --footer-logo-width-lg: 7.25rem;
+  --footer-second-logo-width: 4.5rem;
+  --footer-second-logo-width-lg: 7.25rem;
   --footer-bg-color: var(--color-white);
   --footer-text-color: var(--color-charcoal);
 }


### PR DESCRIPTION
# Description

Update the footer so that it can be co-branded.
Also add the option to have buttons in the secondary links. This is for scenarios where a user has to add the cookie preference functionality. 
In addition to that the interface for the secondary link now allows a `class` field because in our specific case the cookie popup doesn't work unless there is both the `id` and the `class` specified on the element.

Also rename `footer.model.ts` to be `footer.interface.ts` for consistency.

https://user-images.githubusercontent.com/8397116/148810911-fb56bbe5-0dc9-4f51-971b-161126bc6f75.mov

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
