### PR TITLE
Fix bug with spacing not applied to lg-heading component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
         ],
         '@angular-eslint/component-class-suffix': 'error',
         '@angular-eslint/directive-class-suffix': 'error',
-        '@angular-eslint/no-host-metadata-property': 'error',
+        '@angular-eslint/no-host-metadata-property': ['error', { 'allowStatic': true }],
         '@angular-eslint/no-input-rename': 'error',
         '@angular-eslint/no-inputs-metadata-property': 'error',
         '@angular-eslint/no-output-on-prefix': 'error',

--- a/projects/canopy/src/lib/heading/heading.component.scss
+++ b/projects/canopy/src/lib/heading/heading.component.scss
@@ -1,0 +1,13 @@
+.lg-heading[class*='lg-margin'],
+.lg-heading[class*='lg-padding'] {
+  display: block;
+
+  > h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+  }
+}

--- a/projects/canopy/src/lib/heading/heading.component.spec.ts
+++ b/projects/canopy/src/lib/heading/heading.component.spec.ts
@@ -7,13 +7,11 @@ describe('LgHeadingComponent', () => {
   let component: LgHeadingComponent;
   let fixture: ComponentFixture<LgHeadingComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ LgHeadingComponent ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LgHeadingComponent ],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LgHeadingComponent);
@@ -23,6 +21,10 @@ describe('LgHeadingComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should add the generic heading class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-heading');
   });
 
   describe('the level input', () => {

--- a/projects/canopy/src/lib/heading/heading.component.ts
+++ b/projects/canopy/src/lib/heading/heading.component.ts
@@ -5,7 +5,11 @@ import type { HeadingLevel } from './heading.interface';
 @Component({
   selector: 'lg-heading',
   templateUrl: './heading.component.html',
+  styleUrls: [ 'heading.component.scss' ],
   encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'lg-heading',
+  },
 })
 export class LgHeadingComponent {
   @Input() level: HeadingLevel;


### PR DESCRIPTION
# Description

This change fixes a bug where the spacing applied via the LgPadding or LgMargin directives was not applied.

In addition to that allows for static attributes to be added to the component host metadata (https://netbasal.com/adding-static-attributes-to-the-host-element-in-angular-b16cd33b424e).

Fixes #171
Relates to #698

https://user-images.githubusercontent.com/8397116/172418914-5fb35ee4-fe83-4242-ae60-f496cd0ed127.mov


## Requirements

A user should be allowed to add spacing to the `lg-heading` component via the LgPadding and LgMargin directives.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
