### PR TITLE
fix(carousel): carousel scroll behaviour when interacted with cta

### DIFF
--- a/projects/canopy/src/lib/carousel/carousel.component.spec.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.spec.ts
@@ -92,6 +92,26 @@ describe('LgCarouselComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should set the pause to true when pauseCarousel is invoked', fakeAsync(() => {
+    component.pauseCarousel();
+    fixture.detectChanges();
+
+    component.pause.subscribe((pause) => {
+      expect(pause).toBeDefined();
+      expect(pause).toBeTruthy();
+    });
+  }));
+
+  it('should set the pause to false when playCarousel is invoked', fakeAsync(() => {
+    component.playCarousel();
+    fixture.detectChanges();
+
+    component.pause.subscribe((pause) => {
+      expect(pause).toBeDefined();
+      expect(pause).toBeFalsy();
+    });
+  }));
+
   it('should detect the amount of carousel item components are nested in order to build the navigation and apply styles to the carousel wrapper', () => {
     const wrapperElement = fixture.debugElement.query(By.css('.lg-carousel__wrapper'));
     expect(component.carouselItemCount).toBe(3);

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -41,6 +41,14 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   pause = new BehaviorSubject<boolean>(false);
   pausableTimer$: Observable<void>;
 
+  pauseCarousel(): void {
+    this.pause.next(true);
+  }
+
+  playCarousel(): void {
+    this.pause.next(false);
+  }
+
   selectCarouselItem(index: number): void {
     this.selectedItemIndex = index;
     this.selectedItem = this.carouselItems.get(index);

--- a/projects/canopy/src/lib/carousel/carousel.notes.ts
+++ b/projects/canopy/src/lib/carousel/carousel.notes.ts
@@ -42,5 +42,5 @@ and in your HTML:
 | \`\`autoPlay\`\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |
 | \`\`autoPlayDelay\`\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |
 
-## PlayCarousel and PauseCarousel methods can be exposed by targeting the Carousel with ViewChild decorators to fix the accessibility issues.
+## PlayCarousel and PauseCarousel methods can be exposed by targeting the Carousel with ViewChild decorators.
 `;

--- a/projects/canopy/src/lib/carousel/carousel.notes.ts
+++ b/projects/canopy/src/lib/carousel/carousel.notes.ts
@@ -42,5 +42,5 @@ and in your HTML:
 | \`\`autoPlay\`\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |
 | \`\`autoPlayDelay\`\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |
 
-## PlayCarousel and PauseCarousel methods can be exposed by targeting the Carousel with ViewChild decorators.
+PlayCarousel and PauseCarousel methods can be exposed by targeting the Carousel with ViewChild decorators.
 `;

--- a/projects/canopy/src/lib/carousel/carousel.notes.ts
+++ b/projects/canopy/src/lib/carousel/carousel.notes.ts
@@ -41,4 +41,6 @@ and in your HTML:
 | \`\`headingLevel\`\`  | The heading level of the description: \`\`1\`\`, \`\`2\`\`, \`\`3\`\`, \`\`4\`\`, \`\`5\`\`, \`\`6\`\`   | number  | undefined |   Yes    |
 | \`\`autoPlay\`\`      | Enables auto play mode when set to true.                                                                 | boolean |   false   |   No     |
 | \`\`autoPlayDelay\`\` | Delay time in milliseconds to switch to next slide when autoPlay mode is set to true.                    | number  |   2000    |   No     |
+
+## PlayCarousel and PauseCarousel methods can be exposed by targeting the Carousel with ViewChild decorators to fix the accessibility issues.
 `;

--- a/projects/canopy/src/lib/carousel/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/carousel.stories.ts
@@ -28,7 +28,6 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  <button> Button1 </button>
   </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
@@ -36,7 +35,6 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  <button> Button2 </button>
   </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #028844; color: #FFFFFF">
@@ -44,7 +42,6 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  <button> Button3 </button>
 </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
@@ -59,7 +56,6 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  <button> Button4 </button>
   </lg-carousel-item>
 `;
 

--- a/projects/canopy/src/lib/carousel/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/carousel.stories.ts
@@ -28,14 +28,14 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  </lg-carousel-item>
+</lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
   <h3>Carousel item 2</h3>
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  </lg-carousel-item>
+</lg-carousel-item>
 
 <lg-carousel-item style="background-color: #028844; color: #FFFFFF">
   <h3>Carousel item 3</h3>
@@ -56,7 +56,7 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-  </lg-carousel-item>
+</lg-carousel-item>
 `;
 
 function props() {

--- a/projects/canopy/src/lib/carousel/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/carousel.stories.ts
@@ -28,20 +28,23 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-</lg-carousel-item>
+  <button> Button1 </button>
+  </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
   <h3>Carousel item 2</h3>
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-</lg-carousel-item>
+  <button> Button2 </button>
+  </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #028844; color: #FFFFFF">
   <h3>Carousel item 3</h3>
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
+  <button> Button3 </button>
 </lg-carousel-item>
 
 <lg-carousel-item style="background-color: #0076D6; color: #FFFFFF">
@@ -56,7 +59,8 @@ const carouselItems = `
   <p>Carousel items scale vertically to the largest item in the carousel and scale horizontally to the width of the parent container.</p>
   <p>Carousels are built to work with varied content sizes but will work best if the content of each carousel item is of a similar size</p>
   <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit maiores, dolor suscipit ullam omnis corrupti laboriosam, amet, rem fugiat id deleniti ipsum possimus. At assumenda, asperiores dolorem temporibus quaerat libero quos blanditiis quod in? Magni laborum tempora, laudantium facilis ut sunt totam beatae repellat doloribus blanditiis sed repellendus maiores necessitatibus iste ex quod voluptate? Nesciunt, libero officiis labore molestias enim doloribus id assumenda dicta numquam fuga velit reiciendis quae praesentium soluta eaque exercitationem? Ullam iste culpa accusantium tenetur repellendus sit sunt error nisi dicta deleniti cum amet, voluptates soluta et laudantium quis.</p>
-</lg-carousel-item>
+  <button> Button4 </button>
+  </lg-carousel-item>
 `;
 
 function props() {


### PR DESCRIPTION
# Description
Stop carousel when any button inside carousel item has been clicked and fix broken view on tab
switch

If a CTA on one of the advertising tiles has focus, and the animation / scrolling is on, it breaks.
Tabbing between the controls on the ads DCI-17572

Fixes #622 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
