### PR TITLE
fix(segment): stack input is now set correctly

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-group.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterContentInit,
   Component,
   ContentChild,
   ContentChildren,
@@ -31,7 +32,7 @@ let uniqueId = 0;
   styleUrls: ['./radio-group.component.scss', './radio-group--segment.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class LgRadioGroupComponent implements ControlValueAccessor {
+export class LgRadioGroupComponent implements ControlValueAccessor, AfterContentInit {
   nextUniqueId = ++uniqueId;
   private _name = `lg-radio-group-${this.nextUniqueId}`;
 
@@ -58,12 +59,6 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
       );
     }
     this._stack = stack;
-
-    if (this.radios) {
-      this.radios.toArray().forEach((radio) => {
-        radio.stacked = this.stack;
-      });
-    }
   }
   get stack(): RadioStackBreakpoint {
     return this._stack;
@@ -154,6 +149,14 @@ export class LgRadioGroupComponent implements ControlValueAccessor {
       .toLowerCase() as RadioVariant;
     if (this.control != null) {
       this.control.valueAccessor = this;
+    }
+  }
+
+  ngAfterContentInit(): void {
+    if (this.radios && this.stack) {
+      this.radios.toArray().forEach((radio) => {
+        radio.stacked = this.stack;
+      });
     }
   }
 


### PR DESCRIPTION
# Description

The stack input for the segment component was not working when added to an application (worked on Storybook).
This has now been fixed (tested within an application):

https://user-images.githubusercontent.com/8397116/160885436-47298e6a-9900-4c23-adac-88fff17ebef7.mov



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
