### PR TITLE
ci(lint-commit): update workflow to skip check for dependabot-updates

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,7 @@ jobs:
         run: npm ci
 
       - name: 'Lint commit'
+        if: ${{ !contains(github.head_ref, 'dependabot-updates') }}
         run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
 
       - name: 'Eslint'


### PR DESCRIPTION
# Description

Ignore `Lint commit` stage for the `dependency-updates` branch as message is automated.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
