### PR TITLE
fix(carousel): remove aria polite attribute 

### DIFF
--- a/projects/canopy/src/lib/carousel/auto-play/auto-play.component.ts
+++ b/projects/canopy/src/lib/carousel/auto-play/auto-play.component.ts
@@ -19,7 +19,5 @@ export class LgAutoplayComponent {
 
   @HostBinding('class.lg-carousel-autoplay') class = true;
 
-  @HostBinding('attr.aria-live') role = 'polite';
-
   constructor(public element: ElementRef) {}
 }


### PR DESCRIPTION
# Description

Fix accessibility bug for the carousel autoplay component in order for the screen reader not to loop the context of the carousel when we are in the page 

Fix: (carousel)-a11y loop context 

Fixes # (issue)
remove aria: polite attribute from the auto-play.component.html
## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.
# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
