### PR TITLE
fix(hero-card-notification): fix link not clickable in notification

### DIFF
--- a/projects/canopy/src/lib/hero/hero-card-notification/hero-card-notification.component.html
+++ b/projects/canopy/src/lib/hero/hero-card-notification/hero-card-notification.component.html
@@ -1,4 +1,3 @@
-<div class="lg-hero-card-notification__overlay" aria-hidden="true"></div>
 <div class="lg-hero-card-notification__icon">
   <ng-content select="lg-icon"></ng-content>
 </div>

--- a/projects/canopy/src/lib/hero/hero-card-notification/hero-card-notification.component.scss
+++ b/projects/canopy/src/lib/hero/hero-card-notification/hero-card-notification.component.scss
@@ -6,6 +6,8 @@
   position: relative;
   display: inline-flex;
   flex-direction: row;
+  background-color: var(--hero-overlay-bg-color);
+  border-radius: var(--border-radius-sm);
 
   @include lg-breakpoint(lg) {
     padding-right: var(--space-sm);
@@ -23,18 +25,6 @@
       $focus-bg-color: var(--hero-link-focus-bg-color)
     );
   }
-}
-
-.lg-hero-card-notification__overlay {
-  display: block;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: var(--hero-overlay-bg-color);
-  border-radius: var(--border-radius-sm);
-  opacity: var(--hero-bg-alpha);
 }
 
 .lg-hero-card-notification__icon {

--- a/projects/canopy/src/lib/hero/hero-header/hero-header.component.html
+++ b/projects/canopy/src/lib/hero/hero-header/hero-header.component.html
@@ -1,4 +1,3 @@
-<div class="lg-hero-header__overlay" aria-hidden="true"></div>
 <div class="lg-hero-header__content">
   <ng-content></ng-content>
 </div>

--- a/projects/canopy/src/lib/hero/hero-header/hero-header.component.scss
+++ b/projects/canopy/src/lib/hero/hero-header/hero-header.component.scss
@@ -1,17 +1,7 @@
 .lg-hero-header {
   display: block;
   position: relative;
-}
-
-.lg-hero-header__overlay {
-  display: block;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
   background-color: var(--hero-overlay-bg-color);
-  opacity: var(--hero-bg-alpha);
 }
 
 .lg-hero-header__content {

--- a/projects/canopy/src/styles/variables/components/_hero.scss
+++ b/projects/canopy/src/styles/variables/components/_hero.scss
@@ -2,9 +2,9 @@
   --hero-padding: var(--space-sm);
   --hero-color: var(--color-white);
   --hero-bg-color: var(--color-super-blue-dark);
-  --hero-overlay-bg-color: var(--color-black);
   --hero-rule-color: rgba(255, 255, 255, 0.2);
   --hero-bg-alpha: 0.1;
+  --hero-overlay-bg-color: rgba(0, 0, 0, var(--hero-bg-alpha));
 
   --hero-link-color: var(--hero-color);
   --hero-link-hover-color: var(--hero-color);


### PR DESCRIPTION
fix link not being clickable in the notification message, because of the overlay covering it

# Description

Because of the overlay, the link in the notification message could not be interacted with. The solution was to add ``pointer-events: none;``, transforming the overlay into a layer that should ignore / pass-through click-, tap-, scroll- and hover events.

## Requirements

Screenshot:
![Screenshot 2022-02-21 at 14 50 37](https://user-images.githubusercontent.com/68600084/155280818-7eb95103-100f-4948-8be8-6d808c1508eb.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
