### PR TITLE
docs(storybook): update link colour

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -28,6 +28,9 @@
     background-color: transparent;
     color: inherit;
   }
+  .sbdocs.sbdocs-a {
+    color: var(--color-super-blue);
+  }
   .sbdocs.sbdocs-a, .sbdocs.sbdocs-p {
     font-size: 14px;
   }


### PR DESCRIPTION
# Description

Storybook was overriding the super-blue colour of the links in the intro page making them inaccessible.

Before:
![Screenshot 2022-04-28 at 13 43 58](https://user-images.githubusercontent.com/8397116/165755394-a5e231c2-8f0b-4231-a548-4eea09dc9224.png)

After:
![Screenshot 2022-04-28 at 13 43 52](https://user-images.githubusercontent.com/8397116/165755412-bad2074e-05e5-4950-92b5-2dc5ad5427fc.png)

