### PR TITLE
style(colours): add new RGB colour variables

### DIFF
--- a/projects/canopy/src/styles/variables/_colors.scss
+++ b/projects/canopy/src/styles/variables/_colors.scss
@@ -28,6 +28,7 @@
   --color-leafy-green-lightest: #e5f4ea;
   --color-leafy-green-light: #97d3ab;
   --color-leafy-green: #028844;
+  --color-leafy-green-rgb: 2, 136, 68;
   --color-leafy-green-dark: #005826;
   --color-leafy-green-darkest: #003119;
 
@@ -40,9 +41,11 @@
   --color-dandelion-yellow-lightest: #fdf8cd;
   --color-dandelion-yellow-light: #ffef67;
   --color-dandelion-yellow: #ffd500;
+  --color-dandelion-yellow-rgb: 255, 213, 0;
 
   --color-black: #000;
   --color-charcoal: #333;
+  --color-charcoal-rgb: 51, 51, 51;
   --color-battleship-grey: #575756;
   --color-taupe-grey: #929292;
   --color-serenity: #faf7f5;


### PR DESCRIPTION
# Description

Add new RGB colour variables:

```
--color-leafy-green-rgb: 2, 136, 68;
--color-dandelion-yellow-rgb: 255, 213, 0;
--color-charcoal-rgb: 51, 51, 51;
```

`--color-super-blue-rgb: 0, 118, 214;` was already present.

Discussion available here: https://github.com/Legal-and-General/canopy/discussions/913

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
