### PR TITLE
Add size input to radio and checkbox inputs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: 'Lint commit'
         if: ${{ !contains(github.head_ref, 'dependabot-updates') }}
-        run: npx commitlint --from HEAD~${{ github.event.pull_request.commits }} --to HEAD
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
       - name: 'Eslint'
         run: npm run eslint

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.html
@@ -12,7 +12,13 @@
   type="radio"
 />
 
-<label [attr.for]="id" class="lg-radio-button__label">
+<label
+  [attr.for]="id"
+  class="lg-radio-button__label"
+  [ngClass]="{
+    'lg-radio-button__label--sm': variant === 'radio' && size === 'sm',
+    'lg-radio-button__label--lg': variant === 'radio' && size === 'lg'
+  }">
   <ng-content></ng-content>
 </label>
 

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -38,8 +38,8 @@
   top: 0;
   bottom: 0;
   display: inline-block;
-  height: var(--radio-outer-height);
-  width: var(--radio-outer-width);
+  height: var(--_radio-outer-height);
+  width: var(--_radio-outer-width);
   background-color: var(--color-white);
   border-radius: 50%;
   border: var(--border-width) solid var(--radio-border-color);
@@ -60,15 +60,25 @@
   }
 }
 
+.lg-radio-button__label--sm::before {
+  --_radio-outer-height: var(--radio-outer-height);
+  --_radio-outer-width: var(--radio-outer-width);
+}
+
+.lg-radio-button__label--lg::before {
+  --_radio-outer-height: var(--radio-outer-lg-height);
+  --_radio-outer-width: var(--radio-outer-lg-width);
+}
+
 .lg-radio-button__label::after {
   content: ' ';
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
-  margin: auto var(--space-xxxs);
-  height: var(--radio-inner-height);
-  width: var(--radio-inner-width);
+  height: var(--_radio-inner-height);
+  width: var(--_radio-inner-width);
+  margin: auto var(--_radio-inner-margin-horizontal);
   border-radius: 50%;
 
   .lg-radio-button__input:checked + & {
@@ -82,4 +92,16 @@
   .lg-radio-button--error .lg-radio-button__input:checked + & {
     background-color: var(--form-error-border-color);
   }
+}
+
+.lg-radio-button__label--sm::after {
+  --_radio-inner-margin-horizontal: calc(var(--radio-inner-height) / 2);
+  --_radio-inner-height: var(--radio-inner-height);
+  --_radio-inner-width: var(--radio-inner-width);
+}
+
+.lg-radio-button__label--lg::after {
+  --_radio-inner-margin-horizontal: calc(var(--radio-inner-lg-height) / 2);
+  --_radio-inner-height: var(--radio-inner-lg-height);
+  --_radio-inner-width: var(--radio-inner-lg-width);
 }

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, Input } from '@angular/core';
 import {
   FormBuilder,
   FormGroup,
@@ -16,6 +16,7 @@ import { LgHintComponent } from '../hint';
 
 import { LgRadioButtonComponent } from './radio-button.component';
 import { LgRadioGroupComponent } from './radio-group.component';
+import { RadioSize } from './radio.interface';
 
 const hintTestId = 'test-hint-id';
 
@@ -24,7 +25,7 @@ const hintTestId = 'test-hint-id';
     <form [formGroup]="form" #testForm="ngForm">
       <lg-radio-group formControlName="color">
         Color
-        <lg-radio-button value="red">Red</lg-radio-button>
+        <lg-radio-button value="red" [size]="size">Red</lg-radio-button>
         <lg-radio-button value="yellow"
           >Yellow
           <div class="lg-radio-button__content">
@@ -38,6 +39,7 @@ const hintTestId = 'test-hint-id';
 })
 class TestRadioButtonComponent {
   form: FormGroup;
+  @Input() size: RadioSize = 'sm';
 
   constructor(public fb: FormBuilder) {
     this.form = this.fb.group({
@@ -56,47 +58,45 @@ describe('LgRadioButtonComponent', () => {
   let hintDebugElement: DebugElement;
   let inputDebugElement: DebugElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      errorStateMatcherMock = mock(LgErrorStateMatcher);
-      radioGroupMock = mock(LgRadioGroupComponent);
-      when(radioGroupMock.name).thenReturn('color');
-      when(radioGroupMock.variant).thenReturn('segment');
+  beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = mock(LgErrorStateMatcher);
+    radioGroupMock = mock(LgRadioGroupComponent);
+    when(radioGroupMock.name).thenReturn('color');
+    when(radioGroupMock.variant).thenReturn('segment');
 
-      TestBed.configureTestingModule({
-        imports: [ FormsModule, ReactiveFormsModule ],
-        declarations: [
-          LgRadioButtonComponent,
-          LgRadioGroupComponent,
-          TestRadioButtonComponent,
-          MockComponents(LgHintComponent),
-        ],
-        providers: [
-          {
-            provide: LgRadioGroupComponent,
-            useFactory: () => instance(radioGroupMock),
-          },
-          {
-            provide: LgErrorStateMatcher,
-            useFactory: () => instance(errorStateMatcherMock),
-          },
-        ],
-      }).compileComponents();
+    TestBed.configureTestingModule({
+      imports: [ FormsModule, ReactiveFormsModule ],
+      declarations: [
+        LgRadioButtonComponent,
+        LgRadioGroupComponent,
+        TestRadioButtonComponent,
+        MockComponents(LgHintComponent),
+      ],
+      providers: [
+        {
+          provide: LgRadioGroupComponent,
+          useFactory: () => instance(radioGroupMock),
+        },
+        {
+          provide: LgErrorStateMatcher,
+          useFactory: () => instance(errorStateMatcherMock),
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(LgRadioButtonComponent);
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(LgRadioButtonComponent);
+    component = fixture.componentInstance;
 
-      fixture.detectChanges();
+    fixture.detectChanges();
 
-      testFixture = TestBed.createComponent(TestRadioButtonComponent);
-      testComponent = testFixture.componentInstance;
+    testFixture = TestBed.createComponent(TestRadioButtonComponent);
+    testComponent = testFixture.componentInstance;
 
-      testFixture.detectChanges();
+    testFixture.detectChanges();
 
-      inputDebugElement = testFixture.debugElement.queryAll(By.css('input'))[1];
-      hintDebugElement = testFixture.debugElement.query(By.directive(LgHintComponent));
-    }),
-  );
+    inputDebugElement = testFixture.debugElement.queryAll(By.css('input'))[1];
+    hintDebugElement = testFixture.debugElement.query(By.directive(LgHintComponent));
+  }));
 
   it('sets its name from the radio group name', () => {
     expect(component.name).toBe('color');
@@ -120,6 +120,31 @@ describe('LgRadioButtonComponent', () => {
         'lg-radio-button--segment',
       );
     });
+  });
+
+  it('adds the radio button size based on the variant', () => {
+    expect(fixture.debugElement.query(By.css('.lg-radio-button__label--sm'))).toBeNull();
+
+    when(radioGroupMock.variant).thenReturn('radio');
+    fixture = TestBed.createComponent(LgRadioButtonComponent);
+    component = fixture.componentInstance;
+    component.size = 'sm';
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('.lg-radio-button__label--sm')).nativeElement,
+    ).toBeDefined();
+
+    expect(fixture.debugElement.query(By.css('.lg-radio-button__label--lg'))).toBeNull();
+
+    component.size = 'lg';
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('.lg-radio-button__label--lg')).nativeElement,
+    ).toBeDefined();
+
+    expect(fixture.debugElement.query(By.css('.lg-radio-button__label--sm'))).toBeNull();
   });
 
   // https://github.com/NagRock/ts-mockito/issues/120

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.ts
@@ -23,7 +23,7 @@ import { LgHintComponent } from '../hint';
 import { LgDomService } from '../../utils/dom.service';
 
 import { LgRadioGroupComponent } from './radio-group.component';
-import type { RadioStackBreakpoint, RadioVariant } from './radio.interface';
+import type { RadioSize, RadioStackBreakpoint, RadioVariant } from './radio.interface';
 
 let nextUniqueId = 0;
 
@@ -59,6 +59,7 @@ export class LgRadioButtonComponent implements OnInit {
   @Input() id = `lg-radio-button-${++nextUniqueId}`;
   @Input() name: string;
   @Input() value: boolean | string;
+  @Input() size: RadioSize = 'sm';
   @Input() ariaDescribedBy: string;
 
   _stacked: RadioStackBreakpoint;

--- a/projects/canopy/src/lib/forms/radio/radio.interface.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.interface.ts
@@ -1,2 +1,3 @@
 export type RadioVariant = 'radio' | 'filter' | 'segment';
 export type RadioStackBreakpoint = 'sm' | 'md' | 'lg';
+export type RadioSize = 'sm' | 'lg';

--- a/projects/canopy/src/lib/forms/radio/radio.notes.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.notes.ts
@@ -55,6 +55,11 @@ ${
 | \`\`name\`\` | HTML name attribute | string | null | Yes |
 | \`\`value\`\` | HTML value attribute | string | null | Yes |
 | \`\`ariaDescribedBy\`\` | HTML ID for the corresponding element that describes the radio, if not provided it will use the hint field where appropriate. | boolean | null | No |
+${
+  name === 'Radio'
+    ? '| ``size`` | The size of the radio button | `RadioSize` | `sm` | No |'
+    : ''
+}
 
 ### Outputs
 

--- a/projects/canopy/src/lib/forms/radio/radio.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/radio.stories.ts
@@ -13,8 +13,8 @@ const formTemplate = `
   <lg-radio-group [inline]="inline" [focus]="focus" formControlName="color">
     {{ label }}
     <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
-    <lg-radio-button value="red" (blur)="radioBlur.emit($event)">Red</lg-radio-button>
-    <lg-radio-button value="yellow" (blur)="radioBlur.emit($event)"
+    <lg-radio-button value="red" [size]="size" (blur)="radioBlur.emit($event)">Red</lg-radio-button>
+    <lg-radio-button value="yellow" [size]="size" (blur)="radioBlur.emit($event)"
       >Yellow
       <lg-hint>Internal custom text</lg-hint>
     </lg-radio-button>
@@ -28,6 +28,7 @@ const formTemplate = `
 })
 class ReactiveFormRadioComponent {
   @Input() inline = false;
+  @Input() size = 'sm';
   @Input() focus = false;
   @Input() label: string;
   @Input() hint: string;
@@ -50,7 +51,7 @@ class ReactiveFormRadioComponent {
 
   constructor(public fb: FormBuilder) {
     this.form = this.fb.group({ color: 'red' });
-    this.form.valueChanges.subscribe(val => this.radioChange.emit(val));
+    this.form.valueChanges.subscribe((val) => this.radioChange.emit(val));
   }
 }
 
@@ -113,6 +114,21 @@ export default {
         },
       },
     },
+    size: {
+      options: [ 'sm', 'lg' ],
+      description: 'The size of the radio button.',
+      table: {
+        type: {
+          summary: [ 'sm', 'lg' ],
+        },
+        defaultValue: {
+          summary: 'sm',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+    },
     disabled: {
       description: 'Set the inner filters to disabled.',
       table: {
@@ -131,6 +147,12 @@ export default {
     },
     radioChange: {
       action: 'Radio change',
+      table: {
+        disable: true,
+      },
+    },
+    radioBlur: {
+      action: 'Radio blur',
       table: {
         disable: true,
       },
@@ -220,6 +242,7 @@ const radioStory: Story<LgRadioModule> = (args: LgRadioModule) => ({
     [disabled]="disabled"
     [hint]="hint"
     [inline]="inline"
+    [size]="size"
     [label]="label"
     [focus]="focus"
     (radioChange)="radioChange($event)"
@@ -228,18 +251,19 @@ const radioStory: Story<LgRadioModule> = (args: LgRadioModule) => ({
   `,
 });
 
-export const radioButtons = radioStory.bind({});
-radioButtons.storyName = 'Radio';
+export const radio = radioStory.bind({});
+radio.storyName = 'Radio';
 
-radioButtons.args = {
+radio.args = {
   disabled: false,
   inline: false,
+  size: 'sm',
   focus: false,
   label: 'Color',
   hint: 'Please select a color',
 };
 
-radioButtons.parameters = {
+radio.parameters = {
   docs: {
     source: {
       code: formTemplate,

--- a/projects/canopy/src/lib/forms/toggle/checkbox.stories.ts
+++ b/projects/canopy/src/lib/forms/toggle/checkbox.stories.ts
@@ -193,6 +193,7 @@ const code = `
 <lg-checkbox
   formControlName="umbrella"
   [value]="true"
+  [size]="sm"
   [checked]="umbrella.value"
   [focus]="focus"
   (blur)="toggleBlur.emit($event)"

--- a/projects/canopy/src/lib/forms/toggle/switch.stories.ts
+++ b/projects/canopy/src/lib/forms/toggle/switch.stories.ts
@@ -42,6 +42,11 @@ export default {
         disable: true,
       },
     },
+    size: {
+      table: {
+        disable: true,
+      },
+    },
     focus: {
       description: 'Set the focus on the switch.',
       table: {

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.html
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.html
@@ -27,6 +27,10 @@
   <lg-icon
     *ngIf="variant === 'checkbox'"
     class="lg-toggle__checkbox"
+    [ngClass]="{
+      'lg-toggle__checkbox--sm': size === 'sm',
+      'lg-toggle__checkbox--lg': size === 'lg'
+    }"
     name="checkbox-mark"
   ></lg-icon>
   <ng-content></ng-content>

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -28,8 +28,18 @@
   background-color: var(--color-white);
   border: var(--border-width) solid var(--toggle-border-color);
   color: transparent;
-  font-size: 0.8rem;
-  margin: var(--space-xxxs) var(--space-sm) auto 0;
+  font-size: var(--_toggle-icon-font-size);
+  margin: var(--_toggle-icon-margin-top) var(--space-sm) auto 0;
+
+  &--sm {
+    --_toggle-icon-font-size: 0.8rem;
+    --_toggle-icon-margin-top: var(--space-xxxs);
+  }
+
+  &--lg {
+    --_toggle-icon-font-size: 1.334rem;
+    --_toggle-icon-margin-top: -0.063rem;
+  }
 
   &.lg-icon > svg {
     display: inline-block;

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
@@ -10,15 +10,16 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { MockComponents } from 'ng-mocks';
+import { MockComponents, MockDirective } from 'ng-mocks';
 import { anything, instance, mock, when } from 'ts-mockito';
 
 import { LgIconComponent } from '../../icon';
 import { LgErrorStateMatcher } from '../validation/error-state-matcher';
 import { LgValidationComponent } from '../validation/validation.component';
+import { LgFocusDirective } from '../../focus';
 
 import { LgToggleComponent } from './toggle.component';
-import type { ToggleVariant } from './toggle.interface';
+import type { CheckboxSize, ToggleVariant } from './toggle.interface';
 
 const validationTestId = 'test-validation-id';
 
@@ -31,6 +32,7 @@ const validationTestId = 'test-validation-id';
         (change)="onChange()"
         (blur)="onBlur($event)"
         [variant]="variant"
+        [size]="size"
       >
         I will bring my Umbrella if it is raining
         <lg-validation
@@ -45,6 +47,7 @@ const validationTestId = 'test-validation-id';
 })
 class TestToggleComponent {
   @Input() variant: ToggleVariant;
+  @Input() size: CheckboxSize;
 
   form: FormGroup;
 
@@ -117,37 +120,36 @@ describe('LgToggleComponent', () => {
 
   const errorStateMatcherMock = mock(LgErrorStateMatcher);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ FormsModule, ReactiveFormsModule ],
-        declarations: [
-          TestToggleComponent,
-          LgToggleComponent,
-          MockComponents(LgValidationComponent, LgIconComponent),
-        ],
-        providers: [
-          {
-            provide: LgErrorStateMatcher,
-            useFactory: () => instance(errorStateMatcherMock),
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ FormsModule, ReactiveFormsModule ],
+      declarations: [
+        TestToggleComponent,
+        LgToggleComponent,
+        MockComponents(LgValidationComponent, LgIconComponent),
+        MockDirective(LgFocusDirective),
+      ],
+      providers: [
+        {
+          provide: LgErrorStateMatcher,
+          useFactory: () => instance(errorStateMatcherMock),
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(TestToggleComponent);
-      fixture.detectChanges();
-      component = fixture.componentInstance;
+    fixture = TestBed.createComponent(TestToggleComponent);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
 
-      toggleDebugElement = fixture.debugElement.query(By.directive(LgToggleComponent));
+    toggleDebugElement = fixture.debugElement.query(By.directive(LgToggleComponent));
 
-      toggleInstance =
-        toggleDebugElement.injector.get<LgToggleComponent>(LgToggleComponent);
+    toggleInstance =
+      toggleDebugElement.injector.get<LgToggleComponent>(LgToggleComponent);
 
-      inputDebugElement = fixture.debugElement.query(By.css('.lg-toggle__input'));
-      inputLabelElement = fixture.debugElement.query(By.css('.lg-toggle__label'));
-      fixture.detectChanges();
-    }),
-  );
+    inputDebugElement = fixture.debugElement.query(By.css('.lg-toggle__input'));
+    inputLabelElement = fixture.debugElement.query(By.css('.lg-toggle__label'));
+    fixture.detectChanges();
+  }));
 
   it('sets a unique name for the toggle button', () => {
     expect(
@@ -187,6 +189,31 @@ describe('LgToggleComponent', () => {
     expect(
       fixture.debugElement.query(By.css('.lg-toggle__checkbox')).nativeElement,
     ).toBeDefined();
+  });
+
+  it('adds the checkbox size based on the variant', () => {
+    component.variant = 'switch';
+
+    expect(fixture.debugElement.query(By.css('.lg-toggle__checkbox--sm'))).toBeNull();
+
+    component.variant = 'checkbox';
+    component.size = 'sm';
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('.lg-toggle__checkbox--sm')).nativeElement,
+    ).toBeDefined();
+
+    expect(fixture.debugElement.query(By.css('.lg-toggle__checkbox--lg'))).toBeNull();
+
+    component.size = 'lg';
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('.lg-toggle__checkbox--lg')).nativeElement,
+    ).toBeDefined();
+
+    expect(fixture.debugElement.query(By.css('.lg-toggle__checkbox--sm'))).toBeNull();
   });
 
   it('links the label to the input field with the correct attributes', () => {
@@ -281,35 +308,33 @@ describe('LgToggleComponent selector variant', () => {
 
   const errorStateMatcherMock = mock(LgErrorStateMatcher);
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [ FormsModule, ReactiveFormsModule ],
-        declarations: [
-          TestToggleVariantSelectorComponent,
-          LgToggleComponent,
-          MockComponents(LgValidationComponent, LgIconComponent),
-        ],
-        providers: [
-          {
-            provide: LgErrorStateMatcher,
-            useFactory: () => instance(errorStateMatcherMock),
-          },
-        ],
-      }).compileComponents();
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ FormsModule, ReactiveFormsModule ],
+      declarations: [
+        TestToggleVariantSelectorComponent,
+        LgToggleComponent,
+        MockComponents(LgValidationComponent, LgIconComponent),
+      ],
+      providers: [
+        {
+          provide: LgErrorStateMatcher,
+          useFactory: () => instance(errorStateMatcherMock),
+        },
+      ],
+    }).compileComponents();
 
-      fixture = TestBed.createComponent(TestToggleVariantSelectorComponent);
-      fixture.detectChanges();
+    fixture = TestBed.createComponent(TestToggleVariantSelectorComponent);
+    fixture.detectChanges();
 
-      toggleDebugElement = fixture.debugElement.query(By.directive(LgToggleComponent));
+    toggleDebugElement = fixture.debugElement.query(By.directive(LgToggleComponent));
 
-      toggleInstance =
-        toggleDebugElement.injector.get<LgToggleComponent>(LgToggleComponent);
+    toggleInstance =
+      toggleDebugElement.injector.get<LgToggleComponent>(LgToggleComponent);
 
-      inputLabelElement = fixture.debugElement.query(By.css('.lg-toggle__label'));
-      fixture.detectChanges();
-    }),
-  );
+    inputLabelElement = fixture.debugElement.query(By.css('.lg-toggle__label'));
+    fixture.detectChanges();
+  }));
 
   it('sets the correct variant based on the selector', () => {
     expect(toggleInstance.variant).toBe('switch');

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.ts
@@ -24,6 +24,7 @@ import { LgValidationComponent } from '../validation/validation.component';
 import { LgCheckboxGroupComponent } from '../checkbox-group';
 
 import type { ToggleVariant } from './toggle.interface';
+import { CheckboxSize } from './toggle.interface';
 
 let nextUniqueId = 0;
 
@@ -48,6 +49,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
   @Input() focus: boolean;
   @Input() ariaDescribedBy: string;
   @Input() variant: ToggleVariant = 'checkbox';
+  @Input() size: CheckboxSize = 'sm';
   @Input()
   _disabled = false;
   get disabled(): boolean {

--- a/projects/canopy/src/lib/forms/toggle/toggle.interface.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.interface.ts
@@ -1,1 +1,3 @@
 export type ToggleVariant = 'checkbox' | 'switch' | 'filter';
+
+export type CheckboxSize = 'sm' | 'lg';

--- a/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.notes.ts
@@ -36,6 +36,11 @@ or
 | \`\`value\`\` | HTML value attribute | string | null | Yes |
 | \`\`focus\`\` | Set the focus on the ${name.toLowerCase()} | boolean | null | No |
 | \`\`ariaDescribedBy\`\` | HTML ID for the corresponding element that describes the ${name.toLowerCase()}, if not provided it will use the hint field where appropriate | boolean | null | No |
+${
+  name.toLowerCase() === 'checkbox'
+    ? '| ``size`` | The size of the checkbox | `CheckboxSize` | `sm` | No |'
+    : ''
+}
 
 ## Outputs
 

--- a/projects/canopy/src/lib/forms/toggle/toggle.stories.common.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.stories.common.ts
@@ -10,6 +10,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 
 import type { ToggleVariant } from './toggle.interface';
 import { LgToggleModule } from './toggle.module';
+import { CheckboxSize } from './toggle.interface';
 
 @Component({
   selector: 'lg-reactive-form',
@@ -21,6 +22,7 @@ import { LgToggleModule } from './toggle.module';
         [variant]="variant"
         [checked]="umbrella.value"
         [focus]="focus"
+        [size]="size"
         (blur)="toggleBlur.emit($event)"
       >
         {{ label }}
@@ -33,6 +35,7 @@ export class ReactiveToggleFormComponent implements OnChanges {
   @Input() variant: ToggleVariant;
   @Input() checked: boolean;
   @Input() focus: boolean;
+  @Input() size: CheckboxSize;
 
   @Input()
   set disabled(disabled: boolean) {
@@ -78,6 +81,7 @@ export function createToggleStory(args: LgToggleModule, variant: string) {
         [disabled]="disabled"
         [label]="label"
         variant="${variant}"
+        [size]="size"
         [checked]="checked"
         [focus]="focus"
         (toggleChange)="toggleChange($event)"
@@ -92,6 +96,7 @@ export function setupToggleStoryValues(obj, code) {
     disabled: false,
     inline: false,
     focus: false,
+    size: 'sm',
     label: 'I will bring my Umbrella if it is raining',
   };
 

--- a/projects/canopy/src/styles/variables/components/_radio.scss
+++ b/projects/canopy/src/styles/variables/components/_radio.scss
@@ -4,10 +4,14 @@
   --radio-border-color: var(--border-color);
   --radio-disabled-color: var(--color-taupe-grey);
 
-  --radio-inner-height: 0.5rem;
-  --radio-inner-width: var(--radio-inner-height);
   --radio-outer-height: 1rem;
   --radio-outer-width: var(--radio-outer-height);
+  --radio-inner-height: calc(var(--radio-outer-height) / 2);
+  --radio-inner-width: var(--radio-inner-height);
+  --radio-outer-lg-height: 1.5rem;
+  --radio-outer-lg-width: var(--radio-outer-lg-height);
+  --radio-inner-lg-height: calc(var(--radio-outer-lg-height) / 2);
+  --radio-inner-lg-width: var(--radio-inner-lg-height);
 
   --radio-segment-separator-border-width: var(--border-width);
   --radio-segment-separator-border-color: var(--color-platinum);


### PR DESCRIPTION
# Description

Add `size` input to `radio` and `checkbox` inputs.

Also fixes an issue with the `commitlint` step in the CI not picking up the correct commits - caused by how GH checkout works.

## Requirements

Requirements discussed here: https://github.com/Legal-and-General/canopy/discussions/874

Radio `sm`:
<img width="318" alt="Screenshot 2022-08-09 at 16 23 40" src="https://user-images.githubusercontent.com/8397116/183690562-af51fd75-7268-4aff-aaa3-0401061bf4ce.png">

Radio `lg`:
<img width="330" alt="Screenshot 2022-08-09 at 16 23 46" src="https://user-images.githubusercontent.com/8397116/183690538-de13973f-8a41-4dfa-a03f-11157e982c92.png">

Checkbox `sm`:
<img width="234" alt="Screenshot 2022-08-09 at 16 23 29" src="https://user-images.githubusercontent.com/8397116/183690614-93d9d180-daa9-4b01-8133-84338ac6479e.png">

Checkbox `lg`:
<img width="196" alt="Screenshot 2022-08-09 at 16 23 34" src="https://user-images.githubusercontent.com/8397116/183690594-4ef7492d-1ef0-4fb3-9e1b-ad1f89fe813e.png">


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
