### PR TITLE
fix(grid): replace calc with math.div for division

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -25,7 +25,7 @@
     "function-no-unknown": [
       true,
       {
-        "ignoreFunctions": ["space", "map-get", "percentage"],
+        "ignoreFunctions": ["space", "map-get", "percentage", "/math.*/"],
       }
     ]
   }

--- a/projects/canopy/src/styles/grid.scss
+++ b/projects/canopy/src/styles/grid.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 :root {
   --grid-margin: var(--space-sm);
   --grid-gutter: var(--space-sm);
@@ -116,7 +118,7 @@ $columns: 12;
 }
 
 @for $i from 1 through $columns {
-  $width: percentage(calc($i / $columns));
+  $width: percentage(math.div($i, $columns));
 
   .lg-col-xs-#{$i} {
     flex-basis: $width;
@@ -151,7 +153,7 @@ $columns: 12;
   }
 
   @for $i from 1 through 12 {
-    $width: percentage(calc($i / 12));
+    $width: percentage(math.div($i, 12));
 
     .lg-col-sm-#{$i} {
       flex-basis: $width;
@@ -187,7 +189,7 @@ $columns: 12;
   }
 
   @for $i from 1 through 12 {
-    $width: percentage(calc($i / 12));
+    $width: percentage(math.div($i, 12));
 
     .lg-col-md-#{$i} {
       flex-basis: $width;
@@ -223,7 +225,7 @@ $columns: 12;
   }
 
   @for $i from 1 through 12 {
-    $width: percentage(calc($i / 12));
+    $width: percentage(math.div($i, 12));
 
     .lg-col-lg-#{$i} {
       flex-basis: $width;


### PR DESCRIPTION
# Description

When using the `grid` the projects build fails with:
```
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: $number: calc(1 / 12) is not a number.
    ╷
154 │     $width: percentage(calc($i / 12));

```

`calc()` doesn't seem to work within `percentage()`.
I have now run the `sass-migration` package and `calc` has been updated to `math.div`.

https://user-images.githubusercontent.com/8397116/160409651-04eb1769-ad43-40dd-bfdb-222088437c2e.mov


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
