### PR TITLE
Add inputs for setting the outlines and half tone colours of the brand icons

### DIFF
--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
@@ -99,20 +99,54 @@ describe('LgBrandIconComponent', () => {
         expect(el.style.fill).toEqual('var(--colour-css-variable)');
       });
     });
+
+    it('when the icon isn\'t coloured it should not set the fill style', () => {
+      when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
+        '<svg id="test">test-svg<path id="no-color"></path></svg>',
+      );
+
+      component.name = 'sun';
+
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector('path[id^="lg-brand-icon-"]');
+
+      expect(el.getAttribute('data-colour')).toBeNull();
+      expect(el.style.fill).toEqual('');
+    });
   });
 
-  it('when the icon isn\'t coloured it should not set the fill style', () => {
-    when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
-      '<svg id="test">test-svg<path id="no-color"></path></svg>',
-    );
+  describe('the half tone colour input', () => {
+    it('should apply the specific colour', () => {
+      when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
+        '<svg id="test">test-svg<path id="Half-tone"></path></svg>',
+      );
 
-    component.name = 'sun';
+      component.name = 'sun';
+      component.halfToneColour = '--colour-css-variable';
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector(
+        '[data-colour="lg-icon-half-tone-fill"]',
+      );
 
-    fixture.detectChanges();
-    const el = fixture.nativeElement.querySelector('path[id^="lg-brand-icon-"]');
+      expect(el.style.fill).toEqual('var(--colour-css-variable)');
+    });
+  });
 
-    expect(el.getAttribute('data-colour')).toBeNull();
-    expect(el.style.fill).toEqual('');
+  describe('the outlines colour input', () => {
+    it('should apply the specific colour', () => {
+      when(brandIconRegistryMock.getBrandIcon('sun')).thenReturn(
+        '<svg id="test">test-svg<path id="Outlines"></path></svg>',
+      );
+
+      component.name = 'sun';
+      component.outlinesColour = 'rgb(102, 102, 102)';
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector(
+        '[data-colour="lg-icon-outlines-fill"]',
+      );
+
+      expect(el.style.fill).toEqual('rgb(102, 102, 102)');
+    });
   });
 
   describe('the size input', () => {

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.ts
@@ -43,6 +43,24 @@ export class LgBrandIconComponent {
     }
   }
 
+  @Input()
+  set halfToneColour(colour: string) {
+    const el = this.hostElement.nativeElement.querySelector(
+      '[data-colour="lg-icon-half-tone-fill"]',
+    );
+
+    this.setFillColour(el, colour);
+  }
+
+  @Input()
+  set outlinesColour(colour: string) {
+    const el = this.hostElement.nativeElement.querySelector(
+      '[data-colour="lg-icon-outlines-fill"]',
+    );
+
+    this.setFillColour(el, colour);
+  }
+
   _size: BrandIconSize = 'sm';
   @Input()
   set size(size: BrandIconSize) {
@@ -98,6 +116,8 @@ export class LgBrandIconComponent {
       svgData
         // Changes the lg-icon-fill-primary id to be a data attribute to avoid issues with duplicated ids.
         .replace(/id="lg-icon-fill-primary"/g, () => 'data-colour="lg-icon-fill-primary"')
+        .replace(/id="Half-tone"/g, () => 'data-colour="lg-icon-half-tone-fill"')
+        .replace(/id="Outlines"/g, () => 'data-colour="lg-icon-outlines-fill"')
         .replace(/id="([^"]+)"/g, () => `id="lg-brand-icon-${this.id}-${idCount++}"`)
         .replace(
           /xlink:href="#\w+"/g,
@@ -112,5 +132,15 @@ export class LgBrandIconComponent {
     div.innerHTML = svgContent;
 
     return div.querySelector('svg');
+  }
+
+  private setFillColour(el: HTMLElement, colour: string): void {
+    if (el) {
+      const isCssVar = colour?.startsWith('--');
+
+      el.style.fill = isCssVar
+        ? `var(${colour})`
+        : colour;
+    }
   }
 }

--- a/projects/canopy/src/lib/brand-icon/brand-icon.notes.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.notes.ts
@@ -38,6 +38,12 @@ Your HTML:
 
 <!-- with a colour set -->
 <lg-brand-icon name="sun" colour="--color-lily-green"></lg-brand-icon>
+
+<!-- with the half tone colour set -->
+<lg-brand-icon name="sun" halfToneColour="--color-lily-green"></lg-brand-icon>
+
+<!-- with the outlines colour set -->
+<lg-brand-icon name="sun" outlinesColour="--color-lily-green"></lg-brand-icon>
 ~~~
 
 ## Inputs
@@ -46,10 +52,15 @@ Your HTML:
 | \`\`name\`\` | the name of the icon | string | undefined | yes |
 | \`\`size\`\` | the size of the icon | BrandIconSize | 'sm' | no |
 | \`\`colour\`\` | the specific colour of the icon (for global colours see the "Branding" section below) | css variable as a string | undefined | no |
+| \`\`halfToneColour\`\` | the specific half tone (dots) colour of the icon | string * | undefined | no |
+| \`\`outlinesColour\`\` | the specific outlines colour of the icon | string * | undefined | no |
 
+\\* if using a css variable only specify \`--the-variable\`
 
 ## Branding / Colours
 The yellow fill colour of the brand icons can be changed globally  by overriding the \`--brand-icon-fill-primary\` css variable. Note that changing this variable will update the fill colour of all the icons.
 
 To change the colour of a specific icon use the \`colour\` input on the component.
+
+The half tone and outlines colours can only be applied to a specific icon using the inputs on the component.
 `;

--- a/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icons.stories.ts
@@ -16,6 +16,8 @@ import { lgBrandIconsArray } from './brand-icons.interface';
         [name]="icon.name"
         [size]="size"
         [colour]="i === 0 ? colour : null"
+        [halfToneColour]="i === 2 ? halfToneColour : null"
+        [outlinesColour]="i === 2 ? outlinesColour : null"
         [attr.style]="cssVar"
       ></lg-brand-icon>
       <span class="swatch__name">{{ icon.name }}</span>
@@ -49,6 +51,8 @@ import { lgBrandIconsArray } from './brand-icons.interface';
 class SwatchBrandIconComponent implements OnChanges {
   @Input() size: string;
   @Input() colour: string;
+  @Input() halfToneColour: string;
+  @Input() outlinesColour: string;
   @Input() globalColour: string;
 
   icons = lgBrandIconsArray;
@@ -124,13 +128,41 @@ export default {
     colour: {
       options: colours,
       description: 'The colour of a specific icon, using the `colour` input',
-      name: 'Example of applying colour specifically to an icon',
+      name: 'Example of applying colour specifically to an icon (first)',
       table: {
         type: {
           summary: colours,
         },
         defaultValue: {
           summary: '--color-super-blue',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+    },
+    halfToneColour: {
+      options: [ '#333', '--color-poppy-red-dark', 'rgb(0, 83, 128)' ],
+      description:
+        'The half tone (dots) colour of a specific icon, using the halfToneColour input',
+      name: 'Example of applying half tone colour specifically to an icon (third one)',
+      table: {
+        type: {
+          summary: 'string (if using a css variable only specify `--the-variable`)',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+    },
+    outlinesColour: {
+      options: [ '#333', '--color-super-blue-darkest', 'rgb(0, 83, 128)' ],
+      description:
+        'The colour of the outlines of a specific icon, using the `outlinesColour` input',
+      name: 'Example of applying outlines colour specifically to an icon (third one)',
+      table: {
+        type: {
+          summary: 'string (if using a css variable only specify `--the-variable`)',
         },
       },
       control: {
@@ -145,13 +177,15 @@ const exampleTemplate = `
   [name]="name"
   [size]="size"
   [colour]="colour"
+  [halfToneColour]="halfToneColour"
+  [outlinesColour]="outlinesColour"
 ></lg-brand-icon>
 `;
 
 const brandIconsTemplate: Story<LgBrandIconComponent> = (args: LgBrandIconComponent) => ({
   props: args,
   template:
-    '<lg-swatch-brand-icon [size]="size" [colour]="colour" [globalColour]="globalColour"></lg-swatch-brand-icon>',
+    '<lg-swatch-brand-icon [size]="size" [colour]="colour" [halfToneColour]="halfToneColour" [outlinesColour]="outlinesColour" [globalColour]="globalColour"></lg-swatch-brand-icon>',
 });
 
 export const standardBrandIcons = brandIconsTemplate.bind({});
@@ -160,6 +194,8 @@ standardBrandIcons.storyName = 'Brand Icon';
 standardBrandIcons.args = {
   size: 'sm',
   colour: '--color-super-blue',
+  halfToneColour: '--color-poppy-red-dark',
+  outlinesColour: '--color-super-blue-darkest',
 };
 
 standardBrandIcons.parameters = {


### PR DESCRIPTION
# Description

Add inputs for setting the outlines and half tone colours of the brand icons

## Requirements

The brand icons outlines and half tone colours should be configurable so that they can be used on different backgrounds.

Environment: https://legal-and-general.github.io/canopy/sb-fep-824-brand-icons/?path=/story/components-brand-icon--standard-brand-icons
Screenshot: 
![Screenshot 2022-09-06 at 11 12 58](https://user-images.githubusercontent.com/8397116/188609827-9a082ac5-11e2-4465-8de3-f6f2b1834415.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have provided documentation in the notes section of the story
- [ ] I have added any new public feature modules to public-api.ts
