### PR TITLE
feat(lg-row-gap): adds new directive and classes

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -61,6 +61,7 @@ module.exports = {
     '../projects/canopy/src/lib/skeleton/skeleton.stories.ts',
     '../projects/canopy/src/lib/spacing/margin/margin.stories.ts',
     '../projects/canopy/src/lib/spacing/padding/padding.stories.ts',
+    '../projects/canopy/src/lib/spacing/row-gap/row-gap.stories.ts',
     '../projects/canopy/src/lib/spinner/spinner.stories.ts',
     '../projects/canopy/src/lib/sr-alert-message/sr-alert-message.stories.ts',
     '../projects/canopy/src/lib/variant/variant.stories.ts',

--- a/projects/canopy/src/lib/spacing/index.ts
+++ b/projects/canopy/src/lib/spacing/index.ts
@@ -1,3 +1,4 @@
 export * from './margin/index';
 export * from './padding/index';
+export * from './row-gap/index';
 export * from './spacing.module';

--- a/projects/canopy/src/lib/spacing/row-gap/index.ts
+++ b/projects/canopy/src/lib/spacing/row-gap/index.ts
@@ -1,0 +1,3 @@
+export * from './row-gap.directive';
+export * from './row-gap.module';
+export * from '../spacing.interface';

--- a/projects/canopy/src/lib/spacing/row-gap/row-gap.directive.spec.ts
+++ b/projects/canopy/src/lib/spacing/row-gap/row-gap.directive.spec.ts
@@ -1,0 +1,68 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, DebugElement, Input, Renderer2 } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+import { SpacingVariant } from '../index';
+
+import { LgRowGapDirective } from './row-gap.directive';
+
+@Component({
+  template: `
+    <div id="test-0" lgRowGap>Test 0</div>
+    <div id="test-1" [lgRowGap]="rowGap">Test 1</div>
+  `,
+})
+class TestComponent {
+  @Input() rowGap: SpacingVariant;
+}
+
+describe('LgRowGapDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let testElements: Array<DebugElement>;
+  let component: TestComponent;
+  let renderer: Renderer2;
+  let rendererRemoveClassSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TestComponent, LgRowGapDirective ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+
+    renderer = fixture.componentRef.injector.get<Renderer2>(Renderer2);
+
+    rendererRemoveClassSpy = spyOn(renderer, 'removeClass').and.callThrough();
+
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+
+    testElements = fixture.debugElement.queryAll(By.css('div'));
+  });
+
+  it('should default to `sm` row-gap', () => {
+    expect(testElements[0].nativeElement.getAttribute('class')).toEqual('lg-row-gap--sm');
+  });
+
+  it('should add row-gap class for the given value and remove any previous row-gap class', () => {
+    const tests = [
+      { rowGap: 'xs', expectedPrevious: 'sm' },
+      { rowGap: 'xxxl', expectedPrevious: 'xs' },
+    ];
+
+    tests.forEach(t => {
+      component.rowGap = t.rowGap as SpacingVariant;
+      fixture.detectChanges();
+
+      const el = testElements[1].nativeElement;
+      const classPrefix = 'lg-row-gap--';
+
+      expect(rendererRemoveClassSpy).toHaveBeenCalledWith(
+        el,
+        `${classPrefix}${t.expectedPrevious}`,
+      );
+
+      expect(el.getAttribute('class')).toEqual(`${classPrefix}${t.rowGap}`);
+    });
+  });
+});

--- a/projects/canopy/src/lib/spacing/row-gap/row-gap.directive.ts
+++ b/projects/canopy/src/lib/spacing/row-gap/row-gap.directive.ts
@@ -1,0 +1,29 @@
+import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+
+import { SpacingVariant } from '../index';
+
+@Directive({
+  selector: '[lgRowGap]',
+})
+export class LgRowGapDirective {
+  private readonly classPrefix = 'lg-row-gap--';
+  private readonly defaultGap = 'sm';
+
+  lgRowGapClass = `${this.classPrefix}${this.defaultGap}`;
+
+  @Input()
+  set lgRowGap(gap: SpacingVariant) {
+    const newClass = `${this.classPrefix}${gap || this.defaultGap}`;
+
+    this.lgRowGapClass = this.toggleClass(newClass, this.lgRowGapClass);
+  }
+
+  constructor(private renderer: Renderer2, private hostElement: ElementRef) {}
+
+  private toggleClass(newClass: string, oldClass: string): string {
+    this.renderer.removeClass(this.hostElement.nativeElement, oldClass);
+    this.renderer.addClass(this.hostElement.nativeElement, newClass);
+
+    return newClass;
+  }
+}

--- a/projects/canopy/src/lib/spacing/row-gap/row-gap.module.ts
+++ b/projects/canopy/src/lib/spacing/row-gap/row-gap.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LgRowGapDirective } from './row-gap.directive';
+
+@NgModule({
+  declarations: [ LgRowGapDirective ],
+  imports: [ CommonModule ],
+  exports: [ LgRowGapDirective ],
+})
+export class LgRowGapModule {}

--- a/projects/canopy/src/lib/spacing/row-gap/row-gap.notes.ts
+++ b/projects/canopy/src/lib/spacing/row-gap/row-gap.notes.ts
@@ -1,0 +1,41 @@
+export const notes = `
+This directive allows you to add the \`row-gap\` CSS property using Canopy spacing.
+The spacing variables are also available as CSS custom properties (CSS variables)
+which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.
+
+This directive and accompanying CSS classes, work great with our
+<a href="./?path=/docs/directives-grid--grid">Canopy Grid</a> but will
+also work with all other HTML elements that support
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap" target="_blank" rel='noopener noreferrer'>CSS row-gap</a>.
+
+~~~js
+@NgModule({
+  ...
+  imports: [ ..., LgRowGapModule ],
+})
+~~~
+
+### Examples
+
+Apply \`\`xxl\`\` row-gap.
+
+~~~html
+
+<div lgRowGap="xxl"></div>
+
+~~~
+
+Use the default (\`\`sm\`\`) row-gap.
+
+~~~html
+
+<div lgRowGap></div>
+
+~~~
+
+## Inputs
+
+The current available spacing variants are \`\`none\`\`, \`\`xxxs\`\`, \`\`xxs\`\`, \`\`xs\`\`, \`\`sm\`\`, \`\`md\`\`, \`\`lg\`\`, \`\`xl\`\`, \`\`xxl\`\`, \`\`xxxl\`\`, \`\`xxxxxl\`\`.
+
+If no value is provided, the default is \`\`sm\`\`.
+`;

--- a/projects/canopy/src/lib/spacing/row-gap/row-gap.stories.ts
+++ b/projects/canopy/src/lib/spacing/row-gap/row-gap.stories.ts
@@ -1,0 +1,133 @@
+import { Component, Input } from '@angular/core';
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+
+import { SpacingVariant } from '../spacing.interface';
+import { LgCardModule } from '../../card';
+import { LgSpacingModule } from '../spacing.module';
+import { LgGridModule } from '../../grid';
+
+import { notes } from './row-gap.notes';
+import { LgRowGapModule } from './row-gap.module';
+import { LgRowGapDirective } from './row-gap.directive';
+
+const spaces = [
+  'undefined',
+  'none',
+  'xxxs',
+  'xxs',
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'xxl',
+  'xxxl',
+  'xxxxl',
+];
+
+@Component({
+  selector: 'lg-row-gap-story',
+  template: `
+    <div lgContainer>
+      <div lgRow [lgRowGap]="rowGap">
+        <div lgColLg="4" lgCol="12">
+          <lg-card lgMarginBottom="none">
+            <lg-card-content>
+              <p><strong>The row-gap directive</strong></p>
+              <p>Resize the viewport to see it in action</p>
+              <p>
+                <code>row-gap: {{ rowGap | json }}</code>
+              </p>
+            </lg-card-content>
+          </lg-card>
+        </div>
+        <div lgColLg="4" lgCol="12">
+          <lg-card lgMarginBottom="none">
+            <lg-card-content>
+              <p><strong>The row-gap directive</strong></p>
+              <p>Resize the viewport to see it in action</p>
+              <p>
+                <code>row-gap: {{ rowGap | json }}</code>
+              </p>
+            </lg-card-content>
+          </lg-card>
+        </div>
+        <div lgColLg="4" lgCol="12">
+          <lg-card lgMarginBottom="none">
+            <lg-card-content>
+              <p><strong>The row-gap directive</strong></p>
+              <p>Resize the viewport to see it in action</p>
+              <p>
+                <code>row-gap: {{ rowGap | json }}</code>
+              </p>
+            </lg-card-content>
+          </lg-card>
+        </div>
+      </div>
+    </div>
+  `,
+})
+class LgRowGapStoryComponent {
+  @Input() rowGap: SpacingVariant;
+}
+
+export default {
+  title: 'Directives/Row Gap',
+  decorators: [
+    moduleMetadata({
+      declarations: [ LgRowGapStoryComponent ],
+      imports: [ LgRowGapModule, LgCardModule, LgSpacingModule, LgGridModule ],
+    }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: notes,
+      },
+    },
+    a11y: {
+      disable: true,
+    },
+    backgrounds: {
+      default: 'Super Blue',
+    },
+  },
+  argTypes: {
+    rowGap: {
+      control: {
+        type: 'select',
+      },
+      description: 'The row-gap to apply to the element.',
+      options: spaces,
+      table: {
+        type: {
+          summary: spaces,
+        },
+      },
+    },
+  },
+} as Meta;
+
+const template = `
+<lg-row-gap-story [rowGap]="rowGap"></lg-row-gap-story>
+`;
+
+const rowGapStory: Story<LgRowGapDirective> = (args: LgRowGapDirective) => ({
+  props: args,
+  template,
+});
+
+export const rowGap = rowGapStory.bind({});
+rowGap.storyName = 'Row Gap';
+
+rowGap.args = {
+  rowGap: 'sm',
+};
+
+rowGap.parameters = {
+  docs: {
+    source: {
+      code: null,
+    },
+  },
+};

--- a/projects/canopy/src/lib/spacing/spacing.module.ts
+++ b/projects/canopy/src/lib/spacing/spacing.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { LgMarginModule } from './margin/margin.module';
-import { LgPaddingModule } from './padding/padding.module';
+import { LgMarginModule } from './margin';
+import { LgPaddingModule } from './padding';
+import { LgRowGapModule } from './row-gap';
 
 @NgModule({
-  imports: [ CommonModule, LgMarginModule, LgPaddingModule ],
-  exports: [ LgMarginModule, LgPaddingModule ],
+  imports: [ CommonModule, LgMarginModule, LgPaddingModule, LgRowGapModule ],
+  exports: [ LgMarginModule, LgPaddingModule, LgRowGapModule ],
 })
 export class LgSpacingModule {}

--- a/projects/canopy/src/styles/grid.notes.ts
+++ b/projects/canopy/src/styles/grid.notes.ts
@@ -23,9 +23,11 @@ Import the css into the angular.json file of your application, the grid classes 
 If IE11 support is required you will need to polyfill CSS variable functionality.
 This can be done via [css-vars-ponyfill](https://www.npmjs.com/package/css-vars-ponyfill) or similar.
 
-A set of [Angular directives](/?path=/story/directives--grid) are also supplied which can be used to add grid classes to native HTML and Canopy elements.
+## Additional Directives
 
-There are also two utility directives available which allow you to show/hide components at different breakpoints:
-- <a href="./?path=/docs/directives-show-at--show-at-story">LgShowAt</a>
-- <a href="./?path=/docs/directives-hide-at--hide-at-story">LgHideAt</a>
+- A set of [Angular directives](./?path=/story/directives--grid) are also supplied which can be used to add grid classes to native HTML and Canopy elements.
+- There is also a [row-gap spacing directive](./?path=/story/directives-row-gap--row-gap) to enable the use of the CSS row-gap property.
+- There are also two utility directives available which allow you to show/hide components at different breakpoints:
+    - <a href="./?path=/docs/directives-show-at--show-at-story">LgShowAt</a>
+    - <a href="./?path=/docs/directives-hide-at--hide-at-story">LgHideAt</a>
 `;

--- a/projects/canopy/src/styles/grid.stories.ts
+++ b/projects/canopy/src/styles/grid.stories.ts
@@ -11,6 +11,10 @@ const styles = [
       height: var(--space-lg);
     }
 
+    .margin-bottom--none {
+      margin-bottom: 0;
+    }
+
     .nested .box {
       background-color: var(--color-super-blue-lightest);
       height: auto;
@@ -203,6 +207,30 @@ const template = `
         </div>
         <div class="lg-col-xs">
           <div class="box"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="lg-container">
+      <div class="lg-row">
+        <div class="lg-col-xs-12">
+          <h2>Row Gap</h2>
+          <p>
+            Add a row-gap to the flex elements using the row-gap
+            <a href="./?path=/docs/style-spacing--page">Canopy classes</a>
+            or <a href="./?path=/story/directives-row-gap--row-gap--row-gap">Canopy directive</a>.
+            </p>
+        </div>
+      </div>
+      <div class="lg-row lg-row-gap--sm">
+        <div class="lg-col-lg-4 lg-col-xs-12">
+          <div class="box margin-bottom--none"></div>
+        </div>
+        <div class="lg-col-lg-4 lg-col-xs-12">
+          <div class="box margin-bottom--none"></div>
+        </div>
+        <div class="lg-col-lg-4 lg-col-xs-12">
+          <div class="box margin-bottom--none"></div>
         </div>
       </div>
     </div>

--- a/projects/canopy/src/styles/spacing.scss
+++ b/projects/canopy/src/styles/spacing.scss
@@ -48,7 +48,7 @@ $spacing-list: (
   }
 }
 
-// Default margin / padding
+// Default margin / padding / row-gap
 @each $val in $spacing-list {
   .lg-margin--#{$val} {
     margin: space($val) !important;
@@ -56,6 +56,10 @@ $spacing-list: (
 
   .lg-padding--#{$val} {
     padding: space($val) !important;
+  }
+
+  .lg-row-gap--#{$val} {
+    row-gap: space($val) !important;
   }
 }
 


### PR DESCRIPTION
* enables consumers to use the `row-gap` CSS property using Canopy and it's spacing.
* accepts either a value or will default to `sm` row-gap.
* fixes a broken link in the storybook grid style docs.

Follows on from the discussion #1046.

**This draft PR is for master but I am open to it going into [@next](https://github.com/Legal-and-General/canopy/tree/next) if required.**

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [x] I have added any new public feature modules to public-api.ts