### PR TITLE
Fix button styles when within a variant

### DIFF
--- a/projects/canopy/src/lib/variant/variant.notes.ts
+++ b/projects/canopy/src/lib/variant/variant.notes.ts
@@ -17,7 +17,7 @@ This can be useful where you need the particular colour treatment (like the \`\`
 The current available variants are:
 * \`\`generic\`\`
 * \`\`info\`\`
-* \`\`success\`\`s
+* \`\`success\`\`
 * \`\`warning\`\`
 * \`\`error\`\`
 

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -177,7 +177,7 @@ $breakpoints: (
     );
   }
 
-  .lg-btn--outline-primary {
+  .lg-btn--secondary-dark {
     background-color: transparent !important;
     border-color: var(--#{$variant}-color) !important;
     color: var(--#{$variant}-color) !important;


### PR DESCRIPTION
# Description

Update old leftover class within variant mixin to the new one so that the styles are applied correctly:

Before:
![Screenshot 2022-07-19 at 14 09 34](https://user-images.githubusercontent.com/8397116/179758669-fffc33fe-7a8b-4eab-8631-60ae5001f778.png)

After:
![Screenshot 2022-07-19 at 14 09 45](https://user-images.githubusercontent.com/8397116/179758685-5c01d727-0629-4257-8209-dd526c44f62e.png)

Also fix small typo in documentation.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
