### PR TITLE
Add actions to combine dependabot PRs into one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,4 @@ updates:
         versions: ["6.x"]
       - dependency-name: "@storybook/theming"
         versions: ["6.x"]
+      - dependency-name: "jasmine-marbles"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,17 @@ updates:
     # default location of `.github/workflows`
     directory: '/'
     schedule:
+      day: 'sunday'
       interval: 'weekly'
       time: '00:00'
       timezone: 'Europe/London'
-    rebase-strategy: 'disabled'
 
   # Maintain dependencies for npm
   - package-ecosystem: 'npm'
     # Files stored in repository root
     directory: '/'
     schedule:
+      day: 'sunday'
       interval: 'weekly'
       time: '00:00'
       timezone: 'Europe/London'

--- a/.github/workflow-scripts/combine-dependabot-prs.js
+++ b/.github/workflow-scripts/combine-dependabot-prs.js
@@ -1,0 +1,148 @@
+module.exports = async ({
+  github,
+  context: { repo: { repo, owner } },
+}) => {
+  const combinedBranchName = 'dependabot-updates';
+  const baseBranchName = 'master';
+
+  const { data: openPulls } = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    base: baseBranchName,
+    per_page: 100,
+  });
+
+  let pullsToCombine = openPulls
+    .filter(pr => pr.head.ref.startsWith('dependabot/'))
+    .map(pr => ({
+      branch: pr.head.ref,
+      number: pr.number,
+    }))
+
+  if (!pullsToCombine.length) {
+    console.info('ℹ️ No dependabot PRs have been found');
+    return;
+  }
+
+  console.info(`ℹ️ ${pullsToCombine.length} dependabot PR(s) found`);
+
+  const combinedBranchExists = !!openPulls.filter(pr => pr.head.ref === combinedBranchName).length;
+
+  const { data: { object: { sha: baseBranchSHA } } } = await github.rest.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${baseBranchName}`,
+  });
+
+  if (!combinedBranchExists) {
+    console.info(`ℹ️ ${combinedBranchName}: Creating branch`);
+
+    await github.rest.git.createRef({
+      owner,
+      repo,
+      ref: `refs/heads/${combinedBranchName}`,
+      sha: baseBranchSHA,
+    });
+  }
+
+  // Loop over the branches and merge with combinedBranchName
+  // if the branch cannot be merged skip
+  const unmergedPulls = [];
+
+  for (const { branch, number } of pullsToCombine) {
+    console.info(`ℹ️ ${branch}: Trying to merge into ${combinedBranchName}`);
+
+    try {
+      await github.rest.repos.merge({
+        owner,
+        repo,
+        base: combinedBranchName,
+        head: branch,
+      });
+    } catch (error) {
+      unmergedPulls.push({
+        branch,
+        number,
+      });
+
+      console.info(`🚫 ${branch}: ${error}`);
+    }
+  }
+
+  unmergedPulls.forEach(({ number }) => {
+    // Remove unmerged PRs from PRs to combine
+    pullsToCombine = pullsToCombine.filter(pull => pull.number !== number);
+  });
+
+  if (pullsToCombine.length) {
+    const combinedPullTitle = 'Combined dependency updates';
+    const pullsListMessage = pullsToCombine.map(pull => `- #${pull.number}\n`).join('');
+    const dateInfo = `**${new Date().toDateString()}**`;
+
+    if (combinedBranchExists) {
+      // The combined PR already exists so we need to update it
+      const { number, body } = openPulls.filter(pull => pull.title === combinedPullTitle)[0];
+
+      console.info('ℹ️ Update the existing combined PR');
+
+      await github.rest.pulls.update({
+        owner,
+        repo,
+        pull_number: number,
+        body: `${body}\n\n${dateInfo}\n\n${pullsListMessage}`
+      });
+    } else {
+      // The combined PR doesn't exist so we need to create it
+      const body = `This PR was created by the Combine Dependabot PRs action by combining the following PRs:\n\n${dateInfo}\n\n${pullsListMessage}`;
+
+      console.info('ℹ️ Creating the combined PR');
+      await github.rest.pulls.create({
+        owner,
+        repo,
+        title: combinedPullTitle,
+        head: combinedBranchName,
+        base: baseBranchName,
+        body: body
+      });
+    }
+
+    for (const { branch, number } of pullsToCombine) {
+      // Close the PRs that have been combined into the new branch
+      console.info(`ℹ️ Closing PR #${number}`);
+
+      await github.rest.pulls.update({
+        owner,
+        repo,
+        status: 'closed',
+        pull_number: number,
+      });
+
+      console.info(`ℹ️ Deleting branch ${branch}`);
+
+      await github.rest.git.deleteRef({
+        owner,
+        repo,
+        ref: `heads/${branch}`,
+      });
+
+      console.info(`ℹ️ Adding label to PR #${number}`);
+
+      github.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: number,
+        labels: [ 'dependabot-combined' ],
+      })
+    }
+  } else {
+    console.info('🚫 No PRs to combine');
+  }
+
+  if (unmergedPulls.length) {
+    console.info('\n🚫 These branches could not be combined:');
+    console.info(unmergedPulls.map(({ branch }) => branch).join('\n'));
+  }
+
+  console.info('\n✅ All done');
+}

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   analyze:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/')  }}
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dependabot.adhoc.yml
+++ b/.github/workflows/dependabot.adhoc.yml
@@ -1,0 +1,26 @@
+name: Dependabot Batcher Ad-hoc
+on: workflow_dispatch
+
+jobs:
+  # Batches Dependabot PRs into one by merging them into a combined branch, then raising a new PR
+  dependabot-batcher:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v2.5.1
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: 'Combine Dependabot PRs'
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const combineDependabotPrs = require('./.github/workflow-scripts/combine-dependabot-prs.js');
+            return await combineDependabotPrs({
+              github,
+              context,
+            });

--- a/.github/workflows/dependabot.scheduled.yml
+++ b/.github/workflows/dependabot.scheduled.yml
@@ -1,0 +1,28 @@
+name: Dependabot Batcher Scheduled
+on:
+  schedule:
+    - cron:  '0 9 * * 1,3'
+
+jobs:
+  # Batches Dependabot PRs into one by merging them into a combined branch, then raising a new PR
+  dependabot-batcher:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v2.5.1
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: 'Combine Dependabot PRs'
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const combineDependabotPrs = require('./.github/workflow-scripts/combine-dependabot-prs.js');
+            return await combineDependabotPrs({
+              github,
+              context,
+            });

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   verify:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/')  }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

<img width="919" alt="Screenshot 2022-03-09 at 15 44 04" src="https://user-images.githubusercontent.com/1677737/157476592-16741551-2ffe-4005-8668-4aa19609e3de.png">

This PR:

- Adds a scheduled and ad-hoc workflow for batching Dependabot PRs
    - This will fetch all Dependabot PRs that are open, adding their commits into a combined PR branch (which is created if it doesn't exist)
    - This means that manually combining dependency updates is a thing of the past
    - ...and will save everyone a lot of time :)
- Changes the dependabot config to auto-rebase its PRs
- Removes the Dependabot section of the PR template

How this works in practice:

- Every Monday and Wednesday morning the scheduled workflow combines any open Dependabot PRs into one
- The combined PR runs the full checks as per any other PR
- Approve and merge

NB: If there are conflicts (which happens if two adjacent dependencies in `package.json` have updates), just merge the combined PR, then run the ad-hoc script and the remaining Dependabot PRs should be mergeable)
NB2: the dependabot PRs will not run the pull request and code analysis anymore. Only the combined branch will.

*The code has been tested in our private FEP repo and works fine but I might need to update the `GITHUB_TOKEN` once this PR gets merged.*

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
