### PR TITLE
Fix(details): add role attribute for accessibility 

### DIFF
--- a/projects/canopy/src/lib/details/details.component.html
+++ b/projects/canopy/src/lib/details/details.component.html
@@ -4,6 +4,7 @@
   [id]="panelId"
   [class.lg-details__panel--active]="isActive"
   [attr.aria-labelledby]="toggleId"
+  [attr.role]="'region'"
 >
   <ng-content></ng-content>
 </div>


### PR DESCRIPTION
# Description

- issues that were flagged by the accessibility tools (axe devtools) related to the `aria-labelledby` attribute which requires a `role` attribute as well on `div` tags

See the two screenshots (before & after the fix). Please note that the errors that are shown in the "after fix" image are related to local Gramarly extension so they're not related to the project. 

<img width="1433" alt="before_fix" src="https://user-images.githubusercontent.com/20334064/156191449-b626d4fd-d1a7-41a5-a77c-c07226a57bad.png">

<img width="720" alt="after_fix" src="https://user-images.githubusercontent.com/20334064/156191441-9e8549db-981d-4acf-84a6-2a5ee6746707.png">

# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
