### PR TITLE
fix(colours): fix incorrect colour values in Storybook colour page

### DIFF
--- a/projects/canopy/src/styles/variables/_colors.scss
+++ b/projects/canopy/src/styles/variables/_colors.scss
@@ -1,9 +1,9 @@
 :root {
-  --color-lavender: #c9e8fb;
-  --color-sky-blue: #71cbf4;
+  --color-lavender: #d3e5f7;
+  --color-sky-blue: #74c9e3;
   --color-midnight-blue: #005380;
 
-  --color-tea-green: #d9e6b1;
+  --color-tea-green: #e9efd7;
   --color-lily-green: #bbd143;
   --color-mexican-green: #005629;
 
@@ -38,7 +38,7 @@
   --color-poppy-red-dark: #b50005;
   --color-poppy-red-darkest: #671210;
 
-  --color-dandelion-yellow-lightest: #fdf8cd;
+  --color-dandelion-yellow-lightest: #fdf8c6;
   --color-dandelion-yellow-light: #ffef67;
   --color-dandelion-yellow: #ffd500;
   --color-dandelion-yellow-rgb: 255, 213, 0;
@@ -46,7 +46,7 @@
   --color-black: #000;
   --color-charcoal: #333;
   --color-charcoal-rgb: 51, 51, 51;
-  --color-battleship-grey: #575756;
+  --color-battleship-grey: #575757;
   --color-taupe-grey: #929292;
   --color-serenity: #faf7f5;
   --color-platinum: #e3e3e3;


### PR DESCRIPTION
# Description

Change the colour values in Storybook Colours page to use the expected hex values. 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
