### PR TITLE
docs(gh-pages): fix environment issue with deployment

### DIFF
--- a/.github/workflow-scripts/gh-pages/create-gh-deployment.js
+++ b/.github/workflow-scripts/gh-pages/create-gh-deployment.js
@@ -1,6 +1,5 @@
 module.exports = async ({
   sha,
-  branch,
   github,
   context: { repo: { repo, owner } },
 }) => {
@@ -8,7 +7,7 @@ module.exports = async ({
     owner,
     repo,
     ref: sha,
-    environment: branch,
+    environment: 'github-pages',
     transient_environment: true,
     auto_merge: false,
   });

--- a/.github/workflows/branch_pages_deploy.yml
+++ b/.github/workflows/branch_pages_deploy.yml
@@ -56,7 +56,6 @@ jobs:
             const createDeployment = require('./.github/workflow-scripts/gh-pages/create-gh-deployment.js');
             return await createDeployment({
               sha: '${{ fromJSON(steps.prData.outputs.result).sha }}',
-              branch: '${{ fromJSON(steps.prData.outputs.result).branch }}',
               github,
               context,
             });
@@ -88,29 +87,19 @@ jobs:
               exec,
             });
 
-      - name: 'Notify GitHub of deployment failure'
-        if: failure()
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const createDeploymentStatus = require('./.github/workflow-scripts/gh-pages/create-gh-deployment-status.js');
-            await createDeploymentStatus({
-              deploymentId: ${{ fromJSON(steps.deploymentId.outputs.result) }},
-              state: 'failure',
-              environmentUrl: '${{ fromJSON(steps.prData.outputs.result).environmentUrl }}',
-              github,
-              context,
-            });
+      - name: 'Checking out current branch'
+        if: always()
+        run: git checkout ${{ github.sha }}
 
-      - name: 'Notify GitHub of deployment success'
-        if: success()
+      - name: 'Notify GitHub of deployment status'
+        if: always()
         uses: actions/github-script@v6
         with:
           script: |
             const createDeploymentStatus = require('./.github/workflow-scripts/gh-pages/create-gh-deployment-status.js');
             await createDeploymentStatus({
               deploymentId: ${{ fromJSON(steps.deploymentId.outputs.result) }},
-              state: 'success',
+              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
               environmentUrl: '${{ fromJSON(steps.prData.outputs.result).environmentUrl }}',
               github,
               context,


### PR DESCRIPTION
# Description

Remove environment logic as it is unnecessary to create a different environment for each branch.
I have set the environment to the one GitHub pages already uses.

Workflow test run that replicates `master`: https://github.com/Legal-and-General/canopy/runs/6420417310

Workflow to deploy this environment: https://github.com/Legal-and-General/canopy/actions/runs/2318593788

Tested deployment status update using the `job.status` here: https://github.com/Legal-and-General/canopy/runs/6469799176?check_suite_focus=true

![Screenshot 2022-05-17 at 12 39 19](https://user-images.githubusercontent.com/8397116/168802491-efd71242-3256-445a-aa86-d26fc05cbb7e.png)

