### PR TITLE
fix(radio-group): set fieldset focus via outline

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-group.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.scss
@@ -14,3 +14,8 @@
     margin-right: 0;
   }
 }
+
+fieldset[tabindex='-1']:focus {
+  box-shadow: none;
+  outline: 0.25rem solid var(--default-focus-color);
+}


### PR DESCRIPTION
# Description

On a fieldset element the box shadow appears behind the legend element. Using the outline avoid the issues.

Fixes # ([issue](https://github.com/Legal-and-General/canopy/issues/925))
![image](https://user-images.githubusercontent.com/7091410/179783427-6a85dcd4-cf74-4cd8-9830-decc8ada4306.png)

## Requirements

When the fieldset element is focused by Javascript this change means the border will look correct.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
