### PR TITLE
Add commitlint to CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,8 +6,8 @@ about: Create a report to alert us of bugs
 
 ## Prerequisites
 
-* [ ] I have checked the [open Issues](https://github.com/Legal-General-Group-Digital/frontend-platform/issues) to see if this has already been raised
-* [ ] I have searched the [closed Issues](https://github.com/Legal-General-Group-Digital/frontend-platform/issues?q=is%3Aissue+is%3Aclosed) to see if a similar bug has been fixed in the past
+* [ ] I have checked the [open Issues](https://github.com/Legal-and-General/canopy/issues) to see if this has already been raised
+* [ ] I have searched the [closed Issues](https://github.com/Legal-and-General/canopy/issues?q=is%3Aissue+is%3Aclosed) to see if a similar bug has been fixed in the past
 
 ## Description
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,28 +12,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: setup node
+        with:
+          fetch-depth: 0
+
+      - name: 'Setup node'
         uses: actions/setup-node@v3.4.1
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-      - name: install dependencies
+
+      - name: 'Install dependencies'
         run: npm ci
-      - name: eslint
+
+      - name: 'Lint commit'
+        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
+
+      - name: 'Eslint'
         run: npm run eslint
-      - name: stylelint
+
+      - name: 'Stylelint'
         run: npm run stylelint
-      - name: test
+
+      - name: 'Unit test'
         run: npm run test:ci
-      - name: build
+
+      - name: 'Build'
         run: npm run build
-      - name: install build dependencies
+
+      - name: 'Install build dependencies'
         run: npm --prefix ./dist/canopy install
-      - name: license check build dependencies
+
+      - name: 'License check build dependencies'
         run: npm run license-check:build
-      - name: build:test-app
+
+      - name: 'Build test app'
         run: npm run build:test-app
-      - name: build storybook
+
+      - name: 'Build storybook'
         run: npm run build:storybook -- --output-dir ./sb-build
       - uses: actions/upload-artifact@v3.1.0
         with:


### PR DESCRIPTION
# Description

Add commit lint to the CI so that we make sure people don't commit using `--no-verify`.

Also updates wrong links in issue template.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
