### PR TITLE
fix(tabs): remove heading from tab component to fix a11y issue

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -90,7 +90,7 @@
       <div lgCol="12" lgColLg="9" lgColMdOffset="0">
         <lg-card lgPaddingTop="none">
           <lg-card-content>
-            <lg-tabs [headingLevel]="2" label="Annuities">
+            <lg-tabs label="Annuities">
               <lg-tab-item>
                 <lg-tab-item-heading>Tab 1</lg-tab-item-heading>
                 <lg-tab-item-content>

--- a/projects/canopy/src/lib/tabs/tabs.component.html
+++ b/projects/canopy/src/lib/tabs/tabs.component.html
@@ -1,30 +1,26 @@
 <div class="lg-tabs__list" role="tablist" [attr.aria-label]="label">
-  <lg-heading
-    class="lg-tabs__list-item-heading"
+  <button
     *ngFor="let tab of tabs; let index = index"
-    [level]="headingLevel"
+    class="lg-tabs__list-item-toggle"
+    [ngClass]="{
+      'lg-tabs__list-item-toggle--selected': selectedIndex === index
+    }"
+    role="tab"
+    [lgFocus]="isKeyboardEvent && selectedIndex === index"
+    [attr.tabIndex]="index !== selectedIndex ? '-1' : 0"
+    [attr.aria-selected]="index === selectedIndex"
+    [attr.aria-controls]="'tab-item-content-' + id + '-' + index"
+    [attr.keyboard-focus]="(isKeyboardEvent && selectedIndex === index) || null"
+    [id]="'tab-item-heading-' + id + '-' + index"
+    (click)="navigateToTab(index)"
+    (blur)="blur(index)"
+    (keyup)="keyboardNavigation($event)"
   >
-    <button
-      class="lg-tabs__list-item-toggle"
-      [ngClass]="{
-        'lg-tabs__list-item-toggle--selected': selectedIndex === index
-      }"
-      role="tab"
-      [lgFocus]="isKeyboardEvent && selectedIndex === index"
-      [attr.tabIndex]="index !== selectedIndex ? '-1' : null"
-      [attr.aria-selected]="index === selectedIndex"
-      [attr.aria-controls]="'tab-item-content-' + id + '-' + index"
-      [attr.keyboard-focus]="(isKeyboardEvent && selectedIndex === index) || null"
-      [id]="'tab-item-heading-' + id + '-' + index"
-      (click)="navigateToTab(index)"
-      (blur)="blur(index)"
-      (keyup)="keyboardNavigation($event)"
-    >
+    <span class="lg-tabs__list-item-heading">
       <ng-container *ngTemplateOutlet="tab.navItemTemplate"></ng-container>
-    </button>
-  </lg-heading>
+    </span>
+  </button>
 </div>
-
 <div
   *ngFor="let tab of tabs; let index = index"
   class="lg-tabs__content"

--- a/projects/canopy/src/lib/tabs/tabs.component.spec.ts
+++ b/projects/canopy/src/lib/tabs/tabs.component.spec.ts
@@ -43,7 +43,7 @@ describe('LgTabsComponent', () => {
 
   beforeEach(() => {
     fixture = MockRender(`
-      <lg-tabs [headingLevel]="1">
+      <lg-tabs>
         <lg-tab-item>
           <lg-tab-item-heading>Heading 1</lg-tab-item-heading>
             <lg-tab-item-content>
@@ -113,7 +113,7 @@ describe('LgTabsComponent', () => {
   describe('when label is investments', () => {
     beforeEach(() => {
       fixture = MockRender(`
-        <lg-tabs [headingLevel]="1" label="investments">
+        <lg-tabs label="investments">
           <lg-tab-item></lg-tab-item>
         </lg-tabs>
       `);
@@ -135,7 +135,7 @@ describe('LgTabsComponent', () => {
   describe('when are 3 tab items', () => {
     beforeEach(() => {
       fixture = MockRender(`
-        <lg-tabs [headingLevel]="1">
+        <lg-tabs>
           <lg-tab-item>
             <lg-tab-item-heading>Heading 1</lg-tab-item-heading>
             <lg-tab-item-content>Content 1</lg-tab-item-content>

--- a/projects/canopy/src/lib/tabs/tabs.component.ts
+++ b/projects/canopy/src/lib/tabs/tabs.component.ts
@@ -16,7 +16,6 @@ import {
 
 import { Subscription } from 'rxjs';
 
-import type { HeadingLevel } from '../heading/heading.interface';
 import { isKeyDown, isKeyLeft, isKeyRight, isKeyUp } from '../utils/keyboard-keys';
 import { LgTabItemComponent } from './tab-item/tab-item.component';
 
@@ -38,8 +37,6 @@ export class LgTabsComponent implements AfterContentInit, OnDestroy {
   tabQueryList: QueryList<LgTabItemComponent>;
 
   @Input() label = 'tabs';
-
-  @Input() headingLevel: HeadingLevel;
 
   @Output() tabEvent: EventEmitter<{ index: number }> = new EventEmitter();
 

--- a/projects/canopy/src/lib/tabs/tabs.notes.ts
+++ b/projects/canopy/src/lib/tabs/tabs.notes.ts
@@ -16,7 +16,7 @@ The tabs component lets users navigate between related sections of content, disp
 and in your HTML:
 
 ~~~html
-<lg-tabs [headingLevel]="1" label="Title" (tabEvent)="tabEvent($event)">
+<lg-tabs label="Title" (tabEvent)="tabEvent($event)">
   <lg-tab-item>
     <lg-tab-item-heading>Tab 1</lg-tab-item-heading>
     <lg-tab-item-content>
@@ -58,7 +58,6 @@ and in your HTML:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`label\`\` | The value to apply to the aria label | string | tabs | Yes |
-| \`\`headingLevel\`\` | The level of the tab headings: \`\`1\`\`, \`\`2\`\`, \`\`3\`\`, \`\`4\`\`, \`\`5\`\`, \`\`6\`\` | number | n/a | Yes |
 
 ## Outputs
 

--- a/projects/canopy/src/lib/tabs/tabs.stories.ts
+++ b/projects/canopy/src/lib/tabs/tabs.stories.ts
@@ -23,7 +23,7 @@ export default {
 
 export const standard = () => ({
   template: `
-  <lg-tabs [headingLevel]="headingLevel"
+  <lg-tabs 
     label="Annuities"
     (tabEvent)="tabEvent($event)"
     [lgMarginRight]="'none'"


### PR DESCRIPTION
# Description

Fix accessibility bug described in issue #676. 
The team has decided to introduce a breaking change and remove the heading from the tab system
as unnecessary.

Fix: #676

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
