### PR TITLE
docs(canopy): add deprecation message to Canopy module and service

### DIFF
--- a/projects/canopy/src/lib/canopy.module.ts
+++ b/projects/canopy/src/lib/canopy.module.ts
@@ -102,7 +102,9 @@ const modules = [
   LgKebabCasePipeModule,
   LgPrimaryMessageModule,
 ];
-
+/**
+ * @deprecated This module should not be used. Import each module separately instead.
+ */
 @NgModule({
   imports: [CommonModule, ...modules],
   exports: [...modules],

--- a/projects/canopy/src/lib/canopy.service.ts
+++ b/projects/canopy/src/lib/canopy.service.ts
@@ -3,6 +3,9 @@ import { Injectable } from '@angular/core';
 @Injectable({
   providedIn: 'root',
 })
+/**
+ * @deprecated This service should not be used.
+ */
 export class CanopyService {
   constructor() {}
 }


### PR DESCRIPTION
# Description

Add deprecation message to Canopy module and service.

The removal of the Canopy module was discussed here: https://github.com/Legal-and-General/canopy/discussions/768
The service is empty and unused - deprecating it just to be 100% sure before the next breaking change release.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
