### PR TITLE
fix(stylelint): remove syntax param from pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     ],
     "projects/canopy/src/**/*.{scss, css}": [
       "prettier --write",
-      "stylelint --syntax scss --fix",
+      "stylelint --fix",
       "git add"
     ],
     "projects/canopy/src/**/*.ts": [


### PR DESCRIPTION
# Description

Remove `syntax` parameter from `pre-commit` hook as deprecated and blocking new commits.
The syntax is now specified in the `.stylelintrc`.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
