### PR TITLE
Fix console error triggered on blur of certain form elements

### DIFF
--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.stories.ts
@@ -48,7 +48,7 @@ class ReactiveFormComponent {
 
   constructor(public fb: FormBuilder) {
     this.form = this.fb.group({ colors: this.fb.control([ 'red' ]) });
-    this.form.valueChanges.subscribe(val => this.checkboxChange.emit(val));
+    this.form.valueChanges.subscribe((val) => this.checkboxChange.emit(val));
   }
 }
 
@@ -124,6 +124,12 @@ export default {
     },
     checkboxChange: {
       action: 'Checkbox change',
+      table: {
+        disable: true,
+      },
+    },
+    checkboxBlur: {
+      action: 'Checkbox blur',
       table: {
         disable: true,
       },

--- a/projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/filter-group.stories.ts
@@ -49,7 +49,7 @@ class ReactiveFormComponent {
 
   constructor(public fb: FormBuilder) {
     this.form = this.fb.group({ colors: this.fb.control([ 'red' ]) });
-    this.form.valueChanges.subscribe(val => this.checkboxChange.emit(val));
+    this.form.valueChanges.subscribe((val) => this.checkboxChange.emit(val));
   }
 }
 
@@ -114,6 +114,12 @@ export default {
     },
     checkboxChange: {
       action: 'Checkbox change',
+      table: {
+        disable: true,
+      },
+    },
+    checkboxBlur: {
+      action: 'Checkbox blur',
       table: {
         disable: true,
       },

--- a/projects/canopy/src/lib/forms/radio/filter.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/filter.stories.ts
@@ -53,7 +53,7 @@ class ReactiveFormFilterComponent {
 
   constructor(public fb: FormBuilder) {
     this.form = this.fb.group({ color: '' });
-    this.form.valueChanges.subscribe(val => this.filterChange.emit(val));
+    this.form.valueChanges.subscribe((val) => this.filterChange.emit(val));
   }
 }
 
@@ -118,6 +118,12 @@ export default {
     },
     filterChange: {
       action: 'Filter change',
+      table: {
+        disable: true,
+      },
+    },
+    filterBlur: {
+      action: 'Filter blur',
       table: {
         disable: true,
       },

--- a/projects/canopy/src/lib/forms/radio/segment.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/segment.stories.ts
@@ -49,7 +49,7 @@ class ReactiveFormSegmentComponent {
 
   constructor(public fb: FormBuilder) {
     this.form = this.fb.group({ color: null });
-    this.form.valueChanges.subscribe(val => this.segmentChange.emit(val));
+    this.form.valueChanges.subscribe((val) => this.segmentChange.emit(val));
   }
 }
 
@@ -136,6 +136,12 @@ export default {
     },
     segmentChange: {
       action: 'Segment change',
+      table: {
+        disable: true,
+      },
+    },
+    segmentBlur: {
+      action: 'Segment blur',
       table: {
         disable: true,
       },


### PR DESCRIPTION
# Description

Fix a console error triggered on blur of certain form elements. This was raised by DIG Inclusion as Advisory and it only affects the Storybook site.

Updated components:
- checkbox group
- filter group
- filter
- segment

Before and after:

https://user-images.githubusercontent.com/8397116/187689533-427c8778-1abe-43e4-b51f-5e2888a21a94.mov


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
