### PR TITLE
fix(carousel): carousel focus fix

### DIFF
--- a/projects/canopy/src/lib/carousel/auto-play/auto-play.component.scss
+++ b/projects/canopy/src/lib/carousel/auto-play/auto-play.component.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/mixins.scss';
+
 .lg-carousel-autoplay {
   position: absolute;
   right: var(--space-sm);
@@ -12,5 +14,9 @@
     height: var(--space-xxl);
     font-size: var(--text-fs-3-size);
     cursor: pointer;
+
+    &:focus {
+      @include lg-outer-focus-outline(var(--default-focus-color));
+    }
   }
 }

--- a/projects/canopy/src/lib/carousel/carousel.component.spec.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.spec.ts
@@ -9,6 +9,7 @@ import {
 import { By } from '@angular/platform-browser';
 
 import { MockComponents } from 'ng-mocks';
+import { Subscription } from 'rxjs';
 
 import { HeadingLevel, LgHeadingComponent } from '../heading';
 import { LgIconComponent } from '../icon';
@@ -56,6 +57,7 @@ class TestWrapperComponent {}
 describe('LgCarouselComponent', () => {
   let component: LgCarouselComponent;
   let fixture: ComponentFixture<TestWrapperComponent>;
+  let subscription: Subscription;
 
   const timerSelectionCheck = () => {
     component.ngAfterContentInit();
@@ -86,6 +88,10 @@ describe('LgCarouselComponent', () => {
     fixture = TestBed.createComponent(TestWrapperComponent);
     component = fixture.debugElement.children[0].children[0].componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
   });
 
   it('should create', () => {
@@ -144,9 +150,11 @@ describe('LgCarouselComponent', () => {
     });
 
     it('should select the chosen carousel item as expected', () => {
-      expect(component.selectedItemIndex).toBe(0);
-      bullet2.nativeElement.click();
-      expect(component.selectedItemIndex).toBe(1);
+      subscription = component.selectedItemIndexSet$.subscribe((selectedItem) => {
+        expect(component.selectedItemIndex).toBe(selectedItem);
+        bullet2.nativeElement.click();
+        expect(component.selectedItemIndex).toBe(1);
+      });
 
       fixture.detectChanges();
       expect(
@@ -155,6 +163,9 @@ describe('LgCarouselComponent', () => {
     });
 
     it('should navigate to the previous slide as expected', () => {
+      subscription = component.selectedItemIndexSet$.subscribe((selectedItem) => {
+        expect(component.selectedItemIndex).toBe(selectedItem);
+      });
       expect(component.selectedItemIndex).toBe(0);
       bullet2.nativeElement.click();
       fixture.detectChanges();
@@ -169,6 +180,9 @@ describe('LgCarouselComponent', () => {
     });
 
     it('should navigate to the next slide as expected', () => {
+      subscription = component.selectedItemIndexSet$.subscribe((selectedItem) => {
+        expect(component.selectedItemIndex).toBe(selectedItem);
+      });
       expect(component.selectedItemIndex).toBe(0);
       nextButton.nativeElement.click();
       expect(component.selectedItemIndex).toBe(1);

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -35,6 +35,7 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   carouselItems = new QueryList<LgCarouselItemComponent>();
   selectedItem: LgCarouselItemComponent;
   carouselItemCount: number;
+  selectedItemIndexSet$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
   selectedItemIndex: number;
   selectedItemContent: string;
   private unsubscribe: Subject<void> = new Subject<void>();
@@ -50,7 +51,7 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   }
 
   selectCarouselItem(index: number): void {
-    this.selectedItemIndex = index;
+    this.selectedItemIndexSet$.next(index);
     this.selectedItem = this.carouselItems.get(index);
     this.selectedItemContent = this.selectedItem.itemContent;
 
@@ -91,6 +92,11 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   }
 
   ngAfterContentInit(): void {
+    this.selectedItemIndexSet$
+      .pipe(takeUntil(this.unsubscribe))
+      .subscribe((itemIndex) => {
+        this.selectedItemIndex = itemIndex;
+      });
     this.carouselItemCount = this.carouselItems.length;
     this.selectCarouselItem(0);
     if (this.autoPlay) {


### PR DESCRIPTION
keyboard focus carousel fix

# Description
Stop carousel when any button inside carousel item has been clicked and fix broken view on tab
switch
If a CTA on one of the advertising tiles has focus, and the animation / scrolling is on, it breaks.
Tabbing between the controls on the ads DCI-17572

selectedItemIndexSet set to BehaviourSubject so that selectedItemIndexSet$ be exposed by targeting the Carousel with ViewChild decorators.
Advertising Carousel scroll behaviour when CTA is interacted with or has focus.

Fixes # (issue)
DCI-18540, DCI-17572

## Requirements

<img width="411" alt="Screenshot 2022-01-31 at 16 23 09" src="https://user-images.githubusercontent.com/25201625/151832154-0c01d0e7-3c46-40f5-b219-cb6526dd630f.png">
<img width="411" alt="Screenshot 2022-01-31 at 16 22 54" src="https://user-images.githubusercontent.com/25201625/151832152-e9204484-57a2-484b-a822-08732b89bcad.png">


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [x] I have added any new public feature modules to public-api.ts
