### PR TITLE
refactor(details): update id and aria attributes

### DIFF
--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.html
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.html
@@ -1,11 +1,11 @@
 <lg-heading [level]="headingLevel" class="lg-details-panel-heading">
   <button
     type="button"
-    [id]="toggleId"
+    [id]="'lg-details-header-' + uniqueId"
     class="lg-details-panel-heading__toggle"
     [class.lg-details-panel-heading__toggle--active]="isActive"
     [attr.aria-expanded]="isActive"
-    [attr.aria-controls]="panelId"
+    [attr.aria-controls]="'lg-details-content-' + uniqueId"
     (click)="toggle()"
   >
     <div

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
@@ -11,8 +11,6 @@ import {
 import { lgIconChevronDown } from '../../icon';
 import type { Variant } from '../../variant';
 
-let nextUniqueId = 0;
-
 @Component({
   selector: 'lg-details-panel-heading',
   templateUrl: './details-panel-heading.component.html',
@@ -47,13 +45,11 @@ export class LgDetailsPanelHeadingComponent {
   @Output() toggleActive = new EventEmitter<boolean>();
 
   chevronDown = lgIconChevronDown.name;
-  id = nextUniqueId++;
-  toggleId = `lg-details-header-${this.id}`;
-  panelId = `lg-details-content-${this.id}`;
+  uniqueId: number;
 
   constructor(private cdr: ChangeDetectorRef) {}
 
-  toggle() {
+  toggle(): void {
     this.isActive = !this.isActive;
     this.toggleActive.emit(this.isActive);
   }

--- a/projects/canopy/src/lib/details/details.component.html
+++ b/projects/canopy/src/lib/details/details.component.html
@@ -1,10 +1,10 @@
 <ng-content select="lg-details-panel-heading"></ng-content>
 <div
   class="lg-details__panel"
-  [id]="panelId"
+  [id]="'lg-details-content-' + uniqueId"
   [class.lg-details__panel--active]="isActive"
-  [attr.aria-labelledby]="toggleId"
-  [attr.role]="'region'"
+  [attr.aria-labelledby]="'lg-details-header-' + uniqueId"
+  role="region"
 >
   <ng-content></ng-content>
 </div>

--- a/projects/canopy/src/lib/details/details.component.spec.ts
+++ b/projects/canopy/src/lib/details/details.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
-import { MockComponent, MockRender, MockedComponentFixture } from 'ng-mocks';
+import { MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 
 import { LgDetailsPanelHeadingComponent } from './details-panel-heading/details-panel-heading.component';
 import { LgDetailsComponent } from './details.component';
@@ -11,13 +11,11 @@ describe('LgDetailsComponent', () => {
   let detailsDebugElement: DebugElement;
   let detailsEl: HTMLElement;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [ LgDetailsComponent, MockComponent(LgDetailsPanelHeadingComponent) ],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LgDetailsComponent, LgDetailsPanelHeadingComponent ],
+    }).compileComponents();
+  }));
 
   describe('component', () => {
     beforeEach(() => {
@@ -30,7 +28,10 @@ describe('LgDetailsComponent', () => {
       detailsDebugElement = fixture.debugElement;
       component = detailsDebugElement.children[0].componentInstance;
       detailsEl = detailsDebugElement.children[0].nativeElement;
-      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      ngMocks.flushTestBed();
     });
 
     it('should create', () => {
@@ -43,6 +44,19 @@ describe('LgDetailsComponent', () => {
 
     it('adds generic as the default variant', () => {
       expect(detailsEl.getAttribute('class')).toContain('generic');
+    });
+
+    it('should add an id and aria-labelledby attribute to the panel that matches the values of the attributes of the toggle', () => {
+      const panelEl = detailsEl.getElementsByClassName('lg-details__panel')[0];
+      const toggleEl = detailsEl.getElementsByClassName(
+        'lg-details-panel-heading__toggle',
+      )[0];
+
+      const toggleElId = toggleEl.getAttribute('id');
+      const toggleElAriaControls = toggleEl.getAttribute('aria-controls');
+
+      expect(panelEl.getAttribute('id')).toBe(toggleElAriaControls);
+      expect(panelEl.getAttribute('aria-labelledby')).toBe(toggleElId);
     });
   });
 

--- a/projects/canopy/src/lib/details/details.component.ts
+++ b/projects/canopy/src/lib/details/details.component.ts
@@ -30,9 +30,7 @@ let nextUniqueId = 0;
 })
 export class LgDetailsComponent implements AfterContentInit, OnDestroy {
   private subscription: Subscription;
-  id = nextUniqueId++;
-  toggleId = `lg-details-header-${this.id}`;
-  panelId = `lg-details-content-${this.id}`;
+  uniqueId = nextUniqueId++;
   _showIcon = true;
   _variant: Variant;
 
@@ -45,7 +43,7 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
       this.panelHeading.showIcon = showIcon;
     }
   }
-  get showIcon() {
+  get showIcon(): boolean {
     return this._showIcon;
   }
 
@@ -65,7 +63,7 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
     this.renderer.addClass(this.hostElement.nativeElement, `lg-variant--${variant}`);
     this._variant = variant;
   }
-  get variant() {
+  get variant(): Variant {
     return this._variant;
   }
 
@@ -91,6 +89,7 @@ export class LgDetailsComponent implements AfterContentInit, OnDestroy {
   }
 
   ngAfterContentInit(): void {
+    this.panelHeading.uniqueId = this.uniqueId;
     this.panelHeading.isActive = this.isActive;
     this.panelHeading.variant = this.variant;
     this.panelHeading.showIcon = this.showIcon;


### PR DESCRIPTION
# Description

I initially picked this ticket as I had noticed the attributes not being set correctly for the panel content in Storybook:

![184384977-f7e82c3b-931d-4ab9-9ce7-6309acb064ef](https://user-images.githubusercontent.com/8397116/185447992-8543b889-28db-4fb5-97d0-18b4f399a1b3.png)

I could reproduce the issue locally so I refactored the code. It now works locally but Storybook seem to still have the issue.
I tested the component in one of our apps and both before and after I can see it working just fine so this is why I have marked this as refactoring instead of a fix.

No matter what I try Storybook seem to still have the issue so I believe this to be something to do with Storybook itself.

Related to: #726 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
