### PR TITLE
Update input name for secondary logo in header and footer

### DIFF
--- a/projects/canopy/src/lib/footer/footer.component.html
+++ b/projects/canopy/src/lib/footer/footer.component.html
@@ -60,10 +60,10 @@
   <div class="lg-footer__logos-wrapper">
     <img [attr.alt]="logoAlt" [attr.src]="logo" class="lg-footer__logo" *ngIf="logo" />
     <img
-      [attr.alt]="secondLogoAlt"
-      [attr.src]="secondLogo"
+      [attr.alt]="secondaryLogoAlt"
+      [attr.src]="secondaryLogo"
       class="lg-footer__logo lg-footer__second-logo"
-      *ngIf="secondLogo"
+      *ngIf="secondaryLogo"
     />
   </div>
   <span class="lg-footer__copyright">

--- a/projects/canopy/src/lib/footer/footer.component.spec.ts
+++ b/projects/canopy/src/lib/footer/footer.component.spec.ts
@@ -83,9 +83,9 @@ describe('FooterComponent', () => {
     });
   });
 
-  describe('second logo', () => {
+  describe('secondary logo', () => {
     it('renders the logo when the property is set', () => {
-      component.secondLogo = logo;
+      component.secondaryLogo = logo;
       fixture.detectChanges();
       const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
       expect(image).toBeTruthy();
@@ -93,14 +93,14 @@ describe('FooterComponent', () => {
     });
 
     it('does not render a logo when the property is not set', () => {
-      component.secondLogo = null;
+      component.secondaryLogo = null;
       fixture.detectChanges();
       const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
       expect(image).toBeFalsy();
     });
 
     it('adds a silent alt when there is a logo', () => {
-      component.secondLogo = logo;
+      component.secondaryLogo = logo;
       fixture.detectChanges();
       const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
       expect(image).toBeTruthy();
@@ -108,8 +108,8 @@ describe('FooterComponent', () => {
     });
 
     it('adds a standard alt when alt and logo are set', () => {
-      component.secondLogo = logo;
-      component.secondLogoAlt = logoAlt;
+      component.secondaryLogo = logo;
+      component.secondaryLogoAlt = logoAlt;
       fixture.detectChanges();
       const image = fixture.debugElement.query(By.css('.lg-footer__second-logo'));
       expect(image).toBeTruthy();

--- a/projects/canopy/src/lib/footer/footer.component.ts
+++ b/projects/canopy/src/lib/footer/footer.component.ts
@@ -34,20 +34,20 @@ export class LgFooterComponent {
     }
   }
 
-  private _secondLogo: string;
+  private _secondaryLogo: string;
   @Input()
-  get secondLogo(): string | null {
-    return this._secondLogo;
+  get secondaryLogo(): string | null {
+    return this._secondaryLogo;
   }
-  set secondLogo(secondLogo) {
-    this._secondLogo = secondLogo;
-    if (!this.secondLogoAlt) {
-      this.secondLogoAlt = '';
+  set secondaryLogo(secondaryLogo) {
+    this._secondaryLogo = secondaryLogo;
+    if (!this.secondaryLogoAlt) {
+      this.secondaryLogoAlt = '';
     }
   }
 
   @Input() logoAlt: string | null;
-  @Input() secondLogoAlt: string | null;
+  @Input() secondaryLogoAlt: string | null;
   @Input() copyright: string;
   @Input() primaryLinks: Array<Link> | null;
   @Input() secondaryLinks: Array<SecondaryLink> | null;

--- a/projects/canopy/src/lib/footer/footer.notes.ts
+++ b/projects/canopy/src/lib/footer/footer.notes.ts
@@ -34,8 +34,8 @@ and in your HTML:
 |------|-------------|:----:|:-----:|:-----:|
 | \`\`logo\`\` | A url link to the logo | string | null | Yes |
 | \`\`logoAlt\`\` | alt text to display alongside the logo | string | '' | Yes |
-| \`\`secondLogo\`\` | A url link to the second logo | string | null | No |
-| \`\`secondLogoAlt\`\` | alt text to display alongside the second logo | string | '' | No |
+| \`\`secondaryLogo\`\` | A url link to the secondary logo | string | null | No |
+| \`\`secondaryLogoAlt\`\` | alt text to display alongside the secondary logo | string | '' | No |
 | \`\`copyright\`\` | Copyright text to display in footer | string | undefined | No |
 | \`\`primaryLinks\`\` | The primary footer links | \`[{ text: string, href: string, id?: string, target?: string }]\` | null | No |
 | \`\`secondaryLinks\`\` | The secondary footer links | \`[{ text: string, href: string, id?: string, class?: string, target?: string, type?: 'button' }]\` | null | No |

--- a/projects/canopy/src/lib/footer/footer.stories.ts
+++ b/projects/canopy/src/lib/footer/footer.stories.ts
@@ -101,8 +101,8 @@ export const coBranded = () => ({
       [copyright]="copyright"
       [logo]="logo"
       [logoAlt]="logoAlt"
-      [secondLogo]="secondLogo"
-      [secondLogoAlt]="secondLogoAlt"
+      [secondaryLogo]="secondaryLogo"
+      [secondaryLogoAlt]="secondaryLogoAlt"
       [primaryLinks]="primaryLinks"
       [secondaryLinks]="secondaryLinks"
       (primaryLinkClicked)="primaryLinkClicked($event)"
@@ -112,8 +112,8 @@ export const coBranded = () => ({
   props: {
     logo: text('logo', 'legal-and-general-logo.svg', groupId),
     logoAlt: text('logoAlt', 'Company name', groupId),
-    secondLogo: text('secondLogo', 'dummy-logo.svg', groupId),
-    secondLogoAlt: text('secondLogoAlt', 'Second company name', groupId),
+    secondaryLogo: text('secondaryLogo', 'dummy-logo.svg', groupId),
+    secondaryLogoAlt: text('secondaryLogoAlt', 'Second company name', groupId),
     copyright: text('copyright', '© Some Company plc 2018', groupId),
     secondaryLinks: object('secondaryLinks', secondaryLinks, groupId),
     primaryLinks: object('primaryLinks', primaryLinks, groupId),

--- a/projects/canopy/src/lib/header/header.component.html
+++ b/projects/canopy/src/lib/header/header.component.html
@@ -10,15 +10,15 @@
             "
           ></ng-container>
 
-          <ng-container *ngIf="secondLogo">
+          <ng-container *ngIf="secondaryLogo">
             <ng-container
               *ngTemplateOutlet="
-                secondLogoHref ? linkTpl : imgTpl;
+                secondaryLogoHref ? linkTpl : imgTpl;
                 context: {
                   img: {
-                    logoAlt: secondLogoAlt,
-                    logoHref: secondLogoHref,
-                    logo: secondLogo,
+                    logoAlt: secondaryLogoAlt,
+                    logoHref: secondaryLogoHref,
+                    logo: secondaryLogo,
                     isSecondLogo: true
                   }
                 }

--- a/projects/canopy/src/lib/header/header.component.spec.ts
+++ b/projects/canopy/src/lib/header/header.component.spec.ts
@@ -9,8 +9,8 @@ describe('HeaderComponent', () => {
 
   const logo = 'http://a.b/logo.png';
   const href = 'http://a.b';
-  const secondLogo = 'http://second/logo.png';
-  const secondLogoHref = 'http://a.b.c';
+  const secondaryLogo = 'http://second/logo.png';
+  const secondaryLogoHref = 'http://a.b.c';
 
   beforeEach(
     waitForAsync(() => {
@@ -43,31 +43,31 @@ describe('HeaderComponent', () => {
   });
 
   describe('co-branding', () => {
-    it('renders a second logo when the secondLogo is specified', () => {
-      component.secondLogo = secondLogo;
+    it('renders a secondary logo when the secondaryLogo is specified', () => {
+      component.secondaryLogo = secondaryLogo;
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css('.lg-header__second-logo'))).toBeTruthy();
     });
 
-    it('does not render a second logo when the secondLogo is not specified', () => {
+    it('does not render a secondary logo when the secondaryLogo is not specified', () => {
       expect(fixture.debugElement.query(By.css('.lg-header__second-logo'))).toBeNull();
     });
 
     it('does not render a link if an href is not provided', () => {
-      component.secondLogo = secondLogo;
+      component.secondaryLogo = secondaryLogo;
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css(`a[href="${secondLogo}"]`))).toBeNull();
+      expect(fixture.debugElement.query(By.css(`a[href="${secondaryLogo}"]`))).toBeNull();
     });
 
     it('renders a link if an href is provided', () => {
-      component.secondLogo = secondLogo;
-      component.secondLogoHref = secondLogoHref;
+      component.secondaryLogo = secondaryLogo;
+      component.secondaryLogoHref = secondaryLogoHref;
       fixture.detectChanges();
 
       expect(
-        fixture.debugElement.query(By.css(`a[href="${secondLogoHref}"]`)),
+        fixture.debugElement.query(By.css(`a[href="${secondaryLogoHref}"]`)),
       ).toBeTruthy();
     });
   });

--- a/projects/canopy/src/lib/header/header.component.ts
+++ b/projects/canopy/src/lib/header/header.component.ts
@@ -13,7 +13,7 @@ export class LgHeaderComponent {
   @Input() logoAlt = '';
   @Input() logoHref: string;
 
-  @Input() secondLogo: string;
-  @Input() secondLogoAlt = '';
-  @Input() secondLogoHref: string;
+  @Input() secondaryLogo: string;
+  @Input() secondaryLogoAlt = '';
+  @Input() secondaryLogoHref: string;
 }

--- a/projects/canopy/src/lib/header/header.notes.ts
+++ b/projects/canopy/src/lib/header/header.notes.ts
@@ -37,9 +37,9 @@ and in your HTML:
 | \`\`logo\`\` | A url link to the logo | string | undefined | Yes |
 | \`\`logoAlt\`\` | alt text to display alongside the logo | string | '' | Yes |
 | \`\`logoHref\`\` | Url link if the logo is clickable | string | undefined | No |
-| \`\`secondLogo\`\` | A url link to the second logo | string | undefined | Yes |
-| \`\`secondLogoAlt\`\` | alt text to display alongside the second logo | string | '' | Yes |
-| \`\`secondLogoHref\`\` | Url link if the second logo is clickable | string | undefined | No |
+| \`\`secondaryLogo\`\` | A url link to the secondary logo | string | undefined | Yes |
+| \`\`secondaryLogoAlt\`\` | alt text to display alongside the secondary logo | string | '' | Yes |
+| \`\`secondaryLogoHref\`\` | Url link if the secondary logo is clickable | string | undefined | No |
 
 ## Changing the width of the logos
 The width of the logos can be changed by overriding the values of the below css variables:

--- a/projects/canopy/src/lib/header/header.stories.ts
+++ b/projects/canopy/src/lib/header/header.stories.ts
@@ -36,7 +36,7 @@ export const standard = () => ({
 
 export const coBranded = () => ({
   template: `
-    <header lg-header [logo]="logo" [logoAlt]="logoAlt" [logoHref]="logoHref" [secondLogo]="secondLogo" [secondLogoAlt]="secondLogoAlt" [secondLogoHref]="secondLogoHref"></header>
+    <header lg-header [logo]="logo" [logoAlt]="logoAlt" [logoHref]="logoHref" [secondaryLogo]="secondaryLogo" [secondaryLogoAlt]="secondaryLogoAlt" [secondaryLogoHref]="secondaryLogoHref"></header>
   `,
   styles: [
     `
@@ -50,8 +50,8 @@ export const coBranded = () => ({
     logo: text('logo', 'legal-and-general-logo.svg', groupId),
     logoAlt: text('logoAlt', 'Company name', groupId),
     logoHref: text('logoHref', 'https://storybook.js.org', groupId),
-    secondLogo: text('second logo', 'dummy-logo.svg', groupId),
-    secondLogoAlt: text('second logoAlt', 'Second company name', groupId),
-    secondLogoHref: text('second logoHref', 'https://storybook.js.org', groupId),
+    secondaryLogo: text('secondary logo', 'dummy-logo.svg', groupId),
+    secondaryLogoAlt: text('secondary logoAlt', 'Second company name', groupId),
+    secondaryLogoHref: text('secondary logoHref', 'https://storybook.js.org', groupId),
   },
 });


### PR DESCRIPTION
# Description
Header and footer:

BREAKING CHANGE: the input for the second logo has been changed from `secondLogo` to `secondaryLogo` to be inline with the inputs `primaryLinks` and `secondaryLinks`.

Fix: #670

#315 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
