### PR TITLE
Header and footer fix for logos

### DIFF
--- a/projects/canopy/src/lib/footer/footer-logo/footer-logo.component.scss
+++ b/projects/canopy/src/lib/footer/footer-logo/footer-logo.component.scss
@@ -1,6 +1,8 @@
 @import '../../../styles/mixins';
 
 .lg-footer-logo {
+  display: contents;
+
   &__img,
   &__second-img {
     height: auto;

--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.scss
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.scss
@@ -1,37 +1,41 @@
 @import '../../../styles/mixins';
 
-.lg-header-logo__img,
-.lg-header-logo__second-img {
-  height: auto;
-  max-height: 100%;
-}
+.lg-header-logo {
+  display: contents;
 
-.lg-header-logo__img {
-  margin-left: 0;
-  display: block;
-  width: var(--header-logo-width);
-
-  @include lg-breakpoint('lg') {
-    width: var(--header-logo-width-lg);
+  &__img,
+  &__second-img {
+    height: auto;
+    max-height: 100%;
   }
-}
 
-.lg-header-logo__second-img {
-  margin-left: var(--space-sm);
-  width: var(--header-second-logo-width);
+  &__img {
+    margin-left: 0;
+    display: block;
+    width: var(--header-logo-width);
 
-  @include lg-breakpoint('lg') {
-    margin-left: var(--space-lg);
-    width: var(--header-second-logo-width-lg);
+    @include lg-breakpoint('lg') {
+      width: var(--header-logo-width-lg);
+    }
   }
-}
 
-.lg-header-logo__link {
-  display: inline-block;
-  @include lg-unstyled-link;
+  &__second-img {
+    margin-left: var(--space-sm);
+    width: var(--header-second-logo-width);
 
-  &:focus {
-    background-color: transparent;
-    @include lg-inner-focus-outline(var(--default-focus-color));
+    @include lg-breakpoint('lg') {
+      margin-left: var(--space-lg);
+      width: var(--header-second-logo-width-lg);
+    }
+  }
+
+  &__link {
+    display: inline-block;
+    @include lg-unstyled-link;
+
+    &:focus {
+      background-color: transparent;
+      @include lg-inner-focus-outline(var(--default-focus-color));
+    }
   }
 }


### PR DESCRIPTION
# Description

The logos were not getting the correct styles as they have been wrapped in components on their own and the flex properties from the parent were not affecting the inner elements. Adding `display: contents` allows the `img` within the new `lg-header-logo` and `lg-footer-logo` to appear as if they were direct children of the parent.

Also refactors the scss for the header to be nested within `lg-header-logo`.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
