### PR TITLE
docs(breadcrumb): update typo in component preview

### DIFF
--- a/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb.stories.ts
@@ -83,7 +83,7 @@ const template = `
     <a href="#">Products</a>
   </lg-breadcrumb-item>
   <lg-breadcrumb-item>
-    <a href="#">Pension Anniuty</a>
+    <a href="#">Pension Annuity</a>
   </lg-breadcrumb-item>
 </lg-breadcrumb>
 `;
@@ -126,7 +126,7 @@ const ellipisTemplate = `
     <a href="#">Products</a>
   </lg-breadcrumb-item>
   <lg-breadcrumb-item>
-    <a href="#">Pension Anniuty</a>
+    <a href="#">Pension Annuity</a>
   </lg-breadcrumb-item>
 </lg-breadcrumb>
 `;


### PR DESCRIPTION
# Description

Fix typo with the word `Annuity` in the breadcrumb component preview.

Before:
<img width="408" alt="Screenshot 2022-08-02 at 09 44 32" src="https://user-images.githubusercontent.com/8397116/182333177-4b699714-b826-4db0-b940-71d11875a263.png">

After:
<img width="409" alt="Screenshot 2022-08-02 at 09 49 03" src="https://user-images.githubusercontent.com/8397116/182333664-b45d5663-9513-4c60-ad7c-ae088d00e9ad.png">

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
