### PR TITLE
Add blur output to radios and toggles

### DIFF
--- a/projects/canopy/src/lib/footer/footer.component.scss
+++ b/projects/canopy/src/lib/footer/footer.component.scss
@@ -140,6 +140,11 @@
 
   &:hover {
     text-decoration: underline;
+
+    &:focus:hover {
+      text-decoration: none;
+      @include lg-outer-focus-outline;
+    }
   }
 }
 

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts
@@ -15,8 +15,8 @@ import { notes } from './checkbox-group.notes';
       <lg-checkbox-group [inline]="inline" [focus]="focus" formControlName="colors">
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
-        <lg-toggle value="red">Red</lg-toggle>
-        <lg-toggle value="yellow">Yellow</lg-toggle>
+        <lg-toggle value="red" (blur)="checkboxBlur.emit($event)">Red</lg-toggle>
+        <lg-toggle value="yellow" (blur)="checkboxBlur.emit($event)">Yellow</lg-toggle>
       </lg-checkbox-group>
     </form>
   `,
@@ -39,6 +39,7 @@ class ReactiveFormComponent {
   }
 
   @Output() checkboxChange: EventEmitter<void> = new EventEmitter();
+  @Output() checkboxBlur: EventEmitter<Event> = new EventEmitter();
 
   form: FormGroup;
 
@@ -71,7 +72,8 @@ export const standard = () => ({
     [inline]="inline"
     [focus]="focus"
     [label]="label"
-    (checkboxChange)="checkboxChange($event)">
+    (checkboxChange)="checkboxChange($event)"
+    (checkboxBlur)="checkboxBlur($event)">
   </lg-reactive-form>
   `,
   props: {
@@ -79,6 +81,7 @@ export const standard = () => ({
     label: text('label', 'Color'),
     hint: text('hint', 'Please select all colors that apply'),
     checkboxChange: action('checkboxChange'),
+    checkboxBlur: action('checkboxBlur'),
     disabled: boolean('disabled', false),
     focus: boolean('focus', false),
   },

--- a/projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts
@@ -15,10 +15,10 @@ import { LgToggleModule } from '../toggle/toggle.module';
     <form [formGroup]="form">
       <lg-filter-multiple-group formControlName="colors">
         {{ label }}
-        <lg-toggle value="red">Red</lg-toggle>
-        <lg-toggle value="yellow">Yellow</lg-toggle>
-        <lg-toggle value="green">Green</lg-toggle>
-        <lg-toggle value="blue">Blue</lg-toggle>
+        <lg-toggle value="red" (blur)="checkboxBlur.emit($event)">Red</lg-toggle>
+        <lg-toggle value="yellow" (blur)="checkboxBlur.emit($event)">Yellow</lg-toggle>
+        <lg-toggle value="green" (blur)="checkboxBlur.emit($event)">Green</lg-toggle>
+        <lg-toggle value="blue" (blur)="checkboxBlur.emit($event)">Blue</lg-toggle>
       </lg-filter-multiple-group>
     </form>
   `,
@@ -38,6 +38,7 @@ class ReactiveFormComponent {
   }
 
   @Output() checkboxChange: EventEmitter<void> = new EventEmitter();
+  @Output() checkboxBlur: EventEmitter<Event> = new EventEmitter();
 
   form: FormGroup;
 
@@ -67,12 +68,14 @@ export const selectMultiple = () => ({
     <lg-reactive-form
     [disabled]="disabled"
     [label]="label"
-    (checkboxChange)="checkboxChange($event)">
+    (checkboxChange)="checkboxChange($event)"
+    (checkboxBlur)="checkboxBlur($event)">
   </lg-reactive-form>
   `,
   props: {
     label: text('label', 'Select colors'),
     checkboxChange: action('checkboxChange'),
+    checkboxBlur: action('checkboxBlur'),
     disabled: boolean('disabled', false),
   },
 });

--- a/projects/canopy/src/lib/forms/radio/filter.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/filter.stories.ts
@@ -14,10 +14,18 @@ import { LgRadioModule } from './radio.module';
     <form [formGroup]="form">
       <lg-filter-group formControlName="color">
         {{ label }}
-        <lg-filter-button value="red">Red</lg-filter-button>
-        <lg-filter-button value="yellow">Yellow</lg-filter-button>
-        <lg-filter-button value="green">Green</lg-filter-button>
-        <lg-filter-button value="blue">Blue</lg-filter-button>
+        <lg-filter-button value="red" (blur)="filterBlur.emit($event)"
+          >Red</lg-filter-button
+        >
+        <lg-filter-button value="yellow" (blur)="filterBlur.emit($event)"
+          >Yellow</lg-filter-button
+        >
+        <lg-filter-button value="green" (blur)="filterBlur.emit($event)"
+          >Green</lg-filter-button
+        >
+        <lg-filter-button value="blue" (blur)="filterBlur.emit($event)"
+          >Blue</lg-filter-button
+        >
       </lg-filter-group>
     </form>
   `,
@@ -37,6 +45,7 @@ class ReactiveFormFilterComponent {
   }
 
   @Output() filterChange: EventEmitter<void> = new EventEmitter();
+  @Output() filterBlur: EventEmitter<Event> = new EventEmitter();
 
   form: FormGroup;
 
@@ -67,12 +76,14 @@ export const selectOne = () => ({
     <lg-reactive-form-filter
     [disabled]="disabled"
     [label]="label"
-    (filterChange)="filterChange($event)">
+    (filterChange)="filterChange($event)"
+    (filterBlur)="filterBlur($event)">
   </lg-reactive-form-filter>
   `,
   props: {
     label: text('label', 'Select a color'),
     filterChange: action('filterChange'),
+    filterBlur: action('filterBlur'),
     disabled: boolean('disabled', false),
   },
 });

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.html
@@ -1,5 +1,6 @@
 <input
   (click)="onCheck()"
+  (blur)="onBlur($event)"
   [checked]="checked || null"
   [disabled]="disabled || null"
   [attr.id]="id"

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
@@ -9,7 +9,7 @@ import {
   Validators,
 } from '@angular/forms';
 
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
 import { MockComponents } from 'ng-mocks';
 
 import { LgErrorStateMatcher } from '../validation/error-state-matcher';
@@ -172,5 +172,11 @@ describe('LgRadioButtonComponent', () => {
     expect(inputDebugElement.nativeElement.getAttribute('aria-describedBy')).toContain(
       hintDebugElement.nativeElement.getAttribute('id'),
     );
+  });
+
+  it('should emit an event when #onBlur is called', () => {
+    const blurEmitterSpy = spy(component.blur);
+    component.onBlur(new Event(''));
+    verify(blurEmitterSpy.emit(anything())).once();
   });
 });

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ContentChild,
   ElementRef,
+  EventEmitter,
   forwardRef,
   Host,
   HostBinding,
@@ -9,6 +10,7 @@ import {
   Input,
   OnInit,
   Optional,
+  Output,
   Renderer2,
   Self,
   SkipSelf,
@@ -81,6 +83,8 @@ export class LgRadioButtonComponent implements OnInit {
     this._disabled = isDisabled;
   }
 
+  @Output() blur: EventEmitter<Event> = new EventEmitter<Event>();
+
   @HostBinding('class.lg-radio-button') class = true;
   @HostBinding('class.lg-radio-button--error')
   public get errorClass() {
@@ -113,7 +117,7 @@ export class LgRadioButtonComponent implements OnInit {
     private domService: LgDomService,
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.variant = this.radioGroup.variant;
     if (this.radioGroup.value === this.value) {
       this.checked = true;
@@ -121,10 +125,14 @@ export class LgRadioButtonComponent implements OnInit {
     this.name = this.radioGroup.name;
   }
 
-  onCheck() {
+  onCheck(): void {
     this.radioGroup.onTouched();
     if (this.radioGroup.value !== this.value) {
       this.radioGroup.value = this.value;
     }
+  }
+
+  onBlur(event: Event): void {
+    this.blur.emit(event);
   }
 }

--- a/projects/canopy/src/lib/forms/radio/radio.notes.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.notes.ts
@@ -61,9 +61,18 @@ ${
 }
 
 ### LgRadioButtonComponent
+
+#### Inputs
+
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\${++nextUniqueId}' | No |
 | \`\`name\`\` | HTML name attribute | string | null | Yes |
 | \`\`value\`\` | HTML value attribute | string | null | Yes |
+
+#### Outputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| \`\`blur\`\` | Event emitted on blur of a radio button | EventEmitter<Event> | n/a | No |
 `;

--- a/projects/canopy/src/lib/forms/radio/radio.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.stories.ts
@@ -16,8 +16,8 @@ import { LgHintModule } from '../hint/hint.module';
       <lg-radio-group [inline]="inline" formControlName="color">
         {{ label }}
         <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
-        <lg-radio-button value="red">Red</lg-radio-button>
-        <lg-radio-button value="yellow"
+        <lg-radio-button value="red" (blur)="radioBlur.emit($event)">Red</lg-radio-button>
+        <lg-radio-button value="yellow" (blur)="radioBlur.emit($event)"
           >Yellow
           <lg-hint>Internal custom text</lg-hint>
         </lg-radio-button>
@@ -42,6 +42,7 @@ class ReactiveFormRadioComponent {
   }
 
   @Output() radioChange: EventEmitter<void> = new EventEmitter();
+  @Output() radioBlur: EventEmitter<Event> = new EventEmitter();
 
   form: FormGroup;
 
@@ -74,7 +75,8 @@ export const standard = () => ({
     [hint]="hint"
     [inline]="inline"
     [label]="label"
-    (radioChange)="radioChange($event)">
+    (radioChange)="radioChange($event)"
+    (radioBlur)="radioBlur($event)">
   </lg-reactive-form-radio>
   `,
   props: {
@@ -82,6 +84,7 @@ export const standard = () => ({
     label: text('label', 'Color'),
     hint: text('hint', 'Please select a color'),
     radioChange: action('radioChange'),
+    radioBlur: action('radioBlur'),
     disabled: boolean('disabled', false),
   },
 });

--- a/projects/canopy/src/lib/forms/radio/segment.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/segment.stories.ts
@@ -15,10 +15,18 @@ import type { RadioStackBreakpoint } from './radio.interface';
     <form [formGroup]="form">
       <lg-segment-group formControlName="color" [stack]="stack" [focus]="focus">
         {{ label }} {{ itemsInSegment }}
-        <lg-segment-button value="red">Red</lg-segment-button>
-        <lg-segment-button value="yellow">{{ secondButtonLabel }}</lg-segment-button>
-        <lg-segment-button value="green">Green</lg-segment-button>
-        <lg-segment-button value="blue">Blue</lg-segment-button>
+        <lg-segment-button value="red" (blur)="segmentBlur.emit($event)"
+          >Red</lg-segment-button
+        >
+        <lg-segment-button value="yellow" (blur)="segmentBlur.emit($event)">{{
+          secondButtonLabel
+        }}</lg-segment-button>
+        <lg-segment-button value="green" (blur)="segmentBlur.emit($event)"
+          >Green</lg-segment-button
+        >
+        <lg-segment-button value="blue" (blur)="segmentBlur.emit($event)"
+          >Blue</lg-segment-button
+        >
       </lg-segment-group>
     </form>
   `,
@@ -41,6 +49,7 @@ class ReactiveFormSegmentComponent {
   }
 
   @Output() segmentChange: EventEmitter<void> = new EventEmitter();
+  @Output() segmentBlur: EventEmitter<Event> = new EventEmitter();
 
   form: FormGroup;
 
@@ -74,13 +83,15 @@ export const standard = () => ({
     [focus]="focus"
     [label]="label"
     [secondButtonLabel]="secondButtonLabel"
-    (segmentChange)="segmentChange($event)">
+    (segmentChange)="segmentChange($event)"
+    (segmentBlur)="segmentBlur($event)">
   </lg-reactive-form-segment>
   `,
   props: {
     label: text('label', 'Select a color'),
     secondButtonLabel: text('secondButtonLabel', 'Yellow'),
     segmentChange: action('segmentChange'),
+    segmentBlur: action('segmentBlur'),
     disabled: boolean('disabled', false),
     focus: boolean('focus', false),
     stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.html
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.html
@@ -1,5 +1,6 @@
 <input
   (click)="onCheck()"
+  (blur)="onBlur($event)"
   [attr.aria-describedby]="ariaDescribedBy || null"
   [checked]="checked || null"
   [disabled]="disabled || null"

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
@@ -29,6 +29,7 @@ const validationTestId = 'test-validation-id';
         formControlName="umbrella"
         [value]="true"
         (change)="onChange()"
+        (blur)="onBlur($event)"
         [variant]="variant"
       >
         I will bring my Umbrella if it is raining
@@ -68,7 +69,12 @@ class TestToggleComponent {
 @Component({
   template: `
     <form (ngSubmit)="login()" [formGroup]="form" #testForm="ngForm">
-      <lg-switch formControlName="umbrella" [value]="true" (change)="onChange()">
+      <lg-switch
+        formControlName="umbrella"
+        [value]="true"
+        (change)="onChange()"
+        (blur)="onBlur($event)"
+      >
         I will bring my Umbrella if it is raining
         <lg-validation
           id="${validationTestId}"
@@ -207,6 +213,12 @@ describe('LgToggleComponent', () => {
     const onChangeSpy = spyOn(toggleInstance, 'onChange');
     inputDebugElement.triggerEventHandler('click', null);
     expect(onChangeSpy).toHaveBeenCalled();
+  });
+
+  it('triggers the onBlur action when the toggle is blurred', () => {
+    const onBlurSpy = spyOn(toggleInstance, 'onBlur');
+    inputDebugElement.triggerEventHandler('blur', null);
+    expect(onBlurSpy).toHaveBeenCalledTimes(1);
   });
 
   it('disables the input field when the property is set', () => {

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ContentChild,
   ElementRef,
+  EventEmitter,
   forwardRef,
   Host,
   HostBinding,
@@ -9,6 +10,7 @@ import {
   Input,
   OnInit,
   Optional,
+  Output,
   Self,
   SkipSelf,
   ViewChild,
@@ -54,6 +56,8 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     this._disabled = isDisabled;
   }
 
+  @Output() blur: EventEmitter<Event> = new EventEmitter<Event>();
+
   @HostBinding('class.lg-toggle') class = true;
   @HostBinding('class.lg-toggle--error') get errorClass() {
     return this.errorState.isControlInvalid(this.control, this.controlContainer);
@@ -72,7 +76,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     this._validationElement = element;
   }
 
-  onCheck() {
+  onCheck(): void {
     if (this.checkboxGroup) {
       this.checkboxGroup.onTouched();
       if (this.checkboxGroup.value.includes(this.value.toString())) {
@@ -90,13 +94,17 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     this.onChange(this.checked ? this.value : null);
   }
 
-  public onChange(value: boolean | string) {
+  onBlur(event: Event): void {
+    this.blur.emit(event);
+  }
+
+  public onChange(value: boolean | string): void {
     this.value = value;
   }
 
-  public onTouched(_?: any) {}
+  public onTouched(_?: any): void {}
 
-  public writeValue(value: any) {
+  public writeValue(value: any): void {
     if (value === this.value) {
       this.checked = true;
     }
@@ -110,7 +118,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     this.onTouched = fn;
   }
 
-  public setDisabledState(isDisabled: boolean) {
+  public setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
   }
 

--- a/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
@@ -26,14 +26,9 @@ or
 <lg-${name.toLowerCase()} formControlName="confirm" value="yes">Do you agree?</lg-${name.toLowerCase()}>
 ~~~
 
-## Inputs
+## Outputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| \`\`checked\`\` | Check status of the toggle | boolean | false | No |
-| \`\`value\`\` | Value that is set when the toggle is checked | boolean or string | 'on' | No |
-| \`\`id\`\` | HTML ID attribute, auto generated if not provided | string | 'lg-toggle-\${nextUniqueId++}' | No |
-| \`\`name\`\` | HTML Name attribute, auto generated if not provided | string | 'lg-toggle-\${nextUniqueId++}' | No |
-| \`\`variant\`\` | The variant of the toggle | 'checkbox', 'switch' or 'filter' | 'checkbox | No |
-| \`\`focus\`\` | Set the focus on the input field | boolean | null | No |
+| \`\`blur\`\` | Event emitted on blur of a toggle | EventEmitter<Event> | n/a | No |
 `;

--- a/projects/canopy/src/lib/forms/toggle/toggle.stories.common.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.stories.common.ts
@@ -23,6 +23,7 @@ import type { ToggleVariant } from './toggle.interface';
         [variant]="variant"
         [checked]="umbrella.value"
         [focus]="focus"
+        (blur)="toggleBlur.emit($event)"
       >
         {{ label }}
       </lg-toggle>
@@ -52,6 +53,7 @@ export class ReactiveToggleFormComponent implements OnChanges {
   }
 
   @Output() toggleChange: EventEmitter<void> = new EventEmitter();
+  @Output() toggleBlur: EventEmitter<Event> = new EventEmitter();
 
   form: FormGroup;
 
@@ -77,10 +79,12 @@ export const createToggleStory = (variant: string) => ({
     variant="${variant}"
     [checked]="checked"
     [focus]="focus"
+    (toggleBlur)="toggleBlur($event)"
     (toggleChange)="toggleChange($event)">
   </lg-reactive-form>`,
   props: {
     toggleChange: action('toggleChange'),
+    toggleBlur: action('toggleBlur'),
     label: text('label', 'I will bring my Umbrella if it is raining'),
     disabled: boolean('disabled', false),
     checked: boolean('reactively checked', false),

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -57,6 +57,10 @@
     color: $focus-color;
     outline: 0.063rem solid $focus-bg-color;
     outline-offset: 0;
+
+    &:hover {
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
# Description

This PR:
- reverts the commit with a "fix" for the focused hover state (this actually broke the state for some other links)
- adds specific focused hover state to the footer links
- add a blur output to the radios and toggles

## Links
### Before

https://user-images.githubusercontent.com/8397116/149518393-d36991b7-8c4b-46de-a3ab-dfaf1bdf5a15.mov

### After

https://user-images.githubusercontent.com/8397116/149518435-08558684-17c8-424e-88bf-b8aac86a0548.mov

## Blur events

https://user-images.githubusercontent.com/8397116/149518464-15fc423c-3369-47e3-81b3-c02980e8dbb9.mov

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
