### PR TITLE
Remove "Standard" naming convention for single stories

### DIFF
--- a/documentation.json
+++ b/documentation.json
@@ -16443,7 +16443,7 @@
         },
         {
             "name": "LgPrimaryMessageStoryComponent",
-            "id": "component-LgPrimaryMessageStoryComponent-a05194467ec6f6ac19d81bd6eae986c4",
+            "id": "component-LgPrimaryMessageStoryComponent-a6db6bfecb0917e9c15682f7b2bb48f8",
             "file": "projects/canopy/src/lib/primary-message/primary-message.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -16475,7 +16475,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input } from '@angular/core';\n\nimport { Meta, moduleMetadata, Story } from '@storybook/angular';\n\nimport { notes } from './primary-message.notes';\nimport { LgPrimaryMessageModule } from './primary-message.module';\nimport { LgButtonModule } from '../button';\nimport {\n  lgBrandIconCalendar,\n  LgBrandIconModule,\n  LgBrandIconRegistry,\n} from '../brand-icon';\nimport { LgPrimaryMessageComponent } from './primary-message.component';\n\n@Component({\n  selector: 'lg-primary-message-story',\n  template: `\n    <lg-primary-message [hasRole]=\"hasRole\">\n      <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n      <lg-primary-message-title\n        >This is a message with brand icon\n      </lg-primary-message-title>\n      <lg-primary-message-description>\n        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n        <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n      </lg-primary-message-description>\n      <lg-primary-message-description>\n        <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">\n          Call to action\n        </button>\n      </lg-primary-message-description>\n    </lg-primary-message>\n  `,\n})\nclass LgPrimaryMessageStoryComponent {\n  @Input() hasRole: boolean;\n\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    this.brandIconRegistry.registerBrandIcon([lgBrandIconCalendar]);\n  }\n}\n\nexport default {\n  title: 'Components/Primary message',\n  component: LgPrimaryMessageStoryComponent,\n  decorators: [\n    moduleMetadata({\n      imports: [LgPrimaryMessageModule, LgButtonModule, LgBrandIconModule],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    hasRole: {\n      description: 'If false, removes the role ``alert`` from the component.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: true,\n        },\n      },\n    },\n    class: {\n      table: {\n        disable: true,\n      },\n    },\n  },\n} as Meta;\n\nconst template = `\n  <lg-primary-message-story [hasRole]=\"hasRole\"></lg-primary-message-story>\n`;\n\nconst exampleTemplate = `\n  <lg-primary-message [hasRole]=\"hasRole\">\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title\n      >This is a message with brand icon\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">\n        Call to action\n      </button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n`;\n\nconst detailsTemplate: Story<LgPrimaryMessageComponent> = (\n  args: LgPrimaryMessageComponent,\n) => ({\n  props: args,\n  template,\n});\n\nexport const standardPrimaryMessage = detailsTemplate.bind({});\nstandardPrimaryMessage.storyName = 'Standard';\nstandardPrimaryMessage.args = {\n  hasRole: true,\n};\nstandardPrimaryMessage.parameters = {\n  docs: {\n    source: {\n      code: exampleTemplate,\n    },\n  },\n};\n",
+            "sourceCode": "import { Component, Input } from '@angular/core';\n\nimport { Meta, moduleMetadata, Story } from '@storybook/angular';\n\nimport { notes } from './primary-message.notes';\nimport { LgPrimaryMessageModule } from './primary-message.module';\nimport { LgButtonModule } from '../button';\nimport {\n  lgBrandIconCalendar,\n  LgBrandIconModule,\n  LgBrandIconRegistry,\n} from '../brand-icon';\nimport { LgPrimaryMessageComponent } from './primary-message.component';\n\n@Component({\n  selector: 'lg-primary-message-story',\n  template: `\n    <lg-primary-message [hasRole]=\"hasRole\">\n      <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n      <lg-primary-message-title\n        >This is a message with brand icon\n      </lg-primary-message-title>\n      <lg-primary-message-description>\n        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n        <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n      </lg-primary-message-description>\n      <lg-primary-message-description>\n        <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">\n          Call to action\n        </button>\n      </lg-primary-message-description>\n    </lg-primary-message>\n  `,\n})\nclass LgPrimaryMessageStoryComponent {\n  @Input() hasRole: boolean;\n\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    this.brandIconRegistry.registerBrandIcon([lgBrandIconCalendar]);\n  }\n}\n\nexport default {\n  title: 'Components/Primary Message',\n  component: LgPrimaryMessageStoryComponent,\n  decorators: [\n    moduleMetadata({\n      imports: [LgPrimaryMessageModule, LgButtonModule, LgBrandIconModule],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    hasRole: {\n      description: 'If false, removes the role ``alert`` from the component.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: true,\n        },\n      },\n    },\n    class: {\n      table: {\n        disable: true,\n      },\n    },\n  },\n} as Meta;\n\nconst template = `\n  <lg-primary-message-story [hasRole]=\"hasRole\"></lg-primary-message-story>\n`;\n\nconst exampleTemplate = `\n  <lg-primary-message [hasRole]=\"hasRole\">\n    <lg-brand-icon name=\"calendar\"></lg-brand-icon>\n    <lg-primary-message-title\n      >This is a message with brand icon\n    </lg-primary-message-title>\n    <lg-primary-message-description>\n      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\n      <a href=\"#\">eiusmod tempor</a> incididunt ut labore et dolore magna aliqua.\n    </lg-primary-message-description>\n    <lg-primary-message-description>\n      <button lg-button variant=\"solid-primary\" lgMarginTop=\"sm\" type=\"button\">\n        Call to action\n      </button>\n    </lg-primary-message-description>\n  </lg-primary-message>\n`;\n\nconst detailsTemplate: Story<LgPrimaryMessageComponent> = (\n  args: LgPrimaryMessageComponent,\n) => ({\n  props: args,\n  template,\n});\n\nexport const standardPrimaryMessage = detailsTemplate.bind({});\nstandardPrimaryMessage.storyName = 'Primary Message';\nstandardPrimaryMessage.args = {\n  hasRole: true,\n};\nstandardPrimaryMessage.parameters = {\n  docs: {\n    source: {\n      code: exampleTemplate,\n    },\n  },\n};\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
@@ -23994,7 +23994,7 @@
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-370401b13a767d1ef9066ccdc5041189-1",
+            "id": "component-ReactiveFormComponent-e056beb3fa746ef5bda301245d732f92-1",
             "file": "projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -24064,7 +24064,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { notes } from './checkbox-group.notes';\nimport { LgCheckboxGroupComponent } from './checkbox-group.component';\nimport { LgCheckboxGroupModule } from './checkbox-group.module';\nimport { LgHintModule } from '../hint';\n\nconst formTemplate = `\n<form [formGroup]=\"form\">\n  <lg-filter-multiple-group formControlName=\"colors\" [focus]=\"focus\">\n    Select colours\n    <lg-hint>Please select all colours that apply</lg-hint>\n    <lg-filter-checkbox value=\"red\">Red</lg-filter-checkbox>\n    <lg-filter-checkbox value=\"yellow\">Yellow</lg-filter-checkbox>\n    <lg-filter-checkbox value=\"green\">Green</lg-filter-checkbox>\n    <lg-filter-checkbox value=\"blue\">Blue</lg-filter-checkbox>\n  </lg-filter-multiple-group>\n</form>\n`;\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: formTemplate,\n})\nclass ReactiveFormComponent {\n  @Input() focus: boolean;\n  @Input()\n  set disabled(isDisabled: boolean) {\n    if (isDisabled === true) {\n      this.form.controls.colors.disable();\n    } else {\n      this.form.controls.colors.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.colors.disabled;\n  }\n\n  @Output() checkboxChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({ colors: this.fb.control(['red']) });\n    this.form.valueChanges.subscribe((val) => this.checkboxChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Filter multiple buttons',\n  component: LgCheckboxGroupComponent,\n  decorators: [\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, LgCheckboxGroupModule, LgHintModule],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes('Filter'),\n      },\n    },\n  },\n  argTypes: {\n    id: {\n      description: 'HTML ID attribute, auto generated if not provided.',\n      control: false,\n      table: {\n        defaultValue: {\n          summary: 'lg-checkbox-group-id-${++nextUniqueId}',\n        },\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    name: {\n      description:\n        'Set the name value for all inputs in the group, auto-generated if not provided.',\n      control: false,\n      table: {\n        defaultValue: {\n          summary: 'lg-checkbox-group-${++nextUniqueId}',\n        },\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    value: {\n      description:\n        'HTML value attribute. Sets the default checked filter buttons, must match the values of the filter buttons.',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    focus: {\n      description: 'Set the focus on the fieldset.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    disabled: {\n      description: 'Set the inner filters to disabled.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    ariaDescribedBy: {\n      description:\n        'HTML ID for the corresponding element that describes the filters, if not provided it will use the hint field where appropriate.',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    checkboxChange: {\n      action: 'Checkbox change',\n      table: {\n        disable: true,\n      },\n    },\n    inline: {\n      table: {\n        disable: true,\n      },\n    },\n    _checkboxes: {\n      table: {\n        disable: true,\n      },\n    },\n    _hintElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _validationElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _variant: {\n      table: {\n        disable: true,\n      },\n    },\n    nextUniqueId: {\n      table: {\n        disable: true,\n      },\n    },\n    onChange: {\n      table: {\n        disable: true,\n      },\n    },\n    onTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnChange: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    setDisabledState: {\n      table: {\n        disable: true,\n      },\n    },\n    writeValue: {\n      table: {\n        disable: true,\n      },\n    },\n  },\n};\n\nconst filterMultiple: Story<LgCheckboxGroupComponent> = (\n  args: LgCheckboxGroupComponent,\n) => ({\n  props: args,\n  template: `\n    <lg-reactive-form (checkboxChange)=\"checkboxChange($event)\" [disabled]=\"disabled\" [focus]=\"focus\"></lg-reactive-form>\n  `,\n});\n\nexport const filterMultipleButtons = filterMultiple.bind({});\nfilterMultipleButtons.storyName = 'Standard';\nfilterMultipleButtons.args = {\n  disabled: false,\n  focus: false,\n};\nfilterMultipleButtons.parameters = {\n  docs: {\n    source: {\n      code: formTemplate,\n    },\n  },\n};\n",
+            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { notes } from './checkbox-group.notes';\nimport { LgCheckboxGroupComponent } from './checkbox-group.component';\nimport { LgCheckboxGroupModule } from './checkbox-group.module';\nimport { LgHintModule } from '../hint';\n\nconst formTemplate = `\n<form [formGroup]=\"form\">\n  <lg-filter-multiple-group formControlName=\"colors\" [focus]=\"focus\">\n    Select colours\n    <lg-hint>Please select all colours that apply</lg-hint>\n    <lg-filter-checkbox value=\"red\">Red</lg-filter-checkbox>\n    <lg-filter-checkbox value=\"yellow\">Yellow</lg-filter-checkbox>\n    <lg-filter-checkbox value=\"green\">Green</lg-filter-checkbox>\n    <lg-filter-checkbox value=\"blue\">Blue</lg-filter-checkbox>\n  </lg-filter-multiple-group>\n</form>\n`;\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: formTemplate,\n})\nclass ReactiveFormComponent {\n  @Input() focus: boolean;\n  @Input()\n  set disabled(isDisabled: boolean) {\n    if (isDisabled === true) {\n      this.form.controls.colors.disable();\n    } else {\n      this.form.controls.colors.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.colors.disabled;\n  }\n\n  @Output() checkboxChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({ colors: this.fb.control(['red']) });\n    this.form.valueChanges.subscribe((val) => this.checkboxChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Filter Multiple Buttons',\n  component: LgCheckboxGroupComponent,\n  decorators: [\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, LgCheckboxGroupModule, LgHintModule],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes('Filter'),\n      },\n    },\n  },\n  argTypes: {\n    id: {\n      description: 'HTML ID attribute, auto generated if not provided.',\n      control: false,\n      table: {\n        defaultValue: {\n          summary: 'lg-checkbox-group-id-${++nextUniqueId}',\n        },\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    name: {\n      description:\n        'Set the name value for all inputs in the group, auto-generated if not provided.',\n      control: false,\n      table: {\n        defaultValue: {\n          summary: 'lg-checkbox-group-${++nextUniqueId}',\n        },\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    value: {\n      description:\n        'HTML value attribute. Sets the default checked filter buttons, must match the values of the filter buttons.',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    focus: {\n      description: 'Set the focus on the fieldset.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    disabled: {\n      description: 'Set the inner filters to disabled.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    ariaDescribedBy: {\n      description:\n        'HTML ID for the corresponding element that describes the filters, if not provided it will use the hint field where appropriate.',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    checkboxChange: {\n      action: 'Checkbox change',\n      table: {\n        disable: true,\n      },\n    },\n    inline: {\n      table: {\n        disable: true,\n      },\n    },\n    _checkboxes: {\n      table: {\n        disable: true,\n      },\n    },\n    _hintElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _validationElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _variant: {\n      table: {\n        disable: true,\n      },\n    },\n    nextUniqueId: {\n      table: {\n        disable: true,\n      },\n    },\n    onChange: {\n      table: {\n        disable: true,\n      },\n    },\n    onTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnChange: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    setDisabledState: {\n      table: {\n        disable: true,\n      },\n    },\n    writeValue: {\n      table: {\n        disable: true,\n      },\n    },\n  },\n};\n\nconst filterMultiple: Story<LgCheckboxGroupComponent> = (\n  args: LgCheckboxGroupComponent,\n) => ({\n  props: args,\n  template: `\n    <lg-reactive-form (checkboxChange)=\"checkboxChange($event)\" [disabled]=\"disabled\" [focus]=\"focus\"></lg-reactive-form>\n  `,\n});\n\nexport const filterMultipleButtons = filterMultiple.bind({});\nfilterMultipleButtons.storyName = 'Filter Multiple Buttons';\nfilterMultipleButtons.args = {\n  disabled: false,\n  focus: false,\n};\nfilterMultipleButtons.parameters = {\n  docs: {\n    source: {\n      code: formTemplate,\n    },\n  },\n};\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
@@ -24758,7 +24758,158 @@
         },
         {
             "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-642bbf5cf717af1e24c4ab6574581eb9-5",
+            "id": "component-ReactiveFormComponent-9488c7e4508507ffdd5446ad58ef69e0-5",
+            "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "lg-reactive-form",
+            "styleUrls": [],
+            "styles": [],
+            "template": "<form [formGroup]=\"form\">\n  <lg-input-field>\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n    <input lgInput lgSortCode formControlName=\"sortCode\" />\n  </lg-input-field>\n</form>\n",
+            "templateUrl": [],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "disabled",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 29,
+                    "type": "boolean"
+                },
+                {
+                    "name": "hint",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 25,
+                    "type": "string"
+                },
+                {
+                    "name": "label",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 26,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "inputChange",
+                    "defaultValue": "new EventEmitter<void>()",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "line": 40,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "fb",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormBuilder",
+                    "optional": false,
+                    "description": "",
+                    "line": 44,
+                    "modifierKind": [
+                        123
+                    ]
+                },
+                {
+                    "name": "form",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "FormGroup",
+                    "optional": false,
+                    "description": "",
+                    "line": 42
+                }
+            ],
+            "methodsClass": [],
+            "deprecated": false,
+            "deprecationMessage": "",
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "\n",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata } from '@storybook/angular';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { action } from '@storybook/addon-actions';\n\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './sort-code.notes';\nimport { LgSortCodeDirective } from './sort-code.directive';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-input-field>\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n        <input lgInput lgSortCode formControlName=\"sortCode\" />\n      </lg-input-field>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled) {\n      this.form.controls.sortCode.disable();\n    } else {\n      this.form.controls.sortCode.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.sortCode.disabled;\n  }\n\n  @Output() inputChange = new EventEmitter<void>();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      sortCode: [''],\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Sort Code',\n  components: [LgSortCodeDirective],\n  decorators: [\n    withKnobs,\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, CanopyModule],\n    }),\n  ],\n  parameters: {\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n  },\n});\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "args": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": ""
+                    }
+                ],
+                "line": 42,
+                "jsdoctags": [
+                    {
+                        "name": "fb",
+                        "type": "FormBuilder",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "accessors": {
+                "disabled": {
+                    "name": "disabled",
+                    "setSignature": {
+                        "name": "disabled",
+                        "type": "void",
+                        "deprecated": false,
+                        "deprecationMessage": "",
+                        "args": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 29,
+                        "jsdoctags": [
+                            {
+                                "name": "disabled",
+                                "type": "boolean",
+                                "deprecated": false,
+                                "deprecationMessage": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "disabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 36
+                    }
+                }
+            },
+            "isDuplicate": true,
+            "duplicateId": 5,
+            "duplicateName": "ReactiveFormComponent-5"
+        },
+        {
+            "name": "ReactiveFormComponent",
+            "id": "component-ReactiveFormComponent-642bbf5cf717af1e24c4ab6574581eb9-6",
             "file": "projects/canopy/src/lib/forms/validation/form.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -25004,163 +25155,12 @@
                 }
             },
             "isDuplicate": true,
-            "duplicateId": 5,
-            "duplicateName": "ReactiveFormComponent-5"
-        },
-        {
-            "name": "ReactiveFormComponent",
-            "id": "component-ReactiveFormComponent-9488c7e4508507ffdd5446ad58ef69e0-6",
-            "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-            "encapsulation": [],
-            "entryComponents": [],
-            "inputs": [],
-            "outputs": [],
-            "providers": [],
-            "selector": "lg-reactive-form",
-            "styleUrls": [],
-            "styles": [],
-            "template": "<form [formGroup]=\"form\">\n  <lg-input-field>\n    {{ label }}\n    <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n    <input lgInput lgSortCode formControlName=\"sortCode\" />\n  </lg-input-field>\n</form>\n",
-            "templateUrl": [],
-            "viewProviders": [],
-            "inputsClass": [
-                {
-                    "name": "disabled",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 29,
-                    "type": "boolean"
-                },
-                {
-                    "name": "hint",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 25,
-                    "type": "string"
-                },
-                {
-                    "name": "label",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 26,
-                    "type": "string"
-                }
-            ],
-            "outputsClass": [
-                {
-                    "name": "inputChange",
-                    "defaultValue": "new EventEmitter<void>()",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "line": 40,
-                    "type": "EventEmitter"
-                }
-            ],
-            "propertiesClass": [
-                {
-                    "name": "fb",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormBuilder",
-                    "optional": false,
-                    "description": "",
-                    "line": 44,
-                    "modifierKind": [
-                        123
-                    ]
-                },
-                {
-                    "name": "form",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "FormGroup",
-                    "optional": false,
-                    "description": "",
-                    "line": 42
-                }
-            ],
-            "methodsClass": [],
-            "deprecated": false,
-            "deprecationMessage": "",
-            "hostBindings": [],
-            "hostListeners": [],
-            "description": "",
-            "rawdescription": "\n",
-            "type": "component",
-            "sourceCode": "import { Component, EventEmitter, Input, Output } from '@angular/core';\nimport { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\n\nimport { moduleMetadata } from '@storybook/angular';\nimport { boolean, text, withKnobs } from '@storybook/addon-knobs';\nimport { action } from '@storybook/addon-actions';\n\nimport { CanopyModule } from '../../canopy.module';\nimport { notes } from './sort-code.notes';\nimport { LgSortCodeDirective } from './sort-code.directive';\n\n@Component({\n  selector: 'lg-reactive-form',\n  template: `\n    <form [formGroup]=\"form\">\n      <lg-input-field>\n        {{ label }}\n        <lg-hint *ngIf=\"hint\">{{ hint }}</lg-hint>\n        <input lgInput lgSortCode formControlName=\"sortCode\" />\n      </lg-input-field>\n    </form>\n  `,\n})\nclass ReactiveFormComponent {\n  @Input() hint: string;\n  @Input() label: string;\n\n  @Input()\n  set disabled(disabled: boolean) {\n    if (disabled) {\n      this.form.controls.sortCode.disable();\n    } else {\n      this.form.controls.sortCode.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.sortCode.disabled;\n  }\n\n  @Output() inputChange = new EventEmitter<void>();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({\n      sortCode: [''],\n    });\n    this.form.valueChanges.subscribe((val) => this.inputChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Form/Sort Code',\n  components: [LgSortCodeDirective],\n  decorators: [\n    withKnobs,\n    moduleMetadata({\n      declarations: [ReactiveFormComponent],\n      imports: [ReactiveFormsModule, CanopyModule],\n    }),\n  ],\n  parameters: {\n    notes: {\n      markdown: notes,\n    },\n  },\n};\n\nexport const standard = () => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n  },\n});\n",
-            "assetsDirs": [],
-            "styleUrlsData": "",
-            "stylesData": "",
-            "constructorObj": {
-                "name": "constructor",
-                "description": "",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "args": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": ""
-                    }
-                ],
-                "line": 42,
-                "jsdoctags": [
-                    {
-                        "name": "fb",
-                        "type": "FormBuilder",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "tagName": {
-                            "text": "param"
-                        }
-                    }
-                ]
-            },
-            "accessors": {
-                "disabled": {
-                    "name": "disabled",
-                    "setSignature": {
-                        "name": "disabled",
-                        "type": "void",
-                        "deprecated": false,
-                        "deprecationMessage": "",
-                        "args": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": ""
-                            }
-                        ],
-                        "returnType": "void",
-                        "line": 29,
-                        "jsdoctags": [
-                            {
-                                "name": "disabled",
-                                "type": "boolean",
-                                "deprecated": false,
-                                "deprecationMessage": "",
-                                "tagName": {
-                                    "text": "param"
-                                }
-                            }
-                        ]
-                    },
-                    "getSignature": {
-                        "name": "disabled",
-                        "type": "boolean",
-                        "returnType": "boolean",
-                        "line": 36
-                    }
-                }
-            },
-            "isDuplicate": true,
             "duplicateId": 6,
             "duplicateName": "ReactiveFormComponent-6"
         },
         {
             "name": "ReactiveFormFilterComponent",
-            "id": "component-ReactiveFormFilterComponent-e34836e0128c980def3ca886c1cdf481",
+            "id": "component-ReactiveFormFilterComponent-314514fbd49d9146b8c695fd673fc62b",
             "file": "projects/canopy/src/lib/forms/radio/filter.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -25230,7 +25230,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\nimport { Component, EventEmitter, Input, Output } from '@angular/core';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { notes } from './radio.notes';\nimport { LgRadioModule } from './radio.module';\nimport { LgRadioButtonComponent } from './radio-button.component';\nimport { LgRadioGroupComponent } from './radio-group.component';\n\nconst formTemplate = `\n<form [formGroup]=\"form\">\n  <lg-filter-group formControlName=\"color\" [focus]=\"focus\">\n    Select a colour\n    <lg-filter-button value=\"red\">Red</lg-filter-button>\n    <lg-filter-button value=\"yellow\">Yellow</lg-filter-button>\n    <lg-filter-button value=\"green\">Green</lg-filter-button>\n    <lg-filter-button value=\"blue\">Blue</lg-filter-button>\n  </lg-filter-group>\n</form>\n`;\n\n@Component({\n  selector: 'lg-reactive-form-filter',\n  template: formTemplate,\n})\nclass ReactiveFormFilterComponent {\n  @Input() focus: boolean;\n  @Input()\n  set disabled(isDisabled: boolean) {\n    if (isDisabled === true) {\n      this.form.controls.color.disable();\n    } else {\n      this.form.controls.color.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.color.disabled;\n  }\n\n  @Output() filterChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({ color: '' });\n    this.form.valueChanges.subscribe((val) => this.filterChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Filter buttons',\n  component: LgRadioGroupComponent,\n  decorators: [\n    moduleMetadata({\n      declarations: [ReactiveFormFilterComponent],\n      imports: [ReactiveFormsModule, LgRadioModule],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes('Filter'),\n      },\n    },\n  },\n  argTypes: {\n    id: {\n      description: 'HTML ID attribute, auto generated if not provided',\n      control: false,\n      table: {\n        defaultValue: {\n          summary: 'lg-radio-button-${++nextUniqueId}',\n        },\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    name: {\n      description: 'HTML name attribute',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    value: {\n      description: 'HTML value attribute',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    focus: {\n      description: 'Set the focus on the fieldset.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    ariaDescribedBy: {\n      description:\n        'HTML ID for the corresponding element that describes the filters, if not provided it will use the hint field where appropriate.',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    disabled: {\n      description: 'Set the inner filters to disabled.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    filterChange: {\n      action: 'Filter change',\n      table: {\n        disable: true,\n      },\n    },\n    inline: {\n      table: {\n        disable: true,\n      },\n    },\n    stack: {\n      table: {\n        disable: true,\n      },\n    },\n    _hintElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _radios: {\n      table: {\n        disable: true,\n      },\n    },\n    _stack: {\n      table: {\n        disable: true,\n      },\n    },\n    _validationElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _value: {\n      table: {\n        disable: true,\n      },\n    },\n    class: {\n      table: {\n        disable: true,\n      },\n    },\n    nextUniqueId: {\n      table: {\n        disable: true,\n      },\n    },\n    variant: {\n      table: {\n        disable: true,\n      },\n    },\n    onChange: {\n      table: {\n        disable: true,\n      },\n    },\n    onTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnChange: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    setDisabledState: {\n      table: {\n        disable: true,\n      },\n    },\n    writeValue: {\n      table: {\n        disable: true,\n      },\n    },\n  },\n};\n\nconst filterButtonsStory: Story<LgRadioButtonComponent> = (\n  args: LgRadioButtonComponent,\n) => ({\n  props: args,\n  template: `\n    <lg-reactive-form-filter (filterChange)=\"filterChange($event)\" [disabled]=\"disabled\" [focus]=\"focus\"></lg-reactive-form-filter>\n  `,\n});\n\nexport const filterButtons = filterButtonsStory.bind({});\nfilterButtons.storyName = 'Standard';\nfilterButtons.args = {\n  disabled: false,\n  focus: false,\n};\nfilterButtons.parameters = {\n  docs: {\n    source: {\n      code: formTemplate,\n    },\n  },\n};\n",
+            "sourceCode": "import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';\nimport { Component, EventEmitter, Input, Output } from '@angular/core';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { notes } from './radio.notes';\nimport { LgRadioModule } from './radio.module';\nimport { LgRadioButtonComponent } from './radio-button.component';\nimport { LgRadioGroupComponent } from './radio-group.component';\n\nconst formTemplate = `\n<form [formGroup]=\"form\">\n  <lg-filter-group formControlName=\"color\" [focus]=\"focus\">\n    Select a colour\n    <lg-filter-button value=\"red\">Red</lg-filter-button>\n    <lg-filter-button value=\"yellow\">Yellow</lg-filter-button>\n    <lg-filter-button value=\"green\">Green</lg-filter-button>\n    <lg-filter-button value=\"blue\">Blue</lg-filter-button>\n  </lg-filter-group>\n</form>\n`;\n\n@Component({\n  selector: 'lg-reactive-form-filter',\n  template: formTemplate,\n})\nclass ReactiveFormFilterComponent {\n  @Input() focus: boolean;\n  @Input()\n  set disabled(isDisabled: boolean) {\n    if (isDisabled === true) {\n      this.form.controls.color.disable();\n    } else {\n      this.form.controls.color.enable();\n    }\n  }\n  get disabled(): boolean {\n    return this.form.controls.color.disabled;\n  }\n\n  @Output() filterChange: EventEmitter<void> = new EventEmitter();\n\n  form: FormGroup;\n\n  constructor(public fb: FormBuilder) {\n    this.form = this.fb.group({ color: '' });\n    this.form.valueChanges.subscribe((val) => this.filterChange.emit(val));\n  }\n}\n\nexport default {\n  title: 'Components/Filter Buttons',\n  component: LgRadioGroupComponent,\n  decorators: [\n    moduleMetadata({\n      declarations: [ReactiveFormFilterComponent],\n      imports: [ReactiveFormsModule, LgRadioModule],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes('Filter'),\n      },\n    },\n  },\n  argTypes: {\n    id: {\n      description: 'HTML ID attribute, auto generated if not provided',\n      control: false,\n      table: {\n        defaultValue: {\n          summary: 'lg-radio-button-${++nextUniqueId}',\n        },\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    name: {\n      description: 'HTML name attribute',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    value: {\n      description: 'HTML value attribute',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    focus: {\n      description: 'Set the focus on the fieldset.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    ariaDescribedBy: {\n      description:\n        'HTML ID for the corresponding element that describes the filters, if not provided it will use the hint field where appropriate.',\n      control: false,\n      table: {\n        type: {\n          summary: 'string',\n        },\n      },\n    },\n    disabled: {\n      description: 'Set the inner filters to disabled.',\n      table: {\n        type: {\n          summary: 'boolean',\n        },\n        defaultValue: {\n          summary: false,\n        },\n      },\n    },\n    filterChange: {\n      action: 'Filter change',\n      table: {\n        disable: true,\n      },\n    },\n    inline: {\n      table: {\n        disable: true,\n      },\n    },\n    stack: {\n      table: {\n        disable: true,\n      },\n    },\n    _hintElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _radios: {\n      table: {\n        disable: true,\n      },\n    },\n    _stack: {\n      table: {\n        disable: true,\n      },\n    },\n    _validationElement: {\n      table: {\n        disable: true,\n      },\n    },\n    _value: {\n      table: {\n        disable: true,\n      },\n    },\n    class: {\n      table: {\n        disable: true,\n      },\n    },\n    nextUniqueId: {\n      table: {\n        disable: true,\n      },\n    },\n    variant: {\n      table: {\n        disable: true,\n      },\n    },\n    onChange: {\n      table: {\n        disable: true,\n      },\n    },\n    onTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnChange: {\n      table: {\n        disable: true,\n      },\n    },\n    registerOnTouched: {\n      table: {\n        disable: true,\n      },\n    },\n    setDisabledState: {\n      table: {\n        disable: true,\n      },\n    },\n    writeValue: {\n      table: {\n        disable: true,\n      },\n    },\n  },\n};\n\nconst filterButtonsStory: Story<LgRadioButtonComponent> = (\n  args: LgRadioButtonComponent,\n) => ({\n  props: args,\n  template: `\n    <lg-reactive-form-filter (filterChange)=\"filterChange($event)\" [disabled]=\"disabled\" [focus]=\"focus\"></lg-reactive-form-filter>\n  `,\n});\n\nexport const filterButtons = filterButtonsStory.bind({});\nfilterButtons.storyName = 'Filter Buttons';\nfilterButtons.args = {\n  disabled: false,\n  focus: false,\n};\nfilterButtons.parameters = {\n  docs: {\n    source: {\n      code: formTemplate,\n    },\n  },\n};\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "",
@@ -26102,7 +26102,7 @@
         },
         {
             "name": "SwatchBrandIconComponent",
-            "id": "component-SwatchBrandIconComponent-26964c2df5d3dbb60422d472a4ab6c71",
+            "id": "component-SwatchBrandIconComponent-5f3df313933893d1016d567caaf2969c",
             "file": "projects/canopy/src/lib/brand-icon/brand-icons.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -26197,7 +26197,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';\nimport { DomSanitizer, SafeStyle } from '@angular/platform-browser';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { LgBrandIconComponent } from './brand-icon.component';\nimport { notes } from './brand-icon.notes';\nimport { LgBrandIconRegistry } from './brand-icon.registry';\n\nimport * as brandIconSet from './brand-icons.interface';\n\nconst brandIconsArray: Array<brandIconSet.BrandIcon> = [\n  brandIconSet.lgBrandIconCalendar,\n  brandIconSet.lgBrandIconChangeExistingHoldings,\n  brandIconSet.lgBrandIconChangeFutureContributions,\n  brandIconSet.lgBrandIconCookiesAndArrows,\n  brandIconSet.lgBrandIconErrorInBrowser,\n  brandIconSet.lgBrandIconGuaranteedIncome,\n  brandIconSet.lgBrandIconHelpAdvice,\n  brandIconSet.lgBrandIconNoInformation,\n  brandIconSet.lgBrandIconNoTransactionsMatch,\n  brandIconSet.lgBrandIconPaymentSuccess,\n  brandIconSet.lgBrandIconPensionPot,\n  brandIconSet.lgBrandIconPeople,\n  brandIconSet.lgBrandIconPerformance,\n  brandIconSet.lgBrandIconPiggyBank,\n  brandIconSet.lgBrandIconRainOrShine,\n  brandIconSet.lgBrandIconSun,\n  brandIconSet.lgBrandIconSurvey,\n  brandIconSet.lgBrandIconThumbsUp,\n  brandIconSet.lgBrandIconVideoGuides,\n  brandIconSet.lgBrandIconWarning,\n  brandIconSet.lgBrandIconMinutes,\n  brandIconSet.lgBrandIconQuickAndEasy,\n  brandIconSet.lgBrandIconHandFlower,\n  brandIconSet.lgBrandIconCurrencyPounds,\n  brandIconSet.lgBrandIconWindTurbine,\n];\n@Component({\n  selector: 'lg-swatch-brand-icon',\n  template: `\n    <div class=\"swatch\" *ngFor=\"let icon of icons; let i = index\">\n      <lg-brand-icon\n        class=\"swatch__svg\"\n        [name]=\"icon.name\"\n        [size]=\"size\"\n        [colour]=\"i === 0 ? colour : null\"\n        [attr.style]=\"cssVar\"\n      ></lg-brand-icon>\n      <span class=\"swatch__name\">{{ icon.name }}</span>\n    </div>\n  `,\n  styles: [\n    `\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-md);\n        flex: 0 0 8rem;\n      }\n\n      .swatch__name {\n        display: block;\n        text-align: center;\n        margin-top: var(--space-xxs);\n      }\n\n      .swatch__svg {\n        display: block;\n        margin: 0 auto;\n      }\n    `,\n  ],\n})\nclass SwatchBrandIconComponent implements OnChanges {\n  @Input() size: string;\n  @Input() colour: string;\n  @Input() globalColour: string;\n\n  icons = brandIconsArray;\n  cssVar: SafeStyle;\n\n  constructor(private registry: LgBrandIconRegistry, private sanitizer: DomSanitizer) {\n    this.registry.registerBrandIcon(this.icons);\n  }\n\n  ngOnChanges({ globalColour }: SimpleChanges) {\n    if (globalColour && globalColour.currentValue) {\n      this.cssVar = this.sanitizer.bypassSecurityTrustStyle(\n        `--brand-icon-fill-primary: var(${globalColour.currentValue})`,\n      );\n    }\n  }\n}\n\nconst sizes = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'];\n\nconst colours = [\n  '--color-dandelion-yellow',\n  '--color-super-blue',\n  '--color-lily-green',\n  '--color-shocking-pink',\n  '--color-poppy-red-dark',\n];\n\nexport default {\n  title: 'Components/Brand Icon',\n  decorators: [\n    moduleMetadata({\n      declarations: [SwatchBrandIconComponent, LgBrandIconComponent],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    size: {\n      options: sizes,\n      description: 'The size of the icon',\n      table: {\n        type: {\n          summary: sizes,\n        },\n        defaultValue: {\n          summary: 'sm',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n    globalColour: {\n      options: colours,\n      description:\n        'The primary colour of icons globally. Can be changed by overriding the `--brand-icon-fill-primary` CSS variable.',\n      table: {\n        defaultValue: {\n          summary: '--color-dandelion-yellow',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n    colour: {\n      options: colours,\n      description: 'The colour of a specific icon, using the `colour` input',\n      table: {\n        type: {\n          summary: colours,\n        },\n        defaultValue: {\n          summary: '--color-dandelion-yellow',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n  },\n};\n\nconst exampleTemplate = `\n<lg-brand-icon\n  [name]=\"sun\"\n  size=\"sm\"\n  colour=\"--color-dandelion-yellow\"\n></lg-brand-icon>\n`;\n\nconst brandIconsTemplate: Story<LgBrandIconComponent> = (args: LgBrandIconComponent) => ({\n  props: args,\n  template:\n    '<lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [globalColour]=\"globalColour\"></lg-swatch-brand-icon>',\n});\n\nexport const standardBrandIcons = brandIconsTemplate.bind({});\nstandardBrandIcons.storyName = 'Standard';\nstandardBrandIcons.args = {\n  size: 'sm',\n};\nstandardBrandIcons.parameters = {\n  docs: {\n    description: {\n      component: notes,\n    },\n    source: {\n      code: exampleTemplate,\n    },\n  },\n};\n",
+            "sourceCode": "import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';\nimport { DomSanitizer, SafeStyle } from '@angular/platform-browser';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { LgBrandIconComponent } from './brand-icon.component';\nimport { notes } from './brand-icon.notes';\nimport { LgBrandIconRegistry } from './brand-icon.registry';\n\nimport * as brandIconSet from './brand-icons.interface';\n\nconst brandIconsArray: Array<brandIconSet.BrandIcon> = [\n  brandIconSet.lgBrandIconCalendar,\n  brandIconSet.lgBrandIconChangeExistingHoldings,\n  brandIconSet.lgBrandIconChangeFutureContributions,\n  brandIconSet.lgBrandIconCookiesAndArrows,\n  brandIconSet.lgBrandIconErrorInBrowser,\n  brandIconSet.lgBrandIconGuaranteedIncome,\n  brandIconSet.lgBrandIconHelpAdvice,\n  brandIconSet.lgBrandIconNoInformation,\n  brandIconSet.lgBrandIconNoTransactionsMatch,\n  brandIconSet.lgBrandIconPaymentSuccess,\n  brandIconSet.lgBrandIconPensionPot,\n  brandIconSet.lgBrandIconPeople,\n  brandIconSet.lgBrandIconPerformance,\n  brandIconSet.lgBrandIconPiggyBank,\n  brandIconSet.lgBrandIconRainOrShine,\n  brandIconSet.lgBrandIconSun,\n  brandIconSet.lgBrandIconSurvey,\n  brandIconSet.lgBrandIconThumbsUp,\n  brandIconSet.lgBrandIconVideoGuides,\n  brandIconSet.lgBrandIconWarning,\n  brandIconSet.lgBrandIconMinutes,\n  brandIconSet.lgBrandIconQuickAndEasy,\n  brandIconSet.lgBrandIconHandFlower,\n  brandIconSet.lgBrandIconCurrencyPounds,\n  brandIconSet.lgBrandIconWindTurbine,\n];\n@Component({\n  selector: 'lg-swatch-brand-icon',\n  template: `\n    <div class=\"swatch\" *ngFor=\"let icon of icons; let i = index\">\n      <lg-brand-icon\n        class=\"swatch__svg\"\n        [name]=\"icon.name\"\n        [size]=\"size\"\n        [colour]=\"i === 0 ? colour : null\"\n        [attr.style]=\"cssVar\"\n      ></lg-brand-icon>\n      <span class=\"swatch__name\">{{ icon.name }}</span>\n    </div>\n  `,\n  styles: [\n    `\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-md);\n        flex: 0 0 8rem;\n      }\n\n      .swatch__name {\n        display: block;\n        text-align: center;\n        margin-top: var(--space-xxs);\n      }\n\n      .swatch__svg {\n        display: block;\n        margin: 0 auto;\n      }\n    `,\n  ],\n})\nclass SwatchBrandIconComponent implements OnChanges {\n  @Input() size: string;\n  @Input() colour: string;\n  @Input() globalColour: string;\n\n  icons = brandIconsArray;\n  cssVar: SafeStyle;\n\n  constructor(private registry: LgBrandIconRegistry, private sanitizer: DomSanitizer) {\n    this.registry.registerBrandIcon(this.icons);\n  }\n\n  ngOnChanges({ globalColour }: SimpleChanges) {\n    if (globalColour && globalColour.currentValue) {\n      this.cssVar = this.sanitizer.bypassSecurityTrustStyle(\n        `--brand-icon-fill-primary: var(${globalColour.currentValue})`,\n      );\n    }\n  }\n}\n\nconst sizes = ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'];\n\nconst colours = [\n  '--color-dandelion-yellow',\n  '--color-super-blue',\n  '--color-lily-green',\n  '--color-shocking-pink',\n  '--color-poppy-red-dark',\n];\n\nexport default {\n  title: 'Components/Brand Icon',\n  decorators: [\n    moduleMetadata({\n      declarations: [SwatchBrandIconComponent, LgBrandIconComponent],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    size: {\n      options: sizes,\n      description: 'The size of the icon',\n      table: {\n        type: {\n          summary: sizes,\n        },\n        defaultValue: {\n          summary: 'sm',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n    globalColour: {\n      options: colours,\n      description:\n        'The primary colour of icons globally. Can be changed by overriding the `--brand-icon-fill-primary` CSS variable.',\n      table: {\n        defaultValue: {\n          summary: '--color-dandelion-yellow',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n    colour: {\n      options: colours,\n      description: 'The colour of a specific icon, using the `colour` input',\n      table: {\n        type: {\n          summary: colours,\n        },\n        defaultValue: {\n          summary: '--color-dandelion-yellow',\n        },\n      },\n      control: {\n        type: 'select',\n      },\n    },\n  },\n};\n\nconst exampleTemplate = `\n<lg-brand-icon\n  [name]=\"sun\"\n  size=\"sm\"\n  colour=\"--color-dandelion-yellow\"\n></lg-brand-icon>\n`;\n\nconst brandIconsTemplate: Story<LgBrandIconComponent> = (args: LgBrandIconComponent) => ({\n  props: args,\n  template:\n    '<lg-swatch-brand-icon [size]=\"size\" [colour]=\"colour\" [globalColour]=\"globalColour\"></lg-swatch-brand-icon>',\n});\n\nexport const standardBrandIcons = brandIconsTemplate.bind({});\nstandardBrandIcons.storyName = 'Brand Icon';\nstandardBrandIcons.args = {\n  size: 'sm',\n};\nstandardBrandIcons.parameters = {\n  docs: {\n    description: {\n      component: notes,\n    },\n    source: {\n      code: exampleTemplate,\n    },\n  },\n};\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-md);\n        flex: 0 0 8rem;\n      }\n\n      .swatch__name {\n        display: block;\n        text-align: center;\n        margin-top: var(--space-xxs);\n      }\n\n      .swatch__svg {\n        display: block;\n        margin: 0 auto;\n      }\n    \n",
@@ -26389,7 +26389,7 @@
         },
         {
             "name": "SwatchIconComponent",
-            "id": "component-SwatchIconComponent-7d65400ce8988f89ce58e94bb2243bfb",
+            "id": "component-SwatchIconComponent-42908539674fe859de38573182a4824d",
             "file": "projects/canopy/src/lib/icon/icons.stories.ts",
             "encapsulation": [],
             "entryComponents": [],
@@ -26470,7 +26470,7 @@
             "description": "",
             "rawdescription": "\n",
             "type": "component",
-            "sourceCode": "import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';\nimport { DomSanitizer, SafeStyle } from '@angular/platform-browser';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { LgIconComponent } from './icon.component';\nimport { notes } from './icon.notes';\nimport { LgIconRegistry } from './icon.registry';\nimport * as iconSet from './icons.interface';\n\nexport const iconsArray: Array<iconSet.Icon> = [\n  iconSet.lgIconAdd,\n  iconSet.lgIconAlignCentre,\n  iconSet.lgIconAlignLeft,\n  iconSet.lgIconAlignRight,\n  iconSet.lgIconAnalytics,\n  iconSet.lgIconAnnouncement,\n  iconSet.lgIconArrowDecreasing,\n  iconSet.lgIconArrowDown,\n  iconSet.lgIconArrowIncreasing,\n  iconSet.lgIconArrowLeft,\n  iconSet.lgIconArrowRight,\n  iconSet.lgIconArrowUp,\n  iconSet.lgIconAt,\n  iconSet.lgIconAttach,\n  iconSet.lgIconBlog,\n  iconSet.lgIconBolt,\n  iconSet.lgIconBookmarkFill,\n  iconSet.lgIconBookmark,\n  iconSet.lgIconCalculator,\n  iconSet.lgIconCalendar,\n  iconSet.lgIconCall,\n  iconSet.lgIconCamera,\n  iconSet.lgIconCaretDown,\n  iconSet.lgIconCaretLeft,\n  iconSet.lgIconCaretRight,\n  iconSet.lgIconCaretUp,\n  iconSet.lgIconCart,\n  iconSet.lgIconChartBar,\n  iconSet.lgIconChartDonut,\n  iconSet.lgIconChartLine,\n  iconSet.lgIconChartPie,\n  iconSet.lgIconChatGroup,\n  iconSet.lgIconChat,\n  iconSet.lgIconCheckboxChecked,\n  iconSet.lgIconCheckboxEmpty,\n  iconSet.lgIconCheckboxIndeterminate,\n  iconSet.lgIconCheckmarkSpotFill,\n  iconSet.lgIconCheckmarkSpot,\n  iconSet.lgIconCheckmark,\n  iconSet.lgIconChevronDownFilled,\n  iconSet.lgIconChevronDownSlim,\n  iconSet.lgIconChevronDown,\n  iconSet.lgIconChevronLeftCircle,\n  iconSet.lgIconChevronLeftSlim,\n  iconSet.lgIconChevronLeft,\n  iconSet.lgIconChevronRightCircle,\n  iconSet.lgIconChevronRightSlim,\n  iconSet.lgIconChevronRight,\n  iconSet.lgIconChevronUpFilled,\n  iconSet.lgIconChevronUpSlim,\n  iconSet.lgIconChevronUp,\n  iconSet.lgIconCloseSpot,\n  iconSet.lgIconClose,\n  iconSet.lgIconCloud,\n  iconSet.lgIconCode,\n  iconSet.lgIconCollaborate,\n  iconSet.lgIconCompass,\n  iconSet.lgIconConnect,\n  iconSet.lgIconConsole,\n  iconSet.lgIconContributions,\n  iconSet.lgIconCopy,\n  iconSet.lgIconCount,\n  iconSet.lgIconCouple,\n  iconSet.lgIconCreditCard,\n  iconSet.lgIconCrossmarkSpotFill,\n  iconSet.lgIconCsv,\n  iconSet.lgIconData,\n  iconSet.lgIconDatabase,\n  iconSet.lgIconDataset,\n  iconSet.lgIconDelete,\n  iconSet.lgIconDesktop,\n  iconSet.lgIconDiagram,\n  iconSet.lgIconDigg,\n  iconSet.lgIconDoc,\n  iconSet.lgIconDocumentAdd,\n  iconSet.lgIconDocumentSubtract,\n  iconSet.lgIconDocumentTasks,\n  iconSet.lgIconDocument,\n  iconSet.lgIconDownload,\n  iconSet.lgIconDragHandle,\n  iconSet.lgIconDrilldown,\n  iconSet.lgIconEdit,\n  iconSet.lgIconEditNote,\n  iconSet.lgIconEmail,\n  iconSet.lgIconErrorFill,\n  iconSet.lgIconError,\n  iconSet.lgIconEvent,\n  iconSet.lgIconExitFill,\n  iconSet.lgIconExit,\n  iconSet.lgIconExport,\n  iconSet.lgIconFaceDissatisfiedFill,\n  iconSet.lgIconFaceDissatisfied,\n  iconSet.lgIconFaceHappyFill,\n  iconSet.lgIconFaceHappy,\n  iconSet.lgIconFaceNeutralFill,\n  iconSet.lgIconFaceNeutral,\n  iconSet.lgIconFaceSatisfiedFill,\n  iconSet.lgIconFaceSatisfied,\n  iconSet.lgIconFaceUnhappyFill,\n  iconSet.lgIconFacebook,\n  iconSet.lgIconFamily,\n  iconSet.lgIconFavouriteFill,\n  iconSet.lgIconFavourite,\n  iconSet.lgIconFilter,\n  iconSet.lgIconFolderAdd,\n  iconSet.lgIconFolder,\n  iconSet.lgIconFollow,\n  iconSet.lgIconForum,\n  iconSet.lgIconFunds,\n  iconSet.lgIconFurntiure,\n  iconSet.lgIconGenderFemale,\n  iconSet.lgIconGenderMale,\n  iconSet.lgIconGif,\n  iconSet.lgIconGithub,\n  iconSet.lgIconGlobe,\n  iconSet.lgIconGoogle,\n  iconSet.lgIconGotoBottom,\n  iconSet.lgIconGotoFirst,\n  iconSet.lgIconGotoLast,\n  iconSet.lgIconGotoTop,\n  iconSet.lgIconGroup,\n  iconSet.lgIconGuillemetLeft,\n  iconSet.lgIconGuillemetRight,\n  iconSet.lgIconHamburgerMenu,\n  iconSet.lgIconHd,\n  iconSet.lgIconHdr,\n  iconSet.lgIconHedgingCurrency,\n  iconSet.lgIconHedging,\n  iconSet.lgIconHelp,\n  iconSet.lgIconHighlight,\n  iconSet.lgIconHomeFill,\n  iconSet.lgIconHome,\n  iconSet.lgIconHouse,\n  iconSet.lgIconIdea,\n  iconSet.lgIconImage,\n  iconSet.lgIconInformationFill,\n  iconSet.lgIconInformation,\n  iconSet.lgIconInsert,\n  iconSet.lgIconInstagram,\n  iconSet.lgIconJuniorIsa,\n  iconSet.lgIconLandlord,\n  iconSet.lgIconLaunch,\n  iconSet.lgIconLearn,\n  iconSet.lgIconLikeFill,\n  iconSet.lgIconLike,\n  iconSet.lgIconLinkExternal,\n  iconSet.lgIconLink,\n  iconSet.lgIconLinkedin,\n  iconSet.lgIconListBullets,\n  iconSet.lgIconListChecked,\n  iconSet.lgIconListNumbered,\n  iconSet.lgIconList,\n  iconSet.lgIconLocationArrow,\n  iconSet.lgIconLocation,\n  iconSet.lgIconLockedFill,\n  iconSet.lgIconLocked,\n  iconSet.lgIconMaLgi,\n  iconSet.lgIconMail,\n  iconSet.lgIconMap,\n  iconSet.lgIconMaximise,\n  iconSet.lgIconMicrophoneOff,\n  iconSet.lgIconMicrophoneOn,\n  iconSet.lgIconMinimise,\n  iconSet.lgIconMisuseFill,\n  iconSet.lgIconMisuse,\n  iconSet.lgIconMobile,\n  iconSet.lgIconModule,\n  iconSet.lgIconMoney,\n  iconSet.lgIconMove,\n  iconSet.lgIconNeedHelp,\n  iconSet.lgIconNewTab,\n  iconSet.lgIconNews,\n  iconSet.lgIconNotes,\n  iconSet.lgIconNotificationOff,\n  iconSet.lgIconNotificationOn,\n  iconSet.lgIconOpenInNewWindow,\n  iconSet.lgIconOverflowHorizontal,\n  iconSet.lgIconOverflowVertical,\n  iconSet.lgIconOverlay,\n  iconSet.lgIconPage,\n  iconSet.lgIconPages,\n  iconSet.lgIconPartnership,\n  iconSet.lgIconPassword,\n  iconSet.lgIconPause,\n  iconSet.lgIconPdf,\n  iconSet.lgIconPensionPot,\n  iconSet.lgIconPerson,\n  iconSet.lgIconPet,\n  iconSet.lgIconPhoneOff,\n  iconSet.lgIconPhoneOn,\n  iconSet.lgIconPlaySpot,\n  iconSet.lgIconPlay,\n  iconSet.lgIconPng,\n  iconSet.lgIconPopUp,\n  iconSet.lgIconPresentationFile,\n  iconSet.lgIconPrinter,\n  iconSet.lgIconProfile,\n  iconSet.lgIconQueryFill,\n  iconSet.lgIconQuery,\n  iconSet.lgIconQuestionMark,\n  iconSet.lgIconRadioButtonSelected,\n  iconSet.lgIconRadioButtonUnselected,\n  iconSet.lgIconRecommend,\n  iconSet.lgIconRenew,\n  iconSet.lgIconRepeat,\n  iconSet.lgIconReply,\n  iconSet.lgIconReport,\n  iconSet.lgIconReset,\n  iconSet.lgIconRestart,\n  iconSet.lgIconRetirement,\n  iconSet.lgIconReward,\n  iconSet.lgIconRss,\n  iconSet.lgIconScaleDown,\n  iconSet.lgIconScaleUp,\n  iconSet.lgIconScan,\n  iconSet.lgIconSearch,\n  iconSet.lgIconSecureMessaging,\n  iconSet.lgIconSecurity,\n  iconSet.lgIconSend,\n  iconSet.lgIconSettings,\n  iconSet.lgIconShare,\n  iconSet.lgIconSignIn,\n  iconSet.lgIconSign,\n  iconSet.lgIconSkipBack,\n  iconSet.lgIconSkipForward,\n  iconSet.lgIconSlack,\n  iconSet.lgIconStarFill,\n  iconSet.lgIconStarHalfFill,\n  iconSet.lgIconStar,\n  iconSet.lgIconStop,\n  iconSet.lgIconSubtract,\n  iconSet.lgIconSvg,\n  iconSet.lgIconSwitchFunds,\n  iconSet.lgIconTag,\n  iconSet.lgIconTime,\n  iconSet.lgIconTimeDelay,\n  iconSet.lgIconTrash,\n  iconSet.lgIconTwitter,\n  iconSet.lgIconUnhappy,\n  iconSet.lgIconUnlockedFill,\n  iconSet.lgIconUnlocked,\n  iconSet.lgIconUpload,\n  iconSet.lgIconUserOnline,\n  iconSet.lgIconUsers,\n  iconSet.lgIconVideo,\n  iconSet.lgIconViewModeOff,\n  iconSet.lgIconViewModeOn,\n  iconSet.lgIconViewTransactions,\n  iconSet.lgIconVolumeDown,\n  iconSet.lgIconVolumeMute,\n  iconSet.lgIconVolumeUp,\n  iconSet.lgIconWarningFill,\n  iconSet.lgIconWarning,\n  iconSet.lgIconYoutube,\n  iconSet.lgIconZoomInFill,\n  iconSet.lgIconZoomIn,\n  iconSet.lgIconZoomOutFill,\n  iconSet.lgIconZoomOut,\n];\n\n@Component({\n  selector: 'lg-swatch-icon',\n  template: `\n    <div class=\"swatch\" *ngFor=\"let icon of icons\">\n      <lg-icon class=\"swatch__svg\" [name]=\"icon.name\" [attr.style]=\"colourVar\"> </lg-icon>\n      <span class=\"swatch__name\">{{ icon.name }}</span>\n    </div>\n  `,\n  styles: [\n    `\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-sm);\n        flex: 1 1 225px;\n      }\n\n      .swatch__svg {\n        margin-right: var(--space-md);\n      }\n    `,\n  ],\n})\nclass SwatchIconComponent implements OnChanges {\n  @Input() colour: string;\n\n  icons = iconsArray;\n  colourVar: SafeStyle;\n\n  constructor(private registry: LgIconRegistry, private sanitizer: DomSanitizer) {\n    this.registry.registerIcons(this.icons);\n  }\n\n  ngOnChanges({ colour }: SimpleChanges) {\n    if (colour && colour.currentValue) {\n      this.colourVar = this.sanitizer.bypassSecurityTrustStyle(\n        `color: var(${colour.currentValue})`,\n      );\n    }\n  }\n}\n\nconst colours = [\n  '--color-charcoal',\n  '--color-super-blue',\n  '--color-leafy-green-dark',\n  '--color-poppy-red-dark',\n];\n\nexport default {\n  title: 'Components/Icon',\n  excludeStories: ['iconsArray'],\n  decorators: [\n    moduleMetadata({\n      declarations: [SwatchIconComponent, LgIconComponent],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    colour: {\n      options: colours,\n      description: 'Example of changing the colour of the icon',\n      control: {\n        type: 'select',\n      },\n    },\n  },\n};\n\nconst exampleTemplate = `\n<lg-icon name=\"call\"></lg-icon>\n`;\n\nconst iconsTemplate: Story<LgIconComponent> = (args: LgIconComponent) => ({\n  props: args,\n  template: '<lg-swatch-icon [colour]=\"colour\"></lg-swatch-icon>',\n});\n\nexport const standardIcons = iconsTemplate.bind({});\nstandardIcons.storyName = 'Standard';\nstandardIcons.parameters = {\n  docs: {\n    description: {\n      component: notes,\n    },\n    source: {\n      code: exampleTemplate,\n    },\n  },\n};\n",
+            "sourceCode": "import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';\nimport { DomSanitizer, SafeStyle } from '@angular/platform-browser';\n\nimport { moduleMetadata, Story } from '@storybook/angular';\n\nimport { LgIconComponent } from './icon.component';\nimport { notes } from './icon.notes';\nimport { LgIconRegistry } from './icon.registry';\nimport * as iconSet from './icons.interface';\n\nexport const iconsArray: Array<iconSet.Icon> = [\n  iconSet.lgIconAdd,\n  iconSet.lgIconAlignCentre,\n  iconSet.lgIconAlignLeft,\n  iconSet.lgIconAlignRight,\n  iconSet.lgIconAnalytics,\n  iconSet.lgIconAnnouncement,\n  iconSet.lgIconArrowDecreasing,\n  iconSet.lgIconArrowDown,\n  iconSet.lgIconArrowIncreasing,\n  iconSet.lgIconArrowLeft,\n  iconSet.lgIconArrowRight,\n  iconSet.lgIconArrowUp,\n  iconSet.lgIconAt,\n  iconSet.lgIconAttach,\n  iconSet.lgIconBlog,\n  iconSet.lgIconBolt,\n  iconSet.lgIconBookmarkFill,\n  iconSet.lgIconBookmark,\n  iconSet.lgIconCalculator,\n  iconSet.lgIconCalendar,\n  iconSet.lgIconCall,\n  iconSet.lgIconCamera,\n  iconSet.lgIconCaretDown,\n  iconSet.lgIconCaretLeft,\n  iconSet.lgIconCaretRight,\n  iconSet.lgIconCaretUp,\n  iconSet.lgIconCart,\n  iconSet.lgIconChartBar,\n  iconSet.lgIconChartDonut,\n  iconSet.lgIconChartLine,\n  iconSet.lgIconChartPie,\n  iconSet.lgIconChatGroup,\n  iconSet.lgIconChat,\n  iconSet.lgIconCheckboxChecked,\n  iconSet.lgIconCheckboxEmpty,\n  iconSet.lgIconCheckboxIndeterminate,\n  iconSet.lgIconCheckmarkSpotFill,\n  iconSet.lgIconCheckmarkSpot,\n  iconSet.lgIconCheckmark,\n  iconSet.lgIconChevronDownFilled,\n  iconSet.lgIconChevronDownSlim,\n  iconSet.lgIconChevronDown,\n  iconSet.lgIconChevronLeftCircle,\n  iconSet.lgIconChevronLeftSlim,\n  iconSet.lgIconChevronLeft,\n  iconSet.lgIconChevronRightCircle,\n  iconSet.lgIconChevronRightSlim,\n  iconSet.lgIconChevronRight,\n  iconSet.lgIconChevronUpFilled,\n  iconSet.lgIconChevronUpSlim,\n  iconSet.lgIconChevronUp,\n  iconSet.lgIconCloseSpot,\n  iconSet.lgIconClose,\n  iconSet.lgIconCloud,\n  iconSet.lgIconCode,\n  iconSet.lgIconCollaborate,\n  iconSet.lgIconCompass,\n  iconSet.lgIconConnect,\n  iconSet.lgIconConsole,\n  iconSet.lgIconContributions,\n  iconSet.lgIconCopy,\n  iconSet.lgIconCount,\n  iconSet.lgIconCouple,\n  iconSet.lgIconCreditCard,\n  iconSet.lgIconCrossmarkSpotFill,\n  iconSet.lgIconCsv,\n  iconSet.lgIconData,\n  iconSet.lgIconDatabase,\n  iconSet.lgIconDataset,\n  iconSet.lgIconDelete,\n  iconSet.lgIconDesktop,\n  iconSet.lgIconDiagram,\n  iconSet.lgIconDigg,\n  iconSet.lgIconDoc,\n  iconSet.lgIconDocumentAdd,\n  iconSet.lgIconDocumentSubtract,\n  iconSet.lgIconDocumentTasks,\n  iconSet.lgIconDocument,\n  iconSet.lgIconDownload,\n  iconSet.lgIconDragHandle,\n  iconSet.lgIconDrilldown,\n  iconSet.lgIconEdit,\n  iconSet.lgIconEditNote,\n  iconSet.lgIconEmail,\n  iconSet.lgIconErrorFill,\n  iconSet.lgIconError,\n  iconSet.lgIconEvent,\n  iconSet.lgIconExitFill,\n  iconSet.lgIconExit,\n  iconSet.lgIconExport,\n  iconSet.lgIconFaceDissatisfiedFill,\n  iconSet.lgIconFaceDissatisfied,\n  iconSet.lgIconFaceHappyFill,\n  iconSet.lgIconFaceHappy,\n  iconSet.lgIconFaceNeutralFill,\n  iconSet.lgIconFaceNeutral,\n  iconSet.lgIconFaceSatisfiedFill,\n  iconSet.lgIconFaceSatisfied,\n  iconSet.lgIconFaceUnhappyFill,\n  iconSet.lgIconFacebook,\n  iconSet.lgIconFamily,\n  iconSet.lgIconFavouriteFill,\n  iconSet.lgIconFavourite,\n  iconSet.lgIconFilter,\n  iconSet.lgIconFolderAdd,\n  iconSet.lgIconFolder,\n  iconSet.lgIconFollow,\n  iconSet.lgIconForum,\n  iconSet.lgIconFunds,\n  iconSet.lgIconFurntiure,\n  iconSet.lgIconGenderFemale,\n  iconSet.lgIconGenderMale,\n  iconSet.lgIconGif,\n  iconSet.lgIconGithub,\n  iconSet.lgIconGlobe,\n  iconSet.lgIconGoogle,\n  iconSet.lgIconGotoBottom,\n  iconSet.lgIconGotoFirst,\n  iconSet.lgIconGotoLast,\n  iconSet.lgIconGotoTop,\n  iconSet.lgIconGroup,\n  iconSet.lgIconGuillemetLeft,\n  iconSet.lgIconGuillemetRight,\n  iconSet.lgIconHamburgerMenu,\n  iconSet.lgIconHd,\n  iconSet.lgIconHdr,\n  iconSet.lgIconHedgingCurrency,\n  iconSet.lgIconHedging,\n  iconSet.lgIconHelp,\n  iconSet.lgIconHighlight,\n  iconSet.lgIconHomeFill,\n  iconSet.lgIconHome,\n  iconSet.lgIconHouse,\n  iconSet.lgIconIdea,\n  iconSet.lgIconImage,\n  iconSet.lgIconInformationFill,\n  iconSet.lgIconInformation,\n  iconSet.lgIconInsert,\n  iconSet.lgIconInstagram,\n  iconSet.lgIconJuniorIsa,\n  iconSet.lgIconLandlord,\n  iconSet.lgIconLaunch,\n  iconSet.lgIconLearn,\n  iconSet.lgIconLikeFill,\n  iconSet.lgIconLike,\n  iconSet.lgIconLinkExternal,\n  iconSet.lgIconLink,\n  iconSet.lgIconLinkedin,\n  iconSet.lgIconListBullets,\n  iconSet.lgIconListChecked,\n  iconSet.lgIconListNumbered,\n  iconSet.lgIconList,\n  iconSet.lgIconLocationArrow,\n  iconSet.lgIconLocation,\n  iconSet.lgIconLockedFill,\n  iconSet.lgIconLocked,\n  iconSet.lgIconMaLgi,\n  iconSet.lgIconMail,\n  iconSet.lgIconMap,\n  iconSet.lgIconMaximise,\n  iconSet.lgIconMicrophoneOff,\n  iconSet.lgIconMicrophoneOn,\n  iconSet.lgIconMinimise,\n  iconSet.lgIconMisuseFill,\n  iconSet.lgIconMisuse,\n  iconSet.lgIconMobile,\n  iconSet.lgIconModule,\n  iconSet.lgIconMoney,\n  iconSet.lgIconMove,\n  iconSet.lgIconNeedHelp,\n  iconSet.lgIconNewTab,\n  iconSet.lgIconNews,\n  iconSet.lgIconNotes,\n  iconSet.lgIconNotificationOff,\n  iconSet.lgIconNotificationOn,\n  iconSet.lgIconOpenInNewWindow,\n  iconSet.lgIconOverflowHorizontal,\n  iconSet.lgIconOverflowVertical,\n  iconSet.lgIconOverlay,\n  iconSet.lgIconPage,\n  iconSet.lgIconPages,\n  iconSet.lgIconPartnership,\n  iconSet.lgIconPassword,\n  iconSet.lgIconPause,\n  iconSet.lgIconPdf,\n  iconSet.lgIconPensionPot,\n  iconSet.lgIconPerson,\n  iconSet.lgIconPet,\n  iconSet.lgIconPhoneOff,\n  iconSet.lgIconPhoneOn,\n  iconSet.lgIconPlaySpot,\n  iconSet.lgIconPlay,\n  iconSet.lgIconPng,\n  iconSet.lgIconPopUp,\n  iconSet.lgIconPresentationFile,\n  iconSet.lgIconPrinter,\n  iconSet.lgIconProfile,\n  iconSet.lgIconQueryFill,\n  iconSet.lgIconQuery,\n  iconSet.lgIconQuestionMark,\n  iconSet.lgIconRadioButtonSelected,\n  iconSet.lgIconRadioButtonUnselected,\n  iconSet.lgIconRecommend,\n  iconSet.lgIconRenew,\n  iconSet.lgIconRepeat,\n  iconSet.lgIconReply,\n  iconSet.lgIconReport,\n  iconSet.lgIconReset,\n  iconSet.lgIconRestart,\n  iconSet.lgIconRetirement,\n  iconSet.lgIconReward,\n  iconSet.lgIconRss,\n  iconSet.lgIconScaleDown,\n  iconSet.lgIconScaleUp,\n  iconSet.lgIconScan,\n  iconSet.lgIconSearch,\n  iconSet.lgIconSecureMessaging,\n  iconSet.lgIconSecurity,\n  iconSet.lgIconSend,\n  iconSet.lgIconSettings,\n  iconSet.lgIconShare,\n  iconSet.lgIconSignIn,\n  iconSet.lgIconSign,\n  iconSet.lgIconSkipBack,\n  iconSet.lgIconSkipForward,\n  iconSet.lgIconSlack,\n  iconSet.lgIconStarFill,\n  iconSet.lgIconStarHalfFill,\n  iconSet.lgIconStar,\n  iconSet.lgIconStop,\n  iconSet.lgIconSubtract,\n  iconSet.lgIconSvg,\n  iconSet.lgIconSwitchFunds,\n  iconSet.lgIconTag,\n  iconSet.lgIconTime,\n  iconSet.lgIconTimeDelay,\n  iconSet.lgIconTrash,\n  iconSet.lgIconTwitter,\n  iconSet.lgIconUnhappy,\n  iconSet.lgIconUnlockedFill,\n  iconSet.lgIconUnlocked,\n  iconSet.lgIconUpload,\n  iconSet.lgIconUserOnline,\n  iconSet.lgIconUsers,\n  iconSet.lgIconVideo,\n  iconSet.lgIconViewModeOff,\n  iconSet.lgIconViewModeOn,\n  iconSet.lgIconViewTransactions,\n  iconSet.lgIconVolumeDown,\n  iconSet.lgIconVolumeMute,\n  iconSet.lgIconVolumeUp,\n  iconSet.lgIconWarningFill,\n  iconSet.lgIconWarning,\n  iconSet.lgIconYoutube,\n  iconSet.lgIconZoomInFill,\n  iconSet.lgIconZoomIn,\n  iconSet.lgIconZoomOutFill,\n  iconSet.lgIconZoomOut,\n];\n\n@Component({\n  selector: 'lg-swatch-icon',\n  template: `\n    <div class=\"swatch\" *ngFor=\"let icon of icons\">\n      <lg-icon class=\"swatch__svg\" [name]=\"icon.name\" [attr.style]=\"colourVar\"> </lg-icon>\n      <span class=\"swatch__name\">{{ icon.name }}</span>\n    </div>\n  `,\n  styles: [\n    `\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-sm);\n        flex: 1 1 225px;\n      }\n\n      .swatch__svg {\n        margin-right: var(--space-md);\n      }\n    `,\n  ],\n})\nclass SwatchIconComponent implements OnChanges {\n  @Input() colour: string;\n\n  icons = iconsArray;\n  colourVar: SafeStyle;\n\n  constructor(private registry: LgIconRegistry, private sanitizer: DomSanitizer) {\n    this.registry.registerIcons(this.icons);\n  }\n\n  ngOnChanges({ colour }: SimpleChanges) {\n    if (colour && colour.currentValue) {\n      this.colourVar = this.sanitizer.bypassSecurityTrustStyle(\n        `color: var(${colour.currentValue})`,\n      );\n    }\n  }\n}\n\nconst colours = [\n  '--color-charcoal',\n  '--color-super-blue',\n  '--color-leafy-green-dark',\n  '--color-poppy-red-dark',\n];\n\nexport default {\n  title: 'Components/Icon',\n  excludeStories: ['iconsArray'],\n  decorators: [\n    moduleMetadata({\n      declarations: [SwatchIconComponent, LgIconComponent],\n    }),\n  ],\n  parameters: {\n    docs: {\n      description: {\n        component: notes,\n      },\n    },\n  },\n  argTypes: {\n    colour: {\n      options: colours,\n      description: 'Example of changing the colour of the icon',\n      control: {\n        type: 'select',\n      },\n    },\n  },\n};\n\nconst exampleTemplate = `\n<lg-icon name=\"call\"></lg-icon>\n`;\n\nconst iconsTemplate: Story<LgIconComponent> = (args: LgIconComponent) => ({\n  props: args,\n  template: '<lg-swatch-icon [colour]=\"colour\"></lg-swatch-icon>',\n});\n\nexport const standardIcons = iconsTemplate.bind({});\nstandardIcons.storyName = 'Icon';\nstandardIcons.parameters = {\n  docs: {\n    description: {\n      component: notes,\n    },\n    source: {\n      code: exampleTemplate,\n    },\n  },\n};\n",
             "assetsDirs": [],
             "styleUrlsData": "",
             "stylesData": "\n      :host {\n        display: flex;\n        flex-wrap: wrap;\n      }\n\n      .swatch {\n        margin: var(--space-sm);\n        flex: 1 1 225px;\n      }\n\n      .swatch__svg {\n        margin-right: var(--space-md);\n      }\n    \n",
@@ -30533,21 +30533,21 @@
                 "name": "detailsTemplate",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "Story<LgHeadingComponent>",
-                "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
-            },
-            {
-                "name": "detailsTemplate",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/header/header.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "Story<LgHeaderComponent>",
                 "defaultValue": "(args: LgHeaderComponent) => ({\n  props: args,\n  template,\n})"
+            },
+            {
+                "name": "detailsTemplate",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "Story<LgHeadingComponent>",
+                "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
             },
             {
                 "name": "detailsTemplate",
@@ -34193,26 +34193,6 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/label/label.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/select/select-field.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34233,6 +34213,36 @@
                 "name": "nextUniqueId",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/label/label.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "number",
+                "defaultValue": "0"
+            },
+            {
+                "name": "nextUniqueId",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/toggle/toggle.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34244,16 +34254,6 @@
                 "ctype": "miscellaneous",
                 "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "number",
-                "defaultValue": "0"
-            },
-            {
-                "name": "nextUniqueId",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "number",
@@ -34303,16 +34303,6 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/styles/mixins.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/styles/typography.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34343,21 +34333,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` service and register your brand icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgBrandIconSun } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    // register the icon using the \\`brandIconRegistry\\` service\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<!-- with default size and colour -->\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n\n<!-- with a size set -->\n<lg-brand-icon name=\"sun\" size=\"sm\"></lg-brand-icon>\n\n<!-- with a colour set -->\n<lg-brand-icon name=\"sun\" colour=\"--color-lily-green\"></lg-brand-icon>\n~~~\n\n## Branding / Colours\nThe yellow fill colour of the brand icons can be changed globally  by overriding the \\`--brand-icon-fill-primary\\` css variable. Note that changing this variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input on the component.\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/alert/alert.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` service and register your brand icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgBrandIconSun } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    // register the icon using the \\`brandIconRegistry\\` service\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<!-- with default size and colour -->\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n\n<!-- with a size set -->\n<lg-brand-icon name=\"sun\" size=\"sm\"></lg-brand-icon>\n\n<!-- with a colour set -->\n<lg-brand-icon name=\"sun\" colour=\"--color-lily-green\"></lg-brand-icon>\n~~~\n\n## Branding / Colours\nThe yellow fill colour of the brand icons can be changed globally  by overriding the \\`--brand-icon-fill-primary\\` css variable. Note that changing this variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input on the component.\n`"
             },
             {
                 "name": "notes",
@@ -34453,31 +34443,21 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/grid/grid.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/heading/heading.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\nThis component allows for headings to be set dynamically.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeadingModule ],\n})\n~~~\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/header/header.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/grid/grid.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
             },
             {
                 "name": "notes",
@@ -34513,6 +34493,16 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/page/page.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/modal/modal.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34523,11 +34513,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/page/page.notes.ts",
+                "file": "projects/canopy/src/lib/heading/heading.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
+                "defaultValue": "`\nThis component allows for headings to be set dynamically.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeadingModule ],\n})\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -34563,11 +34553,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/separator/separator.notes.ts",
+                "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n`"
+                "defaultValue": "`\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -34583,11 +34573,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
+                "file": "projects/canopy/src/lib/side-nav/side-nav.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n`"
+                "defaultValue": "`\n# Side Nav Component\n\n## Purpose\n\nSide Navs are components that allow the user to define a series of navigation items that display content in a predefined area.\n\n### Side Nav Bar\n\nHere is where the navigation menu items are put. The links, once clicked on, will display their routes'\ncontent in the Side Nav Content component.\nOn mobile devices, the menu is below the content area, instead of to the left.\n\n### Side Nav Bar Link\nThis \\`lgSideNavBarLink\\` directive applies the appropriate styling to the links. It also emits an event when the link is activated.\n\n### Side Nav Bar Footer\n\nThe footer is below the navigation items and can hold different kinds of content (e.g. a button).\n\n### Side Nav Content\n\nThis is the predefined area where content is shown. It should always contain a router outlet to be able to display\nthe different nav item routes.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgSideNavModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-side-nav>\n    <lg-side-nav-bar label=\"Side Nav Demo\">\n      <a id=\"side-nav-0\"\n         [routerLink]=\"'firstPage'\"\n         [isActive]=\"true\"\n         lgSideNavBarLink\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Overview</lg-side-nav-bar-item-heading>\n        </lg-side-nav-bar-item>\n      </a>\n      <a id=\"side-nav-1\"\n         [routerLink]=\"'secondPage'\"\n         lgSideNavBarLink\n        >\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Personal details</lg-side-nav-bar-item-heading>\n            <lg-side-nav-bar-item-content>Your name, date of birth, marital status and National Insurance Number.</lg-side-nav-bar-item-content>\n        </lg-side-nav-bar-item>\n      </a>\n      <lg-side-nav-bar-footer>\n        <a lg-button lgMarginTop=\"xxl\" variant=\"outline-primary\" [fullWidth]=\"false\" href=\"#\">Logout</a>\n      </lg-side-nav-bar-footer>\n    </lg-side-nav-bar>\n    <lg-side-nav-content tabindex=\"0\">\n      <router-outlet></router-outlet>\n    </lg-side-nav-content>\n</lg-side-nav>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-------:|:--------:|\n| isActive | specifies whether or not the navigation link is in an active state | boolean | false | No\n`"
             },
             {
                 "name": "notes",
@@ -34603,11 +34593,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/side-nav/side-nav.notes.ts",
+                "file": "projects/canopy/src/lib/separator/separator.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Side Nav Component\n\n## Purpose\n\nSide Navs are components that allow the user to define a series of navigation items that display content in a predefined area.\n\n### Side Nav Bar\n\nHere is where the navigation menu items are put. The links, once clicked on, will display their routes'\ncontent in the Side Nav Content component.\nOn mobile devices, the menu is below the content area, instead of to the left.\n\n### Side Nav Bar Link\nThis \\`lgSideNavBarLink\\` directive applies the appropriate styling to the links. It also emits an event when the link is activated.\n\n### Side Nav Bar Footer\n\nThe footer is below the navigation items and can hold different kinds of content (e.g. a button).\n\n### Side Nav Content\n\nThis is the predefined area where content is shown. It should always contain a router outlet to be able to display\nthe different nav item routes.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgSideNavModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-side-nav>\n    <lg-side-nav-bar label=\"Side Nav Demo\">\n      <a id=\"side-nav-0\"\n         [routerLink]=\"'firstPage'\"\n         [isActive]=\"true\"\n         lgSideNavBarLink\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Overview</lg-side-nav-bar-item-heading>\n        </lg-side-nav-bar-item>\n      </a>\n      <a id=\"side-nav-1\"\n         [routerLink]=\"'secondPage'\"\n         lgSideNavBarLink\n        >\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Personal details</lg-side-nav-bar-item-heading>\n            <lg-side-nav-bar-item-content>Your name, date of birth, marital status and National Insurance Number.</lg-side-nav-bar-item-content>\n        </lg-side-nav-bar-item>\n      </a>\n      <lg-side-nav-bar-footer>\n        <a lg-button lgMarginTop=\"xxl\" variant=\"outline-primary\" [fullWidth]=\"false\" href=\"#\">Logout</a>\n      </lg-side-nav-bar-footer>\n    </lg-side-nav-bar>\n    <lg-side-nav-content tabindex=\"0\">\n      <router-outlet></router-outlet>\n    </lg-side-nav-content>\n</lg-side-nav>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-------:|:--------:|\n| isActive | specifies whether or not the navigation link is in an active state | boolean | false | No\n`"
+                "defaultValue": "`\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -34618,6 +34608,16 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nThe spinner component should always be used together with the \\`\\`LgSrAlertMessageDirective\\`\\` as screen reader users should\nbe notified when something has finished loading.\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/table/table.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
             },
             {
                 "name": "notes",
@@ -34638,16 +34638,6 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Tabs Component\n\n## Purpose\nThe tabs component lets users navigate between related sections of content, displaying one section at a time.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tabs [headingLevel]=\"1\" label=\"Title\" (tabEvent)=\"tabEvent($event)\">\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 1</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi posuere nec leo nec hendrerit. Pellentesque eu lacinia tortor. Donec urna felis, dictum et faucibus et, interdum ut urna. Nam eleifend eleifend mi vel blandit. Morbi rutrum a odio in pharetra. Quisque vitae lacus efficitur, elementum mauris in, porta nisl. Praesent porttitor accumsan ante, sed efficitur nunc placerat in. Etiam non lorem leo. Aenean magna lacus, iaculis at velit non, congue commodo dui. Pellentesque tempus elementum tempor.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 2</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Maecenas laoreet tristique ligula, mollis ullamcorper est faucibus eget. Aenean quis placerat arcu. Sed efficitur odio nunc, id facilisis orci accumsan eget. Nunc feugiat elit eget imperdiet faucibus. Maecenas faucibus sit amet nisi a ultricies. Donec id scelerisque ante, eget tempus dui. Fusce semper ex eu lorem pellentesque tristique. Proin non augue quis orci lobortis rhoncus. Aliquam quis luctus ipsum. Maecenas vulputate porta mauris, id lacinia turpis feugiat sed. Aenean et commodo elit, a dignissim massa. Fusce facilisis laoreet orci quis vehicula. Curabitur eu lacus vitae libero laoreet hendrerit at quis magna.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 3</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. Donec at nibh eros. Pellentesque at nunc in elit egestas pellentesque a quis nunc. Praesent commodo risus in metus tincidunt pretium. Nulla vehicula sem lectus, ac eleifend velit pellentesque a. Proin et varius ante, nec venenatis nulla. Pellentesque pharetra risus lorem, et congue ligula interdum volutpat. Donec ut iaculis metus. Nunc rutrum vestibulum ex nec condimentum. Pellentesque nec volutpat quam. Etiam tortor arcu, eleifend ut ante id, ullamcorper tristique libero. Praesent imperdiet, orci in tincidunt aliquet, quam sapien convallis nunc, non maximus dui lacus sed lacus. Suspendisse ut tortor dui.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n  <lg-tab-item>\n    <lg-tab-item-heading>Tab 4</lg-tab-item-heading>\n    <lg-tab-item-content>\n      <div class=\"lg-tabs__content-section\">\n        <p>Pellentesque finibus ac libero ac rutrum. Morbi faucibus, dui et efficitur posuere, urna ipsum vehicula dui, in placerat risus felis et lectus. Vivamus imperdiet nulla nisi, eget varius mi cursus nec. Suspendisse quis risus eleifend, pretium lectus eget, condimentum leo. Aliquam faucibus at mi sit amet volutpat. Nunc nec orci sapien. Duis augue quam, bibendum in enim a, ultricies luctus mi. Aliquam eleifend magna est, eget sagittis massa malesuada quis. Maecenas mattis tortor sit amet mi sagittis, vitae aliquam dui rhoncus. Aenean sed erat eu ante ornare sollicitudin in et est.</p>\n      </div>\n    </lg-tab-item-content>\n  </lg-tab-item>\n</lg-tabs>\n~~~\n\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | The value to apply to the aria label | string | tabs | Yes |\n| \\`\\`headingLevel\\`\\` | The level of the tab headings: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | n/a | Yes |\n\n## Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`tabEvent\\`\\` | Event emitted when the selected tab changes | EventEmitter<{ index: number }> | n/a | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/table/table.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
             },
             {
                 "name": "notes",
@@ -34703,6 +34693,16 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
+            },
+            {
+                "name": "notes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/radio/radio.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -34713,11 +34713,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
+                "defaultValue": "`\n# Sort Code Directive\n\n## Purpose\nProvides a directive to apply formatting and specific validators to the input component for entering a sort code.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Sort Code\n  <lg-hint *ngIf=\"hint\">Must be 6 digits long</lg-hint>\n  <input lgInput lgSortCode formControlName=\"sortCode\" />\n</lg-input-field>\n~~~\n\n**Note: both the \\`lgInput\\` and \\`lgSortCode\\` directives have to be present on the input element.**\n\n## Validators\nThe sort code directive automatically adds the \\`required\\` and \\`pattern\\` validators by default.\nThe \\`pattern\\` validator checks that the sort code value has the following patterns: \\`000000\\`, \\`00 00 00\\` or \\`00-00-00\\`.\n\n## Format of the control value\nOn blur of the input we auto-format the value of the control to \\`00-00-00\\`.\n\n-----------------------------------------------------\n\n# Deprecated: Sort Code Component\n\n## Purpose\n**Please use the directive above instead.**\n\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
             },
             {
                 "name": "notes",
@@ -34753,11 +34753,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
+                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\n# Sort Code Directive\n\n## Purpose\nProvides a directive to apply formatting and specific validators to the input component for entering a sort code.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Sort Code\n  <lg-hint *ngIf=\"hint\">Must be 6 digits long</lg-hint>\n  <input lgInput lgSortCode formControlName=\"sortCode\" />\n</lg-input-field>\n~~~\n\n**Note: both the \\`lgInput\\` and \\`lgSortCode\\` directives have to be present on the input element.**\n\n## Validators\nThe sort code directive automatically adds the \\`required\\` and \\`pattern\\` validators by default.\nThe \\`pattern\\` validator checks that the sort code value has the following patterns: \\`000000\\`, \\`00 00 00\\` or \\`00-00-00\\`.\n\n## Format of the control value\nOn blur of the input we auto-format the value of the control to \\`00-00-00\\`.\n\n-----------------------------------------------------\n\n# Deprecated: Sort Code Component\n\n## Purpose\n**Please use the directive above instead.**\n\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
+                "defaultValue": "`\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgCamelCasePipeModule ],\n})\n~~~\n`"
             },
             {
                 "name": "notes",
@@ -34773,11 +34773,11 @@
                 "name": "notes",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "`\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgCamelCasePipeModule ],\n})\n~~~\n`"
+                "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
             },
             {
                 "name": "notes",
@@ -34788,16 +34788,6 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
-            },
-            {
-                "name": "notes",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
             },
             {
                 "name": "offsets",
@@ -35251,7 +35241,7 @@
                 "name": "spaces",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
@@ -35261,7 +35251,7 @@
                 "name": "spaces",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "[]",
@@ -35311,6 +35301,16 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/table/table.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `\n    <table lg-table [showColumnsAt]=\"columnBreakpoint\" [variant]=\"variant\">\n      <thead lg-table-head>\n        <tr lg-table-row>\n          <th lg-table-head-cell [showLabel]=\"showAuthorLabel\">Author</th>\n          <th lg-table-head-cell [align]=\"alignTitleColumn\">Title</th>\n          <th lg-table-head-cell [align]=\"alignPublishColumn\">Published</th>\n        </tr>\n      </thead>\n\n      <tbody lg-table-body>\n        <tr lg-table-row *ngFor=\"let book of books\">\n          <td lg-table-cell [stack]=\"stack\">{{ book.author }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.title }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.published }}</td>\n        </tr>\n      </tbody>\n    </table>\n  `,\n\n  props: {\n    books: object('Books', getDefaultTableContent(), 'Table data'),\n    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),\n    alignTitleColumn: select(\n      'Align Title column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.Start,\n      'Alignment',\n    ),\n    alignPublishColumn: select(\n      'Align Publish column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.End,\n      'Alignment',\n    ),\n    columnBreakpoint: select(\n      'Minimum breakpoint where column layout is used',\n      [\n        TableColumnLayoutBreakpoints.Small,\n        TableColumnLayoutBreakpoints.Medium,\n        TableColumnLayoutBreakpoints.Large,\n      ],\n      TableColumnLayoutBreakpoints.Medium,\n      'Responsive options',\n    ),\n    showAuthorLabel: boolean(\n      'Display author label in non-columns view (showLabel)',\n      false,\n      'Responsive options',\n    ),\n    stack: boolean(\n      'Stack label and content in non-columns view (stack)',\n      false,\n      'Responsive options',\n    ),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/tabs/tab-nav-bar.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -35326,16 +35326,6 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "() => ({\n  template: `\n  <lg-tabs [headingLevel]=\"headingLevel\"\n    label=\"Annuities\"\n    (tabEvent)=\"tabEvent($event)\"\n    [lgMarginRight]=\"'none'\"\n    [lgMarginBottom]=\"'none'\"\n    [lgMarginLeft]=\"'none'\"\n  >\n    <lg-tab-item *ngFor=\"let tab of tabs\">\n      <lg-tab-item-heading>{{ tab.header }}</lg-tab-item-heading>\n      <lg-tab-item-content>\n        <div class=\"lg-tabs__content-section\">{{ tab.content }}</div>\n      </lg-tab-item-content>\n    </lg-tab-item>\n  </lg-tabs>\n  `,\n  props: {\n    tabs: object('Tabs', getDefaultTabsContent()),\n    headingLevel: select('headingLevel', [1, 2, 3, 4, 5, 6], 2),\n    tabEvent: action('tab selected'),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/table/table.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `\n    <table lg-table [showColumnsAt]=\"columnBreakpoint\" [variant]=\"variant\">\n      <thead lg-table-head>\n        <tr lg-table-row>\n          <th lg-table-head-cell [showLabel]=\"showAuthorLabel\">Author</th>\n          <th lg-table-head-cell [align]=\"alignTitleColumn\">Title</th>\n          <th lg-table-head-cell [align]=\"alignPublishColumn\">Published</th>\n        </tr>\n      </thead>\n\n      <tbody lg-table-body>\n        <tr lg-table-row *ngFor=\"let book of books\">\n          <td lg-table-cell [stack]=\"stack\">{{ book.author }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.title }}</td>\n          <td lg-table-cell [stack]=\"stack\">{{ book.published }}</td>\n        </tr>\n      </tbody>\n    </table>\n  `,\n\n  props: {\n    books: object('Books', getDefaultTableContent(), 'Table data'),\n    variant: select('Variant', ['striped', 'bordered'], 'striped', 'Variant'),\n    alignTitleColumn: select(\n      'Align Title column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.Start,\n      'Alignment',\n    ),\n    alignPublishColumn: select(\n      'Align Publish column',\n      [AlignmentOptions.End, AlignmentOptions.Start],\n      AlignmentOptions.End,\n      'Alignment',\n    ),\n    columnBreakpoint: select(\n      'Minimum breakpoint where column layout is used',\n      [\n        TableColumnLayoutBreakpoints.Small,\n        TableColumnLayoutBreakpoints.Medium,\n        TableColumnLayoutBreakpoints.Large,\n      ],\n      TableColumnLayoutBreakpoints.Medium,\n      'Responsive options',\n    ),\n    showAuthorLabel: boolean(\n      'Display author label in non-columns view (showLabel)',\n      false,\n      'Responsive options',\n    ),\n    stack: boolean(\n      'Stack label and content in non-columns view (stack)',\n      false,\n      'Responsive options',\n    ),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -35371,6 +35361,16 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
+                "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
+            },
+            {
+                "name": "standard",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
                 "file": "projects/canopy/src/lib/forms/radio/radio.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
@@ -35391,11 +35391,11 @@
                 "name": "standard",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
+                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n  },\n})"
             },
             {
                 "name": "standard",
@@ -35436,16 +35436,6 @@
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
-            },
-            {
-                "name": "standard",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
-                "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n  },\n})"
             },
             {
                 "name": "standardAccordion",
@@ -35621,7 +35611,7 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -35631,7 +35621,7 @@
                 "name": "stories",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
@@ -35671,21 +35661,21 @@
                 "name": "template",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/styles/grid.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n  <div>\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Responsive sizing and offsets</h2>\n          <p>Responsive modifiers enable specifying different column sizes and offsets at xs, sm, md & lg viewport widths.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-6 lg-col-sm-6 lg-col-md-8 lg-col-lg-10\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-6 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-12 lg-col-sm-9 lg-col-md-10 lg-col-lg-11\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-10 lg-col-sm-6 lg-col-md-8 lg-col-lg-10\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-2 lg-col-sm-6 lg-col-md-4 lg-col-lg-2\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Responsive alignment and distribution</h2>\n          <p>Responsive modifiers enable specifying different alignment and distribution at xs, sm, md & lg viewport widths.</p>\n          <p>Here the sidebar is displayed first below the md viewport size, and second beyond that.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-9 lg-last-xs lg-first-md\">\n          <div class=\"box\">Main content</div>\n        </div>\n        <div class=\"lg-col-xs-3 lg-first-xs lg-last-md\">\n          <div class=\"box\">Sidebar</div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Fluid</h2>\n          <p>Percent based widths allow fluid resizing of columns and rows.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-3\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-9\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-4\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-8\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-5\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-7\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-6\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-6\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Offsets</h2>\n          <p>Offset a column</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-offset-11 lg-col-xs-1\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-10 lg-col-xs-2\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-9 lg-col-xs-3\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-8 lg-col-xs-4\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-7 lg-col-xs-5\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-6 lg-col-xs-6\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-5 lg-col-xs-7\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-4 lg-col-xs-8\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-3 lg-col-xs-9\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-2 lg-col-xs-10\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-1 lg-col-xs-11\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Auto Width</h2>\n          <p>Add any number of auto sizing columns to a row. Let the grid figure it out.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Nested Grid</h2>\n          <p>Nest grids inside grids inside grids.</p>\n        </div>\n      </div>\n      <div class=\"lg-row nested\">\n        <div class=\"lg-col-xs-7\">\n          <div class=\"box\">\n            <div class=\"lg-row\">\n              <div class=\"lg-col-xs-9\">\n                <div class=\"box\">\n                  <div class=\"lg-row\">\n                    <div class=\"lg-col-xs-4\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                    <div class=\"lg-col-xs-8\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n              <div class=\"lg-col-xs-3\">\n                <div class=\"box\">\n                  <div class=\"lg-row\">\n                    <div class=\"lg-col-xs\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n            </div>\n          </div>\n        </div>\n        <div class=\"lg-col-xs-5\">\n          <div class=\"box\">\n            <div class=\"lg-row\">\n              <div class=\"lg-col-xs-12\">\n                <div class=\"box\">\n                  <div class=\"lg-row\">\n                    <div class=\"lg-col-xs-6\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                    <div class=\"lg-col-xs-6\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </div>\n`"
-            },
-            {
-                "name": "template",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/styles/links.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n  Lorem ipsum dolor sit amet, consectetur adipiscing elit <a href=\"#\">Inline link example</a> and <a href=\"#\" style=\"display: inline-block\">inline block link example</a>\n  Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n  <lg-alert variant=\"generic\" lgMarginTop=\"lg\">Example of <a href=\"#\">link text</a> within an alert.</lg-alert>\n  <lg-alert variant=\"info\">Example of <a href=\"#\">link text</a> within an alert.</lg-alert>\n  <lg-alert variant=\"success\">Example of <a href=\"#\">link text</a> within an alert.</lg-alert>\n  <lg-alert variant=\"error\">Example of <a href=\"#\">link text</a> within an alert.</lg-alert>\n`"
+            },
+            {
+                "name": "template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/styles/grid.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n  <div>\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Responsive sizing and offsets</h2>\n          <p>Responsive modifiers enable specifying different column sizes and offsets at xs, sm, md & lg viewport widths.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-6 lg-col-sm-6 lg-col-md-8 lg-col-lg-10\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-6 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12 lg-col-sm-3 lg-col-md-2 lg-col-lg-1\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-12 lg-col-sm-9 lg-col-md-10 lg-col-lg-11\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-10 lg-col-sm-6 lg-col-md-8 lg-col-lg-10\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-2 lg-col-sm-6 lg-col-md-4 lg-col-lg-2\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Responsive alignment and distribution</h2>\n          <p>Responsive modifiers enable specifying different alignment and distribution at xs, sm, md & lg viewport widths.</p>\n          <p>Here the sidebar is displayed first below the md viewport size, and second beyond that.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-9 lg-last-xs lg-first-md\">\n          <div class=\"box\">Main content</div>\n        </div>\n        <div class=\"lg-col-xs-3 lg-first-xs lg-last-md\">\n          <div class=\"box\">Sidebar</div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Fluid</h2>\n          <p>Percent based widths allow fluid resizing of columns and rows.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-3\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-9\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-4\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-8\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-5\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-7\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-6\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-6\">\n          <div class=\"box\">\n          </div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Offsets</h2>\n          <p>Offset a column</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-offset-11 lg-col-xs-1\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-10 lg-col-xs-2\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-9 lg-col-xs-3\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-8 lg-col-xs-4\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-7 lg-col-xs-5\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-6 lg-col-xs-6\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-5 lg-col-xs-7\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-4 lg-col-xs-8\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-3 lg-col-xs-9\">\n            <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-2 lg-col-xs-10\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs-offset-1 lg-col-xs-11\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Auto Width</h2>\n          <p>Add any number of auto sizing columns to a row. Let the grid figure it out.</p>\n        </div>\n      </div>\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs\">\n          <div class=\"box\"></div>\n        </div>\n        <div class=\"lg-col-xs\">\n          <div class=\"box\"></div>\n        </div>\n      </div>\n    </div>\n\n    <div class=\"lg-container\">\n      <div class=\"lg-row\">\n        <div class=\"lg-col-xs-12\">\n          <h2>Nested Grid</h2>\n          <p>Nest grids inside grids inside grids.</p>\n        </div>\n      </div>\n      <div class=\"lg-row nested\">\n        <div class=\"lg-col-xs-7\">\n          <div class=\"box\">\n            <div class=\"lg-row\">\n              <div class=\"lg-col-xs-9\">\n                <div class=\"box\">\n                  <div class=\"lg-row\">\n                    <div class=\"lg-col-xs-4\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                    <div class=\"lg-col-xs-8\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n              <div class=\"lg-col-xs-3\">\n                <div class=\"box\">\n                  <div class=\"lg-row\">\n                    <div class=\"lg-col-xs\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n            </div>\n          </div>\n        </div>\n        <div class=\"lg-col-xs-5\">\n          <div class=\"box\">\n            <div class=\"lg-row\">\n              <div class=\"lg-col-xs-12\">\n                <div class=\"box\">\n                  <div class=\"lg-row\">\n                    <div class=\"lg-col-xs-6\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                    <div class=\"lg-col-xs-6\">\n                      <div class=\"box\">\n                      </div>\n                    </div>\n                  </div>\n                </div>\n              </div>\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </div>\n`"
             },
             {
                 "name": "template",
@@ -35761,21 +35751,21 @@
                 "name": "template",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`\n  <lg-heading [level]=\"level\">{{content}}</lg-heading>\n`"
-            },
-            {
-                "name": "template",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/header/header.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`\n  <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n`"
+            },
+            {
+                "name": "template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`\n  <lg-heading [level]=\"level\">{{content}}</lg-heading>\n`"
             },
             {
                 "name": "template",
@@ -35871,21 +35861,21 @@
                 "name": "template",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
-                "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.stories.ts",
-                "deprecated": false,
-                "deprecationMessage": "",
-                "type": "",
-                "defaultValue": "`<p>{{text | kebabCase}}</p>`"
-            },
-            {
-                "name": "template",
-                "ctype": "miscellaneous",
-                "subtype": "variable",
                 "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.stories.ts",
                 "deprecated": false,
                 "deprecationMessage": "",
                 "type": "",
                 "defaultValue": "`<p>{{text | camelCase}}</p>`"
+            },
+            {
+                "name": "template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/canopy/src/lib/pipes/kebab-case/kebab-case.stories.ts",
+                "deprecated": false,
+                "deprecationMessage": "",
+                "type": "",
+                "defaultValue": "`<p>{{text | kebabCase}}</p>`"
             },
             {
                 "name": "textWithIcon",
@@ -38436,38 +38426,6 @@
                     "defaultValue": "`\n <footer lg-footer\n   [copyright]=\"copyright\"\n   [logo]=\"logo\"\n   [logoAlt]=\"logoAlt\"\n   [primaryLinks]=\"primaryLinks\"\n   [secondaryLinks]=\"secondaryLinks\"\n   (primaryLinkClicked)=\"clickedLink($event)\"\n   (secondaryLinkClicked)=\"clickedLink($event)\">\n </footer>\n`"
                 }
             ],
-            "projects/canopy/src/lib/heading/heading.stories.ts": [
-                {
-                    "name": "detailsTemplate",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "Story<LgHeadingComponent>",
-                    "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
-                },
-                {
-                    "name": "standardHeading",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "detailsTemplate.bind({})"
-                },
-                {
-                    "name": "template",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n  <lg-heading [level]=\"level\">{{content}}</lg-heading>\n`"
-                }
-            ],
             "projects/canopy/src/lib/header/header.stories.ts": [
                 {
                     "name": "detailsTemplate",
@@ -38498,6 +38456,38 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n  <header lg-header [logo]=\"logo\" [logoAlt]=\"logoAlt\" [logoHref]=\"logoHref\"></header>\n`"
+                }
+            ],
+            "projects/canopy/src/lib/heading/heading.stories.ts": [
+                {
+                    "name": "detailsTemplate",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "Story<LgHeadingComponent>",
+                    "defaultValue": "(args: LgHeadingComponent) => ({\n  props: args,\n  template,\n})"
+                },
+                {
+                    "name": "standardHeading",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "detailsTemplate.bind({})"
+                },
+                {
+                    "name": "template",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/heading/heading.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n  <lg-heading [level]=\"level\">{{content}}</lg-heading>\n`"
                 }
             ],
             "projects/canopy/src/lib/modal/modal.stories.ts": [
@@ -42244,30 +42234,6 @@
                     "defaultValue": "0"
                 }
             ],
-            "projects/canopy/src/lib/forms/label/label.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/label/label.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/radio/radio-button.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
             "projects/canopy/src/lib/forms/select/select-field.component.ts": [
                 {
                     "name": "nextUniqueId",
@@ -42292,6 +42258,42 @@
                     "defaultValue": "0"
                 }
             ],
+            "projects/canopy/src/lib/forms/label/label.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/label/label.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/radio/radio-button.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/radio/radio-button.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
+            "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts": [
+                {
+                    "name": "nextUniqueId",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "number",
+                    "defaultValue": "0"
+                }
+            ],
             "projects/canopy/src/lib/forms/toggle/toggle.component.ts": [
                 {
                     "name": "nextUniqueId",
@@ -42310,18 +42312,6 @@
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/forms/validation/validation.component.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "number",
-                    "defaultValue": "0"
-                }
-            ],
-            "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts": [
-                {
-                    "name": "nextUniqueId",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.component.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "number",
@@ -42376,18 +42366,6 @@
                     "defaultValue": "`\nThe links styles are applied automatically when adding the global Canopy css.\n\nFor custom components it's possible to override the style of a link by using the \\`lg-unstyled-link\\`.\n`"
                 }
             ],
-            "projects/canopy/src/styles/mixins.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/styles/mixins.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n\n`"
-                }
-            ],
             "projects/canopy/src/styles/typography.notes.ts": [
                 {
                     "name": "notes",
@@ -42424,18 +42402,6 @@
                     "defaultValue": "`\nAccordions allow users to quickly expand and collapse grouped sections of content.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAccordionModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n  <lg-accordion [headingLevel]=\"2\">\n    <lg-accordion-item [isActive]=\"isActive\" (opened)=\"handleItemOpened()\" (closed)=\"handleItemClosed()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\n        tempor incididunt ut labore et dolore magna aliqua.</p>\n    </lg-accordion-item>\n    <lg-accordion-item>\n      <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>\n      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\n        ut aliquip ex ea commodo consequat. Duis aute irure dolor in\n        reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla\n        pariatur.</p>\n      <button lg-button lgMarginTop=\"sm\" variant=\"solid-primary\">\n        Test primary button\n      </button>\n    </lg-accordion-item>\n    <lg-accordion-item (opened)=\"loadDynamicContent()\">\n      <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>\n\n      <ng-template lgAccordionItemContent>\n        <app-dynamic-component [content]=\"dynamicContentItems$ | async\">\n            An example component that loads data from the network when this panel is opened.\n        </app-dynamic-component>\n      </ng-template>\n    </lg-accordion-item>\n  </lg-accordion>\n~~~\n\n## Accordion Item Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | The active state of the accordion item | boolean | false | No |\n\n\n## Accordion Item Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`opened\\`\\` | Event emitted when the accordion item is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the accordion item is closed | EventEmitter<void> | n/a | No |\n\n\n## Lazy content initialisation\n\nWrap the panel content in a \\`ng-template\\` with the \\`lgAccordionContent\\` directive to only initialise and render\nthe panel when it is first opened.\n`"
                 }
             ],
-            "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` service and register your brand icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgBrandIconSun } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    // register the icon using the \\`brandIconRegistry\\` service\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<!-- with default size and colour -->\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n\n<!-- with a size set -->\n<lg-brand-icon name=\"sun\" size=\"sm\"></lg-brand-icon>\n\n<!-- with a colour set -->\n<lg-brand-icon name=\"sun\" colour=\"--color-lily-green\"></lg-brand-icon>\n~~~\n\n## Branding / Colours\nThe yellow fill colour of the brand icons can be changed globally  by overriding the \\`--brand-icon-fill-primary\\` css variable. Note that changing this variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input on the component.\n`"
-                }
-            ],
             "projects/canopy/src/lib/alert/alert.notes.ts": [
                 {
                     "name": "notes",
@@ -42446,6 +42412,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\nAlerts are used to communicate important information to the user.\n\nThe \"alert\" ARIA role is automatically added to the component if it's one of these variants: \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`. Note that this role will tell the browser to send out an accessible alert event to assistive technology products which can then notify the user about it.\n\nA decorative icon is also added next to the heading if it's one of the these variants: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\`.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgAlertModule ],\n})\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/brand-icon/brand-icon.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\nProvides a way of adding common brand icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgBrandIconModule],\n})\n~~~\n\nImport the \\`LgBrandIconRegistry\\` service and register your brand icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgBrandIconSun } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  constructor(private brandIconRegistry: LgBrandIconRegistry) {\n    // register the icon using the \\`brandIconRegistry\\` service\n    this.brandIconRegistry.registerBrandIcon([\n      lgBrandIconSun\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<!-- with default size and colour -->\n<lg-brand-icon name=\"sun\"></lg-brand-icon>\n\n<!-- with a size set -->\n<lg-brand-icon name=\"sun\" size=\"sm\"></lg-brand-icon>\n\n<!-- with a colour set -->\n<lg-brand-icon name=\"sun\" colour=\"--color-lily-green\"></lg-brand-icon>\n~~~\n\n## Branding / Colours\nThe yellow fill colour of the brand icons can be changed globally  by overriding the \\`--brand-icon-fill-primary\\` css variable. Note that changing this variable will update the fill colour of all the icons.\n\nTo change the colour of a specific icon use the \\`colour\\` input on the component.\n`"
                 }
             ],
             "projects/canopy/src/lib/breadcrumb/breadcrumb.notes.ts": [
@@ -42556,30 +42534,6 @@
                     "defaultValue": "`\nProvides a generic footer for display at the bottom of the page.\nThe component uses an attribute selector which allows you to use the html [footer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~\n@NgModule({\n  ...\n  imports: [LgFooterModule],\n})\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/grid/grid.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/grid/grid.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
-                }
-            ],
-            "projects/canopy/src/lib/heading/heading.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/heading/heading.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\nThis component allows for headings to be set dynamically.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeadingModule ],\n})\n~~~\n`"
-                }
-            ],
             "projects/canopy/src/lib/header/header.notes.ts": [
                 {
                     "name": "notes",
@@ -42590,6 +42544,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\nProvides a generic header for display at the top of the page.\nThe current implementation is brand agnostic but eventually the branding should be encapsulated into the component.\nThe component uses an attribute selector which allows you to use the html [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) element as the host.\n\nThe logo height is set internally with different heights for different screen sizes, it can not currently be modified to ensure consistency.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgHeaderModule],\n})\n~~~\n`"
+                }
+            ],
+            "projects/canopy/src/lib/grid/grid.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/grid/grid.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Grid Directive\n\n## Purpose\nThe grid directives are used to apply grid classes in order to create multi column layouts.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule],\n})\n~~~\n\nThere are three directives included in this module, which can all be added to Canopy or native HTML components.\nA simple one column responsive grid which expands to two columns for larger screen sizes could be created with the following markup:\n\n~~~html\n<div lgContainer>\n  <div lgRow>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 1</div>\n    <div [lgCol]=\"12\" [lgColMd]=\"6\">Column 2</div>\n  </div>\n</div>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgContainer\\`\\` | Adds the grid container class to the element | null | null | No |\n| \\`\\`lgRow\\`\\` | Adds the row class to the element | null | null | No |\n| \\`\\`lgCol\\`\\` | Specifies the number of columns to fill in a 12 column layout | number (1-12) | null | Yes |\n| \\`\\`lgColMd\\`\\` | Specifies the number of columns to fill in a 12 column layout on a medium sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColLg\\`\\` | Specifies the number of columns to fill in a 12 column layout on a large sized screen | number (1-12) | null | Yes |\n| \\`\\`lgColOffset\\`\\` | Specifies the number of columns to offset in a 12 column layout | number (0-11) | null | Yes |\n| \\`\\`lgColMdOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a medium sized screen | number (0-11) | null | Yes |\n| \\`\\`lgColLgOffset\\`\\` | Specifies the number of columns to offset fill in a 12 column layout on a large sized screen | number (0-11) | null | Yes |\n\n## Using only the SCSS files\n\nRefer to the scss [grid documentation](/?path=/story/grid--grid)\n\n`"
                 }
             ],
             "projects/canopy/src/lib/hero/hero.notes.ts": [
@@ -42628,6 +42594,18 @@
                     "defaultValue": "`\nProvides a way of adding common svg icons.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgIconModule],\n})\n~~~\n\nImport the \\`LgIconRegistry\\` service and register your icons inside your module:\n\n~~~js\n// import the desired icon\nimport { lgIconEmail } from '@legal-and-general/canopy';\n\nexport class AppModule {\n  // register the icon using the \\`LgIconRegistry\\` service\n  constructor(private iconRegistry: LgIconRegistry) {\n    this.iconRegistry.registerIcons([\n      lgIconEmail\n    ]);\n  }\n}\n~~~\n\nYour HTML:\n\n~~~html\n<lg-icon \n  name=\"email\">\n</lg-icon>\n~~~\n\nAll icons have height and width equal to 1em. This means the icons will be as big as the font-size specified by the parent.\n\n*By default the icons have the \\`\\`fill\\`\\` css property set to \\`\\`currentColor\\`\\`.*\n\n> \\`\\`currentColor\\`\\` acts like a variable for the current value of the \\`\\`color\\`\\` property on the element. And the Cascading part of CSS is still effective, so if there’s no defined \\`\\`color\\`\\` property on an element, the cascade will determine the value of \\`\\`currentColor\\`\\`.\n>\n> *Understanding the currentColor Keyword in CSS - https://alligator.io/css/currentcolor/*\n\n*Please note that the 'need-help' and 'question-mark' icons currently don't have the ability to change colour.*\n`"
                 }
             ],
+            "projects/canopy/src/lib/page/page.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/page/page.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
+                }
+            ],
             "projects/canopy/src/lib/modal/modal.notes.ts": [
                 {
                     "name": "notes",
@@ -42640,16 +42618,16 @@
                     "defaultValue": "`\nProvides a modal component for displaying content.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgModalModule ],\n})\n~~~\n\nOpening and closing the modal is possible by using the \\`\\`ModalService\\`\\`.\nImport the service:\n\n~~~js\n  constructor(\n    private modalService: LgModalService,\n    ...\n  ) {}\n~~~\n\nTo open the modal:\n\n~~~js\n  this.modalService.open(<modal-id>)\n~~~\n\nand to close it:\n\n~~~js\n  this.modalService.close(<modal-id>)\n~~~\n\n## Inputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | The unique id of the modal | string | undefined | Yes |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | The level of the modal heading: \\`\\`1\\`\\`, \\`\\`2\\`\\`, \\`\\`3\\`\\`, \\`\\`4\\`\\`, \\`\\`5\\`\\`, \\`\\`6\\`\\` | number | 2 | No |\n\n### LgModalBodyTimerComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`timer\\`\\` | The timer value (in seconds) to apply the styles and formatting to e.g. '90' will be formatted as '1:30' | number | n/a | Yes |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgModalTrigger\\`\\` | The unique id of the modal to trigger | string | undefined | Yes |\n\n## Outputs\n\n### LgModalComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`open\\`\\` | Event emitted when the modal is opened | EventEmitter<void> | n/a | No |\n| \\`\\`closed\\`\\` | Event emitted when the modal is closed | EventEmitter<void> | n/a | No |\n\n### LgModalHeaderComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`closed\\`\\` | Event emitted when the close button is clicked | EventEmitter<void> | n/a | No |\n\n### LgModalTriggerDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`clicked\\`\\` | Event emitted when the trigger button is clicked | EventEmitter<void> | n/a | No |\n\n`"
                 }
             ],
-            "projects/canopy/src/lib/page/page.notes.ts": [
+            "projects/canopy/src/lib/heading/heading.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/page/page.notes.ts",
+                    "file": "projects/canopy/src/lib/heading/heading.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Page Component\n\n## Purpose\nProvides a page layout with content projection slots for standard header and footer.\n\n## Usage\nThe page component works best when combined with the [grid module](/?path=/story/directives--grid) which can be used to provide a responsive layout for the main content.\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgGridModule, LgPageModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-page>\n  <header lg-header></header>\n  <div lgContainer>\n    <div lgRow>\n      <div\n          lgCol=\"12\"\n          lgColMd=\"8\"\n          lgColMdOffset=\"2\"\n          lgColLg=\"6\"\n          lgColLgOffset=\"3\"\n        >\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card1Content}}</lg-card-content></lg-card>\n        <lg-card lgMarginHorizontal=\"none\"><lg-card-content>{{card2Content}}</lg-card-content></lg-card>\n      </div>\n    </div>\n  </div>\n  <footer lg-footer></footer>\n</lg-page>\n~~~\n\n## Inputs\n\n### LgPageComponent\n\nContent projection slots\n\n| Name | Description |\n|------|-------------|\n| \\`\\`lg-header\\`\\` | Provides a slot for the standard header component\n| \\`\\`lg-footer\\`\\` | Provides a slot for the standard footer component\n| \\`\\`<default>\\`\\` | Any other components are projected into the central column\n\nIt is possible to wrap the lg-header and lg-footer components and still use the page component.\nYou can do this by using the [ngProjectAs](https://medium.com/ignite-ui/using-ng-content-ngprojectas-1664d7c1d3b) attribute.\n\n~~~html\n<lg-page>\n  <app-header ngProjectAs=\"[lg-header]\"></app-header>\n  <router-outlet></router-outlet>\n  <app-footer ngProjectAs=\"[lg-footer]\"></app-footer>\n</lg-page>\n~~~\n`"
+                    "defaultValue": "`\nThis component allows for headings to be set dynamically.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgHeadingModule ],\n})\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/primary-message/primary-message.notes.ts": [
@@ -42688,16 +42666,16 @@
                     "defaultValue": "`\n# Promo Card List Component\n\n## Purpose\n\nPromo Cards allow you to arrange content in a card-like manner for promotional purposes. Promo Cards are organised by a\nPromo Card List and will be displayed in columns on desktops and stacked on mobile devices.\n\n### Content guidelines\n\nEach Promo Card should respect the following conventions:\n\n- Title - max 33 characters (with spaces)\n- Content - max 140 characters (with spaces)\n- Button - max 20 characters (with spaces)\n- Image - max 620px x 620px\n\nThis is not enforced in the code, but it should be followed as close as possible to ensure optimal user experience.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgPromoCardModule ],\n})\n~~~\n\nand in your HTML, place your Promo Cards in your Promo Card List:\n\n~~~html\n<lg-promo-card-list>\n  <lg-separator [variant]=\"dotted\" lgMargin=\"none\"></lg-separator>\n  <lg-promo-card-list-title [headingLevel]=\"headingLevel\">\n    Get more from Legal &amp; General\n  </lg-promo-card-list-title>\n  <lg-promo-card\n    [variant]=\"variant\">\n    <lg-promo-card-image [imageUrl]=\"imageUrl\"></lg-promo-card-image>\n    <lg-promo-card-title [headingLevel]=\"headingLevelInner\">\n      Need help with Care?\n    </lg-promo-card-title>\n    <lg-promo-card-content>\n      <p>Our care service can help you understand, find and fund care for you or a loved one.</p>\n    </lg-promo-card-content>\n    <lg-promo-card-footer>\n      <button\n        lgMarginBottom=\"none\"\n        lg-button\n        type=\"button\"\n        [variant]=\"variant\">\n        Find out more\n      </button>\n    </lg-promo-card-footer>\n  </lg-promo-card>\n</lg-promo-card-list>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`headingLevel\\`\\` | Allows the card (list) heading level to be set | number | n/a | Yes |\n| \\`\\`variant\\`\\` | The variant of promo card: \\`\\`solid-white\\`\\`, \\`\\`solid-green\\`\\` | PromoCardVariant | 'solid-white' | No |\n| \\`\\`imageUrl\\`\\` | Identifies the card image | string | n/a | Yes |\n`"
                 }
             ],
-            "projects/canopy/src/lib/separator/separator.notes.ts": [
+            "projects/canopy/src/lib/show-at/show-at.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/separator/separator.notes.ts",
+                    "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n`"
+                    "defaultValue": "`\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/shadow/shadow.notes.ts": [
@@ -42712,16 +42690,16 @@
                     "defaultValue": "`\n# Shadow Directive\n\n## Purpose\nThis directive adds a box shadow to a component.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShadowModule],\n})\n~~~\n\nAnd in your HTML...\n\n~~~html\n<lg-card lgShadow>\n  <lg-card-content>\n    This card has a shadow\n  </lg-card-content>\n</lg-card>\n~~~\n\n`"
                 }
             ],
-            "projects/canopy/src/lib/show-at/show-at.notes.ts": [
+            "projects/canopy/src/lib/side-nav/side-nav.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/show-at/show-at.notes.ts",
+                    "file": "projects/canopy/src/lib/side-nav/side-nav.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\nThis utility directive allows for mobile-first media queries to be added to components, so they can be shown at the desired breakpoint, without the need to write additional CSS.\n\nFor example, you may need to show a component only when the viewport is wide enough, e.g. desktop.\n\nIt uses global CSS responsive utility classes to add the relevant classes.\n\nIt has a sibling directive: \\`\\`LgHideAt\\`\\`.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgShowAtModule],\n})\n~~~\n`"
+                    "defaultValue": "`\n# Side Nav Component\n\n## Purpose\n\nSide Navs are components that allow the user to define a series of navigation items that display content in a predefined area.\n\n### Side Nav Bar\n\nHere is where the navigation menu items are put. The links, once clicked on, will display their routes'\ncontent in the Side Nav Content component.\nOn mobile devices, the menu is below the content area, instead of to the left.\n\n### Side Nav Bar Link\nThis \\`lgSideNavBarLink\\` directive applies the appropriate styling to the links. It also emits an event when the link is activated.\n\n### Side Nav Bar Footer\n\nThe footer is below the navigation items and can hold different kinds of content (e.g. a button).\n\n### Side Nav Content\n\nThis is the predefined area where content is shown. It should always contain a router outlet to be able to display\nthe different nav item routes.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgSideNavModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-side-nav>\n    <lg-side-nav-bar label=\"Side Nav Demo\">\n      <a id=\"side-nav-0\"\n         [routerLink]=\"'firstPage'\"\n         [isActive]=\"true\"\n         lgSideNavBarLink\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Overview</lg-side-nav-bar-item-heading>\n        </lg-side-nav-bar-item>\n      </a>\n      <a id=\"side-nav-1\"\n         [routerLink]=\"'secondPage'\"\n         lgSideNavBarLink\n        >\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Personal details</lg-side-nav-bar-item-heading>\n            <lg-side-nav-bar-item-content>Your name, date of birth, marital status and National Insurance Number.</lg-side-nav-bar-item-content>\n        </lg-side-nav-bar-item>\n      </a>\n      <lg-side-nav-bar-footer>\n        <a lg-button lgMarginTop=\"xxl\" variant=\"outline-primary\" [fullWidth]=\"false\" href=\"#\">Logout</a>\n      </lg-side-nav-bar-footer>\n    </lg-side-nav-bar>\n    <lg-side-nav-content tabindex=\"0\">\n      <router-outlet></router-outlet>\n    </lg-side-nav-content>\n</lg-side-nav>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-------:|:--------:|\n| isActive | specifies whether or not the navigation link is in an active state | boolean | false | No\n`"
                 }
             ],
             "projects/canopy/src/lib/skeleton/skeleton.notes.ts": [
@@ -42736,16 +42714,16 @@
                     "defaultValue": "`\n# Skeleton Loading Directive\n\n## Purpose\nThe skeleton directive adds a skeleton loading state to a component or element.\n\n## Usage\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSkeletonModule],\n})\n~~~\n\nThe directive works on components that output text or projected content. On composite components that\nare made up of other child components, it is best to add the skeleton loading directive to the child\ncomponents or even wrap the projected content inside another element. E.g. In the example,\nthe \\`lg-data-point-label\\` projects the content into an \\`lg-heading\\` component,\nso the directive is added to a span wrapping the content. However, the \\`lg-data-point-value\\` component\nsimply projects the content only so the directive can be applied to the component itself.\n\n~~~html\n<lg-data-point>\n  <lg-data-point-label [headingLevel]=\"4\">\n    <span lgSkeleton lgSkeletonWidth=\"10\">{{ data?.label }}</span>\n  </lg-data-point-label>\n  <lg-data-point-value lgSkeleton lgSkeletonWidth=\"8\">\n    {{ data?.value }}\n  </lg-data-point-value>\n</lg-data-point>\n~~~\n\n## Inputs\n\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgSkeletonWidth\\`\\` | Override the default width with the desired value in ems | string | 100% | No |\n| \\`\\`lgSkeletonHeight\\`\\` | Override the default height with the desired value in ems | string | auto | No |\n\n`"
                 }
             ],
-            "projects/canopy/src/lib/side-nav/side-nav.notes.ts": [
+            "projects/canopy/src/lib/separator/separator.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/side-nav/side-nav.notes.ts",
+                    "file": "projects/canopy/src/lib/separator/separator.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Side Nav Component\n\n## Purpose\n\nSide Navs are components that allow the user to define a series of navigation items that display content in a predefined area.\n\n### Side Nav Bar\n\nHere is where the navigation menu items are put. The links, once clicked on, will display their routes'\ncontent in the Side Nav Content component.\nOn mobile devices, the menu is below the content area, instead of to the left.\n\n### Side Nav Bar Link\nThis \\`lgSideNavBarLink\\` directive applies the appropriate styling to the links. It also emits an event when the link is activated.\n\n### Side Nav Bar Footer\n\nThe footer is below the navigation items and can hold different kinds of content (e.g. a button).\n\n### Side Nav Content\n\nThis is the predefined area where content is shown. It should always contain a router outlet to be able to display\nthe different nav item routes.\n\n## Usage\n\nImport the component in your module:\n\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgSideNavModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-side-nav>\n    <lg-side-nav-bar label=\"Side Nav Demo\">\n      <a id=\"side-nav-0\"\n         [routerLink]=\"'firstPage'\"\n         [isActive]=\"true\"\n         lgSideNavBarLink\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Overview</lg-side-nav-bar-item-heading>\n        </lg-side-nav-bar-item>\n      </a>\n      <a id=\"side-nav-1\"\n         [routerLink]=\"'secondPage'\"\n         lgSideNavBarLink\n        >\n        <lg-side-nav-bar-item>\n            <lg-side-nav-bar-item-heading>Personal details</lg-side-nav-bar-item-heading>\n            <lg-side-nav-bar-item-content>Your name, date of birth, marital status and National Insurance Number.</lg-side-nav-bar-item-content>\n        </lg-side-nav-bar-item>\n      </a>\n      <lg-side-nav-bar-footer>\n        <a lg-button lgMarginTop=\"xxl\" variant=\"outline-primary\" [fullWidth]=\"false\" href=\"#\">Logout</a>\n      </lg-side-nav-bar-footer>\n    </lg-side-nav-bar>\n    <lg-side-nav-content tabindex=\"0\">\n      <router-outlet></router-outlet>\n    </lg-side-nav-content>\n</lg-side-nav>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-------:|:--------:|\n| isActive | specifies whether or not the navigation link is in an active state | boolean | false | No\n`"
+                    "defaultValue": "`\nSeparators are used to separate individual component or group of components.\n\n\n## Usage\n~~~js\n@NgModule({\n    ....\n    declarations: [ ..., LgSeparatorModule ],\n})\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/spinner/spinner.notes.ts": [
@@ -42758,6 +42736,18 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\nLoading spinners are used to notify the users that the next action is being loaded.\nThey are normally used on form submissions or loading cards when the data retrieval is typically slow.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSpinnerModule],\n})\n~~~\n\nThe spinner component should always be used together with the \\`\\`LgSrAlertMessageDirective\\`\\` as screen reader users should\nbe notified when something has finished loading.\n`"
+                }
+            ],
+            "projects/canopy/src/lib/table/table.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/table/table.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/sr-alert-message/sr-alert-message.notes.ts": [
@@ -42792,18 +42782,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Tab Navigation Bar Component\n\n## Purpose\nThe tabbed navigation bar provides a tab-like UI for navigating between routes or urls. The tabbed navigatiom bar is router agnostic, so you will need to place the \\`router-outlet\\` anywhere in your view. Don't forget to add the \\`aria-labelledby\\` attribute to the content output by the \\`router-outlet\\`.\nThe \\`isActive\\` property is used to select the current active tab.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTabsModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-tab-nav-bar label=\"Tabbed navigtion label\">\n  <a lgTabNavBarLink id=\"tabbed-nav-1\" [isActive]=\"true\" [routerLink]=\"\">Tab 1</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-2\" [routerLink]=\"\">Tab 2</a>\n  <a lgTabNavBarLink id=\"tabbed-nav-3\" [routerLink]=\"\">Tab 3</a>\n</lg-tab-nav-bar>\n<lg-tab-nav-content [selectedTabId]=\"tabbed-nav-1\">\n  <p>Insert router-outlet here.</p>\n</lg-tab-nav-content>\n~~~\n\n## \\`lg-tab-nav-bar\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`label\\`\\` | Label for the tab list| string | Tabs | No |\n\n## \\`lgTabNavBarLink\\` Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`index\\`\\` | Sets the tab index position in tab list | number | 0 | No |\n| \\`\\`isActive\\`\\` | Sets the active state of the tab | boolean | false | No |\n| \\`\\`isFocused\\`\\` | Sets the focus state of the tab | boolean | false | No |\n\n## \\`lgTabNavBarLink\\` Outputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Sets the current actve tab | boolean | undefined | No |\n\n## \\`lg-tab-nav-content\\` Inputs\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`selectedTabId\\`\\` | Sets the id of the current selected tab | string | undefined | No |\n\n`"
-                }
-            ],
-            "projects/canopy/src/lib/table/table.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/table/table.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Table Component\n\n## Purpose\nThe table component provides a way to present tabular data in a responsive format. On small screens, the layout of the table changes to display the table headers alongside each value, providing an easier way for users to read the data as they scroll down the list of rows.\n\nThere are several options that allow you to customise the table behaviour at for different uses cases and screen sizes.\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgTableModule ],\n})\n~~~\n\n### Simple example\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row>\n      <td lg-table-cell>Albert Camus</td>\n      <td lg-table-cell>The Plague</td>\n      <td lg-table-cell>1947</td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with expandable detail rows\n\nThis table adds the \\`\\`LgTableRowToggleComponent\\`\\`, and then an expandable detail row. This creates a table that allows the user to expand a row for more information. This can be seen on the <a href=\"/story/components-table--detail\">Expandable Detail story</a>.\n\n~~~html\n<table lg-table>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Author</th>\n      <th lg-table-head-cell>Book</th>\n      <th lg-table-head-cell>Published</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td>\n        <lg-table-row-toggle\n          (click)=\"<function-to-handle-click>\"\n          [isActive]=\"<logic-to-handle-toggle>\"\n        >\n        </lg-table-row-toggle>\n      </td>\n    <td lg-table-cell>Orhan Pamuk</td>\n      <td lg-table-cell>Strangeness in my Mind</td>\n      <td lg-table-cell>2016</td>\n    </tr>\n    <tr lg-table-row [isHidden]=\"<logic-to-handle-row>\">\n      <td lg-table-cell>\n        <lg-table-expanded-detail>\n          Detail content goes here\n        </lg-table-expanded-detail>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n### Table with long copy\n\nSometimes a table can be used to display large amounts of copy, including buttons, links and headings.\n\nNote that each \\`\\`LgTableCellComponent\\`\\` has the \\`\\`stack\\`\\` Input set to \\`\\`true\\`\\`, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of \\`\\`<colgroup>\\`\\` to control width of the columns on large screens. This can be seen on the <a href=\"/story/components-table--with-long-copy\">Table With Long Copy story</a>.\n\nAlso note the use of the \\`\\`LgMarginDirective\\`\\`, such as \\`\\`lgMarginBottom=\"xs\"\\`\\`, to add extra space around content, making it more readable.\n\n~~~html\n<table lg-table>\n  <colgroup>\n    <col span=\"1\" style=\"width: 65%;\" />\n    <col span=\"1\" style=\"width: 35%;\" />\n  </colgroup>\n  <thead lg-table-head>\n    <tr lg-table-row>\n      <th lg-table-head-cell>Item</th>\n      <th lg-table-head-cell>More information</th>\n    </tr>\n  </thead>\n\n  <tbody lg-table-body>\n    <tr lg-table-row>\n      <td lg-table-cell [stack]=\"true\">\n        <h3 lgMarginVertical=\"xs\">Item one: Lorem ipsum dolor sit amet</h3>\n        <p lgMarginBottom=\"xs\">consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>\n      </td>\n      <td lg-table-cell [showLabel]=\"false\" [stack]=\"true\">\n        <p>Sed ut perspiciatis</p>\n        <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n        <button lg-quick-action><lg-icon name=\"information-fill\"></lg-icon>Find out more</button>\n      </td>\n    </tr>\n  </tbody>\n</table>\n~~~\n\n\n## Inputs\n\n### LgTableComponent\nA component that acts as a standard table.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`showColumnsAt\\`\\` | Sets the minimum screen width from which the column layout is displayed. Accepts \\`sm\\`, \\`md\\` or \\`lg\\` | string | 'md' | No |\n| \\`\\`variant\\`\\` | The variant of table. Accepts \\`striped\\` or \\`bordered\\` | string | 'striped' | No |\n\n\n### LgTableBodyComponent\nA component that acts as a standard table body.\n\n### LgTableCellComponent\nA component that acts as a standard table cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`stack\\`\\` | On small screens, stack the label and the content on top of each other, instead of side by side | boolean | false | No |\n| \\`\\`colspan\\`\\` | Sets the colspan attribute on the column when specified | number | undefined | No |\n\n### LgTableExpandedDetailComponent\nA component that provides the ability to add content to expandable rows.\n\n### LgTableHeadComponent\nA component that acts as a standard table head.\n\n### LgTableHeadCellComponent\nA component that acts as a standard table header cell.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`align\\`\\` | Alignment option for the header and its respective column | \\`\\`start\\`\\`, \\`\\`end\\`\\` | n/a | No |\n| \\`\\`showLabel\\`\\` | Whether to show label for this header in each row in non-column layout | boolean | true | No |\n\n### LgTableRowComponent\nA component that acts as a standard table row.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isHidden\\`\\` | Determines if the row is hidden | boolean | false | No |\n\n### LgTableRowToggleComponent\nA component that creates a icon for toggling the expanded state.\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`isActive\\`\\` | Determines if the toggle displays in the active state | boolean | false | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/variant/variant.notes.ts": [
@@ -42866,6 +42844,18 @@
                     "defaultValue": "`\n# Input Field Component\n\n## Purpose\n\nThe Input Field component (\\`\\`<lg-input-field>\\`\\`) provides a flexible way to render a Canopy input. It contains a \\`\\`<label>\\`\\` and an \\`\\`<input>\\`\\` element. The \\`\\`lgInput\\`\\` directive should be added to the input element.\n\nThe Input Field component creates the layout, deals with linking the label and input for screen readers, and also renders the border around the actual input element - this is to allow for the addition of buttons/icons to appear inside the field (e.g. \"clear\" button).\n\nYou can add a hint, validation message or prefix/suffix buttons or icons (see examples below).\n\nThe width can be controlled by the HTML size attribute which should be added to \\`\\`<input>\\`\\` element itself.\n\n## Usage\nImport the input module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgInputModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Name\n  <lg-hint>Please enter your name</lg-hint>\n  <input lgInput size=\"12\" formControlName=\"name\" />\n</lg-input-field>\n~~~\n\n---\n\n\n### Adding input buttons\n\nButtons can be added within input fields to provide functionality linked to the input.\nThe \\`lgSuffix\\` directive needs to be added to the button to place it in the correct place.\nOnly small size buttons should be placed in the input field.\nThere is an additional 'add-on' button variant for adding a button to the input field which inherits the button spacing but no background or border colours.\n\n#### Button suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\">\n    Search\n  </button>\n</lg-input-field>\n~~~\n\n#### Icon Button suffix with add-on class\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <button lg-button lgSuffix size=\"sm\" [iconButton]=\"true\" variant=\"add-on\">\n    <lg-icon name=\"search\" />\n  </button>\n</lg-input-field>\n~~~\n\n### Adding prefixes and suffixes\n\nPrefix and suffix text can be added to input fields using the \\`lgSuffix\\` and \\`lgPrefix\\` directive.\n\n#### Text prefix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgPrefix>£</span>\n</lg-input-field>\n~~~\n\n#### Text suffix\n\n~~~html\n<lg-input-field>\n  Name\n  <input lgInput formControlName=\"name\" />\n  <span lgSuffix>%</span>\n</lg-input-field>\n~~~\n\n## Inputs\n\n### LgInputDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-input-\\${nextUniqueId++}' | No |\n\n### LgInputFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-input-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the input full width (for small screens only). | boolean | false | no\n| \\`\\`showLabel\\`\\` | Show or visually hide the label | boolean | true | No |\n`"
                 }
             ],
+            "projects/canopy/src/lib/forms/select/select.notes.ts": [
+                {
+                    "name": "notes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
+                }
+            ],
             "projects/canopy/src/lib/forms/radio/radio.notes.ts": [
                 {
                     "name": "notes",
@@ -42878,16 +42868,16 @@
                     "defaultValue": "(name: string) => `\nProvides a set of components to implement ${name} buttons in a form. The ${name} Group component is a container which displays the label with an optional hint and should contain two or more ${name} Button components. The ${name} Button component represents a single ${name} button. The Hint component may be used to provide extra context to the user.\n\n## Usage\nImport the Radio Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgRadioModule],\n})\n~~~\n\n\\\n${\n  name === 'Segment'\n    ? `### Displaying the buttons at different breakpoints\n\nRadios are displayed inline, unless given a \\`RadioStackBreakpoint\\`, which tells them at which breakpoint should they appear stacked on top of each other:\n\n~~~html\n<lg-segment-group [stack]=\"sm\" formControlName=\"color\">\n  Colour\n  <lg-segment-button value=\"red\">Red</lg-segment-button>\n  <lg-segment-button value=\"yellow\">Yellow</lg-segment-button>\n</lg-segment-group>\n~~~\n    `\n    : ''\n}\n\n## Inputs\n\n### LgRadioGroupComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-group-id-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | Set the name value for all inputs in the group, auto-generated if not provided | string | 'lg-radio-group-\\${nextUniqueId++}' | No |\n| \\`\\`value\\`\\` | Set the default checked radio button, must match the value of the radio button | boolean or string | null | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n${\n  name === 'Radio'\n    ? `| \\`\\`inline\\`\\` | If true, displays the radio buttons inline rather than stacked | boolean | false | No |`\n    : name === 'Segment'\n    ? `| \\`\\`stack\\`\\` | Stack the radio buttons at a given breakpoint | 'sm', 'md', 'lg' | false | No |`\n    : ''\n}\n\n### LgRadioButtonComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-radio-button-\\${++nextUniqueId}' | No |\n| \\`\\`name\\`\\` | HTML name attribute | string | null | Yes |\n| \\`\\`value\\`\\` | HTML value attribute | string | null | Yes |\n`"
                 }
             ],
-            "projects/canopy/src/lib/forms/select/select.notes.ts": [
+            "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select.notes.ts",
+                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Select Component\n\n## Purpose\nProvides a common select directive and select field component. The select field component controls custom select box styling and linking the label and field.\nThe width of the select field is controlled by the size of the options contained with in it.\n\n## Usage\nImport the component in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgFormsModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-select-field>\n  Color\n  <select lgSelect formControlName=\"color\">\n    <option value=\"red\">Red</option>\n    <option value=\"blue\">Blue</option>\n    <option value=\"green\">Green</option>\n    <option value=\"yellow\">Yellow</option>\n  </select>\n</lg-select-field>\n~~~\n\n## Inputs\n\n### LgSelectDirective\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`name\\`\\` | HTML Name attribute, auto generated if not provided | string | 'lg-select-\\${nextUniqueId++}' | No |\n\n### LgSelectFieldComponent\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`id\\`\\` | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | string | 'lg-select-\\${nextUniqueId++}' | No |\n| \\`\\`block\\`\\` | Property to make the select field full width (for small screens only). | boolean | false | no\n`"
+                    "defaultValue": "`\n# Sort Code Directive\n\n## Purpose\nProvides a directive to apply formatting and specific validators to the input component for entering a sort code.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Sort Code\n  <lg-hint *ngIf=\"hint\">Must be 6 digits long</lg-hint>\n  <input lgInput lgSortCode formControlName=\"sortCode\" />\n</lg-input-field>\n~~~\n\n**Note: both the \\`lgInput\\` and \\`lgSortCode\\` directives have to be present on the input element.**\n\n## Validators\nThe sort code directive automatically adds the \\`required\\` and \\`pattern\\` validators by default.\nThe \\`pattern\\` validator checks that the sort code value has the following patterns: \\`000000\\`, \\`00 00 00\\` or \\`00-00-00\\`.\n\n## Format of the control value\nOn blur of the input we auto-format the value of the control to \\`00-00-00\\`.\n\n-----------------------------------------------------\n\n# Deprecated: Sort Code Component\n\n## Purpose\n**Please use the directive above instead.**\n\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
                 }
             ],
             "projects/canopy/src/lib/forms/toggle/toggle.notes.ts": [
@@ -42926,16 +42916,16 @@
                     "defaultValue": "`\n# Error Component\n\n\n## Purpose\nThe validation component is used to provide contextual information for a form input field. The most common use case is to display validation errors however it can also be used to show additional information.\n\n\n## Usage\n~~~js\n@NgModule({\n  ...\n  imports: [ ..., LgValidationModule ],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-validation>Enter a valid postcode</lg-validation>\n\n<lg-validation variant=\"success\">Username is available</lg-validation>\n~~~\n\n## Inputs\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`variant\\`\\` | The variant of the validation: \\`\\`info\\`\\`, \\`\\`warning\\`\\`, \\`\\`error\\`\\`, \\`\\`success\\`\\` | string | 'error' | No |\n| \\`\\`showIcon\\`\\` | Whether the icon should display | boolean | true | No |\n`"
                 }
             ],
-            "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts": [
+            "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.notes.ts",
+                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\n# Sort Code Directive\n\n## Purpose\nProvides a directive to apply formatting and specific validators to the input component for entering a sort code.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<lg-input-field>\n  Sort Code\n  <lg-hint *ngIf=\"hint\">Must be 6 digits long</lg-hint>\n  <input lgInput lgSortCode formControlName=\"sortCode\" />\n</lg-input-field>\n~~~\n\n**Note: both the \\`lgInput\\` and \\`lgSortCode\\` directives have to be present on the input element.**\n\n## Validators\nThe sort code directive automatically adds the \\`required\\` and \\`pattern\\` validators by default.\nThe \\`pattern\\` validator checks that the sort code value has the following patterns: \\`000000\\`, \\`00 00 00\\` or \\`00-00-00\\`.\n\n## Format of the control value\nOn blur of the input we auto-format the value of the control to \\`00-00-00\\`.\n\n-----------------------------------------------------\n\n# Deprecated: Sort Code Component\n\n## Purpose\n**Please use the directive above instead.**\n\nProvides a form component that can be used to capture a sort code in three individual input fields. The result, when used in a reactive form, is a concatenation of the three values into one string e.g. '204060'. The overall field is only valid if all three input fields are populated with 2 digits.\n\n## Usage\nImport the Sort Code Module into your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgSortCodeModule],\n})\n~~~\n\nand in your HTML:\n\n~~~html\n<form [formGroup]=\"form\" (ngSubmit)=\"...\" #validationForm=\"ngForm\">\n  <lg-sort-code formControlName=\"sortCode\">\n    Sort Code\n    <lg-hint id=\"hintId\">Must be 6 digits long</lg-hint>\n    <lg-validation id=\"errorId\" *ngIf=\"isControlInvalid(sortCode, validationForm)\">\n      Your sort code should be a 6 digit number\n    </lg-validation>\n  </lg-sort-code>\n\n  <button type=\"submit\">Submit</button>\n</form>\n~~~\n\n**Note: for the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.**\n\n## Inputs\n\n### LgSortCodeComponent\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`value\\`\\` | Existing 6 digit sort code string that will prepopulate the three input fields appropriately | string | '' | No |\n| \\`\\`disabled\\`\\` | Set the three inner input fields to disabled if \\`\\`true\\`\\` | boolean | \\`\\`false\\`\\` | No |\n| \\`\\`focus\\`\\` | Set the focus on the fieldset | boolean | null | No |\n| \\`\\`labelId\\`\\` | HTML ID attribute for the sort code fieldset label, auto generated if not provided | string | \\`\\`lg-input-sort-code-label-\\${nextUniqueId}\\`\\` | No |\n| \\`\\`ariaDescribedBy\\`\\` | HTML ID for the corresponding element that describes the sort code field, if not provided it will use the ID attribute from the Hint field if present | string | null | No |\n\n## Validation\n\nAll three input fields are required for the overall sort code field to be valid, and all three must be populated with 2 digits only.\n\nThe form will return \\`requiredField\\` when all of the inputs are left empty and \\`invalidField\\` when any of the inputs are invalid.\n\nFor the validation to work properly it's very important to include the \\`ngForm\\` on the form tag and for the submit button to be within the form.\n\n`"
+                    "defaultValue": "`\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgCamelCasePipeModule ],\n})\n~~~\n`"
                 }
             ],
             "projects/canopy/src/lib/pipes/kebab-case/kebab-case.notes.ts": [
@@ -42950,16 +42940,16 @@
                     "defaultValue": "`\nThis pipe allows for a string to be transformed into kebab case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgKebabCasePipeModule ],\n})\n~~~\n`"
                 }
             ],
-            "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts": [
+            "projects/canopy/src/lib/spacing/margin/margin.notes.ts": [
                 {
                     "name": "notes",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/pipes/camel-case/camel-case.notes.ts",
+                    "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "`\nThis pipe allows for a string to be transformed into camel case.\n\n## Usage\nImport the pipe in your module:\n\n~~~\n@NgModule({\n  ...\n  imports: [ ..., LgCamelCasePipeModule ],\n})\n~~~\n`"
+                    "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/spacing/padding/padding.notes.ts": [
@@ -42972,18 +42962,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "`\n# Padding Directive\n\n## Purpose\nThis directive allows for custom padding to be added without the need to write additional CSS. It's useful for overriding the default padding on Canopy components, as well as general use within your app. Using this directive ensures that your padding adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgPaddingModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgPadding\\`\\` attribute has no value, the default padding will remain. You can also override individual padding such as \\`\\`padding-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgPaddingTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgPadding=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgPadding]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same padding at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different padding at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the padding at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPaddingBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` padding to the left and right\n\n~~~html\n<lg-card lgPaddingHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` padding all round, but \\`\\`xxxl\\`\\` padding to the bottom\n\n~~~html\n<lg-card lgPadding=\"xl\" lgPaddingBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` padding to the top and bottom\n\n~~~html\n<lg-card lgPaddingVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` padding, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` padding, all around the component.\n\n~~~html\n<lg-card [lgPadding]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` padding, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` padding, at the bottom of the component.\n\n~~~html\n<lg-card [lgPaddingBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgPadding\\`\\` | The padding variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingTop\\`\\` | The padding variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingRight\\`\\` | The padding variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingBottom\\`\\` | The padding variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingLeft\\`\\` | The padding variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingHorizontal\\`\\` | The padding variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgPaddingVertical\\`\\` | The padding variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
-                }
-            ],
-            "projects/canopy/src/lib/spacing/margin/margin.notes.ts": [
-                {
-                    "name": "notes",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/margin/margin.notes.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "`\n# Margin Directive\n\n## Purpose\nThis directive allows for custom margin to be added without the need to write additional CSS. It's useful for overriding the default margin on Canopy components, as well as general use within your app. Using this directive ensures that your margin adheres to the prededfined spacing variables and breakpoints in Canopy. The spacing variables are also available as CSS custom properties (CSS variables) which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.\n\n## Usage\n\nImport the module in your application:\n\n~~~js\n@NgModule({\n  ...\n  imports: [LgMarginModule],\n})\n~~~\n\nIn your HTML apply the directive to the relevant component. If the default \\`\\`lgMargin\\`\\` attribute has no value, the default margin will remain. You can also override individual margin such as \\`\\`margin-top\\`\\` by applying the relevant selector/input (.e.g \\`\\`LgMarginTop\\`\\` - see **Inputs** below).\n\nPass in either a **Standard Spacing Variant** or a **Responsive Spacing object** (see below).\n\n~~~html\nStandard spacing variant\n<lg-card lgMargin=\"sm\"></lg-card>\n\nResponsive spacing object\n<lg-card [lgMargin]=\"{ md: 'lg', lg: 'xxxl' }\"></lg-card>\n~~~\n\n## Standard vs Responsive Spacing\n\n### Standard Spacing Variant\n\nThis is set of predfined variants which will apply the same margin at all breakpoints, as defined by the \\`\\`SpacingVariant\\`\\` type. These are:\n\n~~~bash\n'none', 'xxxs', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxxl'\n~~~\n\n### Repsonsive Spacing Object\n\nYou can apply a responsive spacing object instead, which will apply different margin at the specified breakpoints, as defined by the \\`\\`SpacingResponsive\\`\\ type. Example:\n\n~~~js\n{\n  md: \"lg\",\n  lg: \"xxxl\"\n}\n~~~\n\nEach **key** is a mobile-first breakpoint from the standard list of available breakpoints: \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`.\n\nEach **value** is a standard spacing variant.\n\nIn the example above, the margin at the \\`\\`md\\`\\` breakpoint will be \\`\\`lg\\`\\`, and at the \\`\\`lg\\`\\` will be \\`\\`xxxl\\`\\`.\n\n\n### Standard variant examples\n\nApply \\`\\`xxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMarginBottom=\"xxl\"></lg-card>\n~~~\n\nApply \\`\\`sm\\`\\` margin to the left and right\n\n~~~html\n<lg-card lgMarginHorizontal=\"sm\"></lg-card>\n~~~\n\nApply \\`\\`xl\\`\\` margin all round, but \\`\\`xxxl\\`\\` margin to the bottom\n\n~~~html\n<lg-card lgMargin=\"xl\" lgMarginBottom=\"xxxl\"></lg-card>\n~~~\n\nApply \\`\\`lg\\`\\` margin to the top and bottom\n\n~~~html\n<lg-card lgMarginVertical=\"lg\"></lg-card>\n~~~\n\n### Responsive examples\n\n\nAt the \\`\\`sm\\`\\` breakpoint apply \\`\\`xl\\`\\` margin, then at the \\`\\`md breakpoint\\`\\` apply \\`\\`xxxl\\`\\` margin, all around the component.\n\n~~~html\n<lg-card [lgMargin]=\"{ sm: 'lg', md: 'xxxl' }\"></lg-card>\n~~~\n\nAt the \\`\\`md\\`\\` breakpoint apply \\`\\`md\\`\\` margin, then at the \\`\\`lg breakpoint\\`\\` apply \\`\\`sm\\`\\` margin, at the bottom of the component.\n\n~~~html\n<lg-card [lgMarginBottom]=\"{ md: 'md', lg: 'sm' }\"></lg-card>\n~~~\n\n## Inputs\n\nThe current available spacing variants are \\`\\`none\\`\\`, \\`\\`xxxs\\`\\`, \\`\\`xxs\\`\\`, \\`\\`xs\\`\\`, \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`, \\`\\`xxxl\\`\\`, \\`\\`xxxxxl\\`\\`.\n\nThe current available breakpoints are \\`\\`sm\\`\\`, \\`\\`md\\`\\`, \\`\\`lg\\`\\`, \\`\\`xl\\`\\`, \\`\\`xxl\\`\\`\n\n| Name | Description | Type | Default | Required |\n|------|-------------|:----:|:-----:|:-----:|\n| \\`\\`lgMargin\\`\\` | The margin variant applied to all sides | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginTop\\`\\` | The margin variant applied to the top | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginRight\\`\\` | The margin variant applied to the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginBottom\\`\\` | The margin variant applied to the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginLeft\\`\\` | The margin variant applied to the left | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginHorizontal\\`\\` | The margin variant applied to the left and the right | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n| \\`\\`lgMarginVertical\\`\\` | The margin variant applied to the top and the bottom | \\`\\`SpacingVariant | SpacingResponsive\\`\\` | null | No |\n`"
                 }
             ],
             "projects/canopy/src/lib/pipes/pipes.module.ts": [
@@ -43010,28 +42988,6 @@
                     "defaultValue": "() => ({\n  template: `\n    <lg-card lgShadow>\n      <lg-card-content>\n        Look, I have a shadow\n      </lg-card-content>\n    </lg-card>\n  `,\n})"
                 }
             ],
-            "projects/canopy/src/lib/spacing/padding/padding.stories.ts": [
-                {
-                    "name": "spaces",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "[]",
-                    "defaultValue": "[\n  'undefined',\n  'none',\n  'xxxs',\n  'xxs',\n  'xs',\n  'sm',\n  'md',\n  'lg',\n  'xl',\n  'xxl',\n  'xxxl',\n  'xxxxl',\n]"
-                },
-                {
-                    "name": "stories",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "storiesOf('Directives', module)"
-                }
-            ],
             "projects/canopy/src/lib/spacing/margin/margin.stories.ts": [
                 {
                     "name": "spaces",
@@ -43048,6 +43004,28 @@
                     "ctype": "miscellaneous",
                     "subtype": "variable",
                     "file": "projects/canopy/src/lib/spacing/margin/margin.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "storiesOf('Directives', module)"
+                }
+            ],
+            "projects/canopy/src/lib/spacing/padding/padding.stories.ts": [
+                {
+                    "name": "spaces",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "[]",
+                    "defaultValue": "[\n  'undefined',\n  'none',\n  'xxxs',\n  'xxs',\n  'xs',\n  'sm',\n  'md',\n  'lg',\n  'xl',\n  'xxl',\n  'xxxl',\n  'xxxxl',\n]"
+                },
+                {
+                    "name": "stories",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/spacing/padding/padding.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
@@ -43146,6 +43124,18 @@
                     "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Date of birth'),\n    hint: text('hint', 'For example, 12 06 1983'),\n    disabled: boolean('disabled', false),\n  },\n})"
                 }
             ],
+            "projects/canopy/src/lib/forms/select/select.stories.ts": [
+                {
+                    "name": "standard",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                    "deprecated": false,
+                    "deprecationMessage": "",
+                    "type": "",
+                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
+                }
+            ],
             "projects/canopy/src/lib/forms/radio/radio.stories.ts": [
                 {
                     "name": "standard",
@@ -43170,16 +43160,16 @@
                     "defaultValue": "() => ({\n  template: `\n    <lg-reactive-form-segment\n    [stack]=\"stack === 'false' ? false : stack\"\n    [disabled]=\"disabled\"\n    [focus]=\"focus\"\n    [label]=\"label\"\n    [secondButtonLabel]=\"secondButtonLabel\"\n    (segmentChange)=\"segmentChange($event)\">\n  </lg-reactive-form-segment>\n  `,\n  props: {\n    label: text('label', 'Select a color'),\n    secondButtonLabel: text('secondButtonLabel', 'Yellow'),\n    segmentChange: action('segmentChange'),\n    disabled: boolean('disabled', false),\n    focus: boolean('focus', false),\n    stack: select('stack', ['false', 'sm', 'md', 'lg'], undefined),\n  },\n})"
                 }
             ],
-            "projects/canopy/src/lib/forms/select/select.stories.ts": [
+            "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts": [
                 {
                     "name": "standard",
                     "ctype": "miscellaneous",
                     "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/select/select.stories.ts",
+                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
                     "deprecated": false,
                     "deprecationMessage": "",
                     "type": "",
-                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (selectChange)=\"selectChange($event)\"\n    [block]=\"block\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n    [options]=\"options\"\n  ></lg-reactive-form>`,\n  props: {\n    selectChange: action('selectChange'),\n    label: text('label', 'Color'),\n    hint: text('hint', 'Please select a color'),\n    block: boolean('block', false),\n    options: object('options', ['Red', 'Blue', 'Green', 'Yellow']),\n    disabled: boolean('disabled', false),\n  },\n})"
+                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/forms/toggle/checkbox.stories.ts": [
@@ -43228,18 +43218,6 @@
                     "deprecationMessage": "",
                     "type": "",
                     "defaultValue": "() => ({\n  template: `\n    <lg-validation\n      [showIcon]=\"showIcon\"\n      [variant]=\"variant\">\n      {{errorContent}}\n    </lg-validation>\n  `,\n  props: {\n    errorContent: text('content', 'Please enter a valid date of birth'),\n    showIcon: boolean('show icon', true),\n    variant: select(\n      'variant',\n      ['generic', 'info', 'success', 'warning', 'error'],\n      'error',\n    ),\n  },\n})"
-                }
-            ],
-            "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts": [
-                {
-                    "name": "standard",
-                    "ctype": "miscellaneous",
-                    "subtype": "variable",
-                    "file": "projects/canopy/src/lib/forms/sort-code/sort-code.stories.ts",
-                    "deprecated": false,
-                    "deprecationMessage": "",
-                    "type": "",
-                    "defaultValue": "() => ({\n  template: `<lg-reactive-form\n    (inputChange)=\"inputChange($event)\"\n    [disabled]=\"disabled\"\n    [hint]=\"hint\"\n    [label]=\"label\"\n  ></lg-reactive-form>`,\n  props: {\n    inputChange: action('inputChange'),\n    label: text('label', 'Sort code'),\n    hint: text('hint', 'Must be 6 digits long'),\n    disabled: boolean('disabled', false),\n  },\n})"
                 }
             ],
             "projects/canopy/src/lib/skeleton/skeleton.stories.ts": [
@@ -52017,16 +51995,6 @@
                 "linktype": "miscellaneous",
                 "linksubtype": "variable",
                 "name": "template",
-                "coveragePercent": 0,
-                "coverageCount": "0/1",
-                "status": "low"
-            },
-            {
-                "filePath": "projects/canopy/src/styles/mixins.notes.ts",
-                "type": "variable",
-                "linktype": "miscellaneous",
-                "linksubtype": "variable",
-                "name": "notes",
                 "coveragePercent": 0,
                 "coverageCount": "0/1",
                 "status": "low"

--- a/projects/canopy/src/lib/accordion/accordion.stories.ts
+++ b/projects/canopy/src/lib/accordion/accordion.stories.ts
@@ -105,7 +105,7 @@ const accordionTemplate: Story<LgAccordionComponent> = (args: LgAccordionCompone
 });
 
 export const standardAccordion = accordionTemplate.bind({});
-standardAccordion.storyName = 'Standard';
+standardAccordion.storyName = 'Accordion';
 standardAccordion.args = {
   headingLevel: 2,
   itemOneActive: false,

--- a/projects/canopy/src/lib/alert/alert.stories.ts
+++ b/projects/canopy/src/lib/alert/alert.stories.ts
@@ -76,7 +76,7 @@ const alertTemplate: Story<LgAlertComponent> = (args: LgAlertComponent) => ({
 });
 
 export const standardAlert = alertTemplate.bind({});
-standardAlert.storyName = 'Standard';
+standardAlert.storyName = 'Alert';
 standardAlert.args = {
   content: 'This is an alert.',
   variant: 'generic',

--- a/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
@@ -182,7 +182,7 @@ const brandIconsTemplate: Story<LgBrandIconComponent> = (args: LgBrandIconCompon
 });
 
 export const standardBrandIcons = brandIconsTemplate.bind({});
-standardBrandIcons.storyName = 'Standard';
+standardBrandIcons.storyName = 'Brand Icon';
 standardBrandIcons.args = {
   size: 'sm',
 };

--- a/projects/canopy/src/lib/button/button-group/button-group.stories.ts
+++ b/projects/canopy/src/lib/button/button-group/button-group.stories.ts
@@ -46,7 +46,7 @@ const buttonGroupStory: Story<LgButtonGroupComponent> = (
 });
 
 export const standardButtonGroup = buttonGroupStory.bind({});
-standardButtonGroup.storyName = 'Standard';
+standardButtonGroup.storyName = 'Button Group';
 standardButtonGroup.parameters = {
   controls: { hideNoControlsWarning: true },
   docs: {

--- a/projects/canopy/src/lib/details/details.stories.ts
+++ b/projects/canopy/src/lib/details/details.stories.ts
@@ -153,7 +153,7 @@ const detailsTemplate: Story<LgDetailsComponent> = (args: LgDetailsComponent) =>
 });
 
 export const standardDetails = detailsTemplate.bind({});
-standardDetails.storyName = 'Standard';
+standardDetails.storyName = 'Details';
 standardDetails.args = {
   variant: 'generic',
   headingLevel: 5,

--- a/projects/canopy/src/lib/footer/footer.stories.ts
+++ b/projects/canopy/src/lib/footer/footer.stories.ts
@@ -116,7 +116,7 @@ const detailsTemplate: Story<LgFooterComponent> = (args: LgFooterComponent) => (
 });
 
 export const standardFooter = detailsTemplate.bind({});
-standardFooter.storyName = 'Standard';
+standardFooter.storyName = 'Footer';
 standardFooter.args = {
   logo: 'legal-and-general-logo.svg',
   logoAlt: 'Company name',

--- a/projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts
@@ -50,7 +50,7 @@ class ReactiveFormComponent {
 }
 
 export default {
-  title: 'Components/Filter multiple buttons',
+  title: 'Components/Filter Multiple Buttons',
   component: LgCheckboxGroupComponent,
   decorators: [
     moduleMetadata({
@@ -212,7 +212,7 @@ const filterMultiple: Story<LgCheckboxGroupComponent> = (
 });
 
 export const filterMultipleButtons = filterMultiple.bind({});
-filterMultipleButtons.storyName = 'Standard';
+filterMultipleButtons.storyName = 'Filter Multiple Buttons';
 filterMultipleButtons.args = {
   disabled: false,
   focus: false,

--- a/projects/canopy/src/lib/forms/radio/filter.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/filter.stories.ts
@@ -49,7 +49,7 @@ class ReactiveFormFilterComponent {
 }
 
 export default {
-  title: 'Components/Filter buttons',
+  title: 'Components/Filter Buttons',
   component: LgRadioGroupComponent,
   decorators: [
     moduleMetadata({
@@ -226,7 +226,7 @@ const filterButtonsStory: Story<LgRadioButtonComponent> = (
 });
 
 export const filterButtons = filterButtonsStory.bind({});
-filterButtons.storyName = 'Standard';
+filterButtons.storyName = 'Filter Buttons';
 filterButtons.args = {
   disabled: false,
   focus: false,

--- a/projects/canopy/src/lib/header/header.stories.ts
+++ b/projects/canopy/src/lib/header/header.stories.ts
@@ -52,7 +52,7 @@ const detailsTemplate: Story<LgHeaderComponent> = (args: LgHeaderComponent) => (
 });
 
 export const standardHeader = detailsTemplate.bind({});
-standardHeader.storyName = 'Standard';
+standardHeader.storyName = 'Header';
 standardHeader.args = {
   logo: 'legal-and-general-logo.svg',
   logoAlt: 'Company name',

--- a/projects/canopy/src/lib/heading/heading.stories.ts
+++ b/projects/canopy/src/lib/heading/heading.stories.ts
@@ -54,7 +54,7 @@ const detailsTemplate: Story<LgHeadingComponent> = (args: LgHeadingComponent) =>
 });
 
 export const standardHeading = detailsTemplate.bind({});
-standardHeading.storyName = 'Standard';
+standardHeading.storyName = 'Heading';
 standardHeading.args = {
   content: 'Heading',
   level: 1,

--- a/projects/canopy/src/lib/icon/icons.stories.ts
+++ b/projects/canopy/src/lib/icon/icons.stories.ts
@@ -357,7 +357,7 @@ const iconsTemplate: Story<LgIconComponent> = (args: LgIconComponent) => ({
 });
 
 export const standardIcons = iconsTemplate.bind({});
-standardIcons.storyName = 'Standard';
+standardIcons.storyName = 'Icon';
 standardIcons.parameters = {
   docs: {
     description: {

--- a/projects/canopy/src/lib/modal/modal.stories.ts
+++ b/projects/canopy/src/lib/modal/modal.stories.ts
@@ -119,7 +119,7 @@ const detailsTemplate: Story<LgSeparatorComponent> = (args: LgSeparatorComponent
 });
 
 export const standardSeparator = detailsTemplate.bind({});
-standardSeparator.storyName = 'Standard';
+standardSeparator.storyName = 'Modal';
 standardSeparator.args = {
   headingLevel: 2,
 };

--- a/projects/canopy/src/lib/primary-message/primary-message.stories.ts
+++ b/projects/canopy/src/lib/primary-message/primary-message.stories.ts
@@ -41,7 +41,7 @@ class LgPrimaryMessageStoryComponent {
 }
 
 export default {
-  title: 'Components/Primary message',
+  title: 'Components/Primary Message',
   component: LgPrimaryMessageStoryComponent,
   decorators: [
     moduleMetadata({
@@ -105,7 +105,7 @@ const detailsTemplate: Story<LgPrimaryMessageComponent> = (
 });
 
 export const standardPrimaryMessage = detailsTemplate.bind({});
-standardPrimaryMessage.storyName = 'Standard';
+standardPrimaryMessage.storyName = 'Primary Message';
 standardPrimaryMessage.args = {
   hasRole: true,
 };

--- a/projects/canopy/src/lib/separator/separator.stories.ts
+++ b/projects/canopy/src/lib/separator/separator.stories.ts
@@ -69,7 +69,7 @@ const detailsTemplate: Story<LgSeparatorComponent> = (args: LgSeparatorComponent
 });
 
 export const standardSeparator = detailsTemplate.bind({});
-standardSeparator.storyName = 'Standard';
+standardSeparator.storyName = 'Separator';
 standardSeparator.args = {
   variant: 'solid',
   hasRole: false,

--- a/projects/canopy/src/lib/spinner/spinner.stories.ts
+++ b/projects/canopy/src/lib/spinner/spinner.stories.ts
@@ -91,7 +91,7 @@ const alertTemplate: Story<LgSpinnerComponent> = (args: LgSpinnerComponent) => (
 });
 
 export const standardAlert = alertTemplate.bind({});
-standardAlert.storyName = 'Standard';
+standardAlert.storyName = 'Spinner';
 standardAlert.args = {
   text: 'Please wait while we load your data.',
   variant: 'generic',


### PR DESCRIPTION
I have renamed single stories to remove the redundant expandable menu items

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
