### PR TITLE
Add blockquote styles and docs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -74,6 +74,8 @@ module.exports = {
     '../projects/canopy/src/styles/mixins.stories.mdx',
     '../projects/canopy/src/styles/spacing.stories.mdx',
     '../projects/canopy/src/styles/utils.stories.mdx',
+    '../projects/canopy/src/styles/blockquote.stories.mdx',
+    '../projects/canopy/src/styles/blockquote.stories.ts',
   ],
   addons: [
     '@storybook/addon-a11y',

--- a/projects/canopy/src/styles/blockquote.scss
+++ b/projects/canopy/src/styles/blockquote.scss
@@ -1,0 +1,14 @@
+@import 'mixins';
+
+blockquote {
+  border-left: var(--border-radius-lg) solid var(--blockquote-border-left-colour);
+  padding-left: var(--space-sm);
+  @include lg-font-size('2');
+
+  cite {
+    display: block;
+    margin-top: var(--space-sm);
+    font-style: normal;
+    @include lg-font-size('1', 'strong');
+  }
+}

--- a/projects/canopy/src/styles/blockquote.stories.mdx
+++ b/projects/canopy/src/styles/blockquote.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta, Story } from '@storybook/addon-docs';
+
+<Meta title="Components/Block quote/Guide" parameters={{ viewMode: 'docs', previewTabs: { canvas: { hidden: true } } }} />
+
+# Block quote
+
+<p class="standfirst">A quote allows to repeat words that someone else has said or written.</p>
+
+<Story id="components-block-quote-examples--quote"></Story>
+
+## Usage
+
+The [blockquote](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote) and [cite](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite) styles are part of the Canopy global stylesheet, therefore using the HTML below should be enough:
+
+```html
+<blockquote>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  <cite>The author</cite>
+</blockquote>
+```
+
+In addition to that, the side line's colour can be changed by overriding the `--blockquote-border-left-colour` css variable.
+
+## Research on this pattern
+
+This is based on best practice.
+
+## Help improve this page
+
+To help make sure this page is useful, relevant and up to date, you can <a href="https://forms.office.com/r/6UMyXFeupH" target="_blank">suggest an improvement</a>.
+
+Please take a moment to <a href="https://forms.office.com/r/ryiKP7ygUK" target="_blank">rate your experience of using Canopy</a>.

--- a/projects/canopy/src/styles/blockquote.stories.ts
+++ b/projects/canopy/src/styles/blockquote.stories.ts
@@ -1,0 +1,38 @@
+import { Meta, Story } from '@storybook/angular';
+
+const template = `
+<blockquote>
+  {{ content }}
+  <cite *ngIf="author">{{ author }}</cite>
+</blockquote>
+`;
+
+export default {
+  title: 'Components/Block quote/Examples',
+  parameters: {
+    viewMode: 'story',
+    previewTabs: { 'storybook/docs/panel': { hidden: true } },
+  },
+} as Meta;
+
+const quoteTemplate: Story = (args) => ({
+  props: args,
+  template,
+});
+
+export const quote = quoteTemplate.bind({});
+quote.storyName = 'Block quote';
+
+quote.args = {
+  content:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  author: 'Cicero',
+};
+
+quote.parameters = {
+  docs: {
+    source: {
+      code: template,
+    },
+  },
+};

--- a/projects/canopy/src/styles/styles-classes.scss
+++ b/projects/canopy/src/styles/styles-classes.scss
@@ -9,5 +9,6 @@
 @import './typography-fonts';
 @import './typography-classes';
 @import './shadow';
+@import './blockquote';
 @import './utils';
 @import './variants';

--- a/projects/canopy/src/styles/variables/_main.scss
+++ b/projects/canopy/src/styles/variables/_main.scss
@@ -58,4 +58,7 @@
 
   /* Separator */
   --separator-color: var(--color-platinum);
+
+  /* Block quote */
+  --blockquote-border-left-colour: var(--color-super-blue);
 }


### PR DESCRIPTION
# Description

Add blockquote and cite global styles and documentation (the documentation will be enhances later on).

Screenshot: 
<img width="901" alt="Screenshot 2022-10-25 at 13 10 08" src="https://user-images.githubusercontent.com/8397116/197769517-3d95b7f2-7a6d-4fb6-b1f0-002f37ec67f7.png">

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
