### PR TITLE
fix(segment): add hover state

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
@@ -22,6 +22,7 @@
     text-align: center;
     align-items: center;
     justify-content: center;
+    cursor: pointer;
 
     &::before,
     &::after {
@@ -51,7 +52,18 @@
       cursor: not-allowed;
     }
 
+    &:hover + .lg-radio-button__label {
+      background-color: var(--radio-segment-hover-bg-color);
+      color: var(--radio-color);
+      transition: all var(--animation-duration) var(--animation-fn);
+    }
+
     &:focus + .lg-radio-button__label {
+      @include lg-inner-focus-outline(var(--default-focus-color));
+    }
+
+    &:focus:hover + .lg-radio-button__label {
+      background-color: var(--radio-bg-color);
       @include lg-inner-focus-outline(var(--default-focus-color));
     }
   }

--- a/projects/canopy/src/styles/variables/components/_radio.scss
+++ b/projects/canopy/src/styles/variables/components/_radio.scss
@@ -16,4 +16,5 @@
   --radio-segment-separator-border-width: var(--border-width);
   --radio-segment-separator-border-color: var(--color-platinum);
   --radio-segment-label-min-width: calc(6 * var(--space-unit));
+  --radio-segment-hover-bg-color: var(--color-super-blue-dark);
 }


### PR DESCRIPTION
# Description

This PR adds a 'hover' state to the segment buttons/toggles and a 'pointer' as the cursor.

Designs: [designs](https://legalandgeneral.invisionapp.com/console/share/N4HBGD69TXC/597018576)
Screenshot: 
<img width="871" alt="Screenshot 2022-08-18 at 14 15 29" src="https://user-images.githubusercontent.com/68600084/185402703-867772df-7976-4f60-94af-f040ab5f9ead.png">

# Checklist:

- [X] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
