### PR TITLE
fix(links): update focus hover style

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -57,10 +57,6 @@
     color: $focus-color;
     outline: 0.063rem solid $focus-bg-color;
     outline-offset: 0;
-
-    &:hover {
-      box-shadow: none;
-    }
   }
 }
 


### PR DESCRIPTION
# Description

This commit fixes a bug where if a link was focused. and hovered at the same time the focus outline would disappear.
I have tested around and the change doesn't seem to affect anything.

Before and after video:

https://user-images.githubusercontent.com/8397116/149113191-03a121e2-27f6-43b8-a0e3-7010c530eae5.mov


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
