### PR TITLE
fix(grid): update wrong value in percentage

### DIFF
--- a/projects/canopy/src/styles/grid.scss
+++ b/projects/canopy/src/styles/grid.scss
@@ -116,7 +116,7 @@ $columns: 12;
 }
 
 @for $i from 1 through $columns {
-  $width: percentage($i / 12);
+  $width: percentage($i / $columns);
 
   .lg-col-xs-#{$i} {
     flex-basis: $width;


### PR DESCRIPTION
# Description

One of the arguments of the percentage function was changed by mistake from  to 12. This reverts that change.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
