### PR TITLE
fix(directives): fix accessibility issues

### DIFF
--- a/projects/canopy/src/lib/forms/input/docs/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/docs/input.stories.ts
@@ -18,7 +18,8 @@ interface Config {
   block?: boolean;
   buttonText?: boolean;
   disabled?: boolean;
-  hint?: string | null;
+  hint?: boolean;
+  hintText?: string;
   icon?: string;
   iconButton?: boolean;
   label?: string;
@@ -29,6 +30,7 @@ interface Config {
   showTextSuffix?: boolean;
   size?: number;
   suffix?: string;
+  ariaDescribeInput?: boolean;
 }
 
 function createInputStory(args: LgInputModule) {
@@ -43,6 +45,7 @@ function createInputStory(args: LgInputModule) {
         [buttonVariant]="buttonVariant"
         [disabled]="disabled"
         [hint]="hint"
+        [hintText]="hintText"
         [icon]="icon"
         [iconButton]="iconButton"
         [label]="label"
@@ -54,6 +57,7 @@ function createInputStory(args: LgInputModule) {
         [showButtonSecondSuffix]="showButtonSecondSuffix"
         [showTextPrefix]="showTextPrefix"
         [showTextSuffix]="showTextSuffix"
+        [ariaDescribeInput]="ariaDescribeInput"
       ></lg-reactive-form>
     `,
   };
@@ -65,9 +69,8 @@ function setupInputStoryValues(obj, code, config?: Config) {
     buttonText: 'search',
     buttonVariant: 'primary-dark',
     disabled: false,
-    hint: config?.hint === null
-      ? ''
-      : 'Please enter your name',
+    hint: config?.hint,
+    hintText: config?.hintText || 'Please enter your name',
     icon: 'search',
     label: config?.label || 'Name',
     showLabel: true,
@@ -79,6 +82,7 @@ function setupInputStoryValues(obj, code, config?: Config) {
     showTextSuffix: config?.showTextSuffix,
     suffix: '%',
     size: 12,
+    ariaDescribeInput: config?.ariaDescribeInput,
   };
 
   obj.parameters = {
@@ -93,8 +97,8 @@ function setupInputStoryValues(obj, code, config?: Config) {
 const inputTemplate = `
 <lg-input-field [block]="block" [showLabel]="showLabel">
   {{ label }}
-  <lg-hint *ngIf="hint">{{ hint }}</lg-hint>
-  <span lgPrefix *ngIf="showTextPrefix">{{ prefix }}</span>
+  <lg-hint *ngIf="hint">{{ hintText }}</lg-hint>
+  <span lgPrefix *ngIf="showTextPrefix" [ariaDescribeInput]="ariaDescribeInput">{{ prefix }}</span>
   <input lgInput formControlName="name" [size]="size" />
   <button
     lg-button
@@ -118,7 +122,7 @@ const inputTemplate = `
     {{ buttonText }}
     <lg-icon [name]="icon" *ngIf="iconButton"></lg-icon>
   </button>
-  <span lgSuffix *ngIf="showTextSuffix">{{ suffix }}</span>
+  <span lgSuffix *ngIf="showTextSuffix" [ariaDescribeInput]="ariaDescribeInput">{{ suffix }}</span>
 </lg-input-field>
 `;
 
@@ -144,7 +148,8 @@ class ReactiveFormComponent {
   @Input() block: boolean;
   @Input() buttonText: ButtonVariant;
   @Input() buttonVariant: ButtonVariant;
-  @Input() hint: string;
+  @Input() hint: boolean;
+  @Input() hintText: string;
   @Input() icon: string;
   @Input() iconButton: boolean;
   @Input() label: string;
@@ -156,6 +161,7 @@ class ReactiveFormComponent {
   @Input() showTextSuffix: boolean;
   @Input() size: number;
   @Input() suffix: string;
+  @Input() ariaDescribeInput: boolean;
 
   @Output() inputChange: EventEmitter<void> = new EventEmitter();
   @Output() formSubmit: EventEmitter<void> = new EventEmitter();
@@ -317,6 +323,13 @@ export default {
         disable: true,
       },
     },
+    ariaDescribeInput: {
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
   },
 };
 
@@ -331,6 +344,8 @@ withButtonSuffix.storyName = 'With button suffix';
 
 setupInputStoryValues(withButtonSuffix, inputTemplate, {
   showButtonFirstSuffix: true,
+  hint: true,
+  ariaDescribeInput: true,
 });
 
 export const withTextSuffix = inputStory.bind({});
@@ -339,7 +354,7 @@ withTextSuffix.storyName = 'With text suffix';
 setupInputStoryValues(withTextSuffix, inputTemplate, {
   showTextSuffix: true,
   label: 'Amount',
-  hint: null,
+  hint: false,
 });
 
 export const withMultipleButtonSuffixes = inputStory.bind({});
@@ -348,4 +363,26 @@ withMultipleButtonSuffixes.storyName = 'With multiple buttons suffixes';
 setupInputStoryValues(withMultipleButtonSuffixes, inputTemplate, {
   showButtonFirstSuffix: true,
   showButtonSecondSuffix: true,
+  hint: true,
+  ariaDescribeInput: true,
+});
+
+export const withHintAndTextSuffix = inputStory.bind({});
+withHintAndTextSuffix.storyName = 'With hint and text suffix';
+
+setupInputStoryValues(withHintAndTextSuffix, inputTemplate, {
+  showTextSuffix: true,
+  label: 'Amount percentage',
+  hint: true,
+  hintText: 'Please enter a value between 1% and 20%',
+});
+
+export const withTextPrefix = inputStory.bind({});
+withTextPrefix.storyName = 'With text prefix';
+
+setupInputStoryValues(withTextPrefix, inputTemplate, {
+  showTextPrefix: true,
+  label: 'Amount in pounds',
+  hint: true,
+  hintText: 'Please enter a value between 2000 and 10000',
 });

--- a/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
@@ -75,6 +75,7 @@ describe('LgInputFieldComponent', () => {
     hasPrefix = false,
     hasSuffix = false,
     showLabel = true,
+    ariaDescribeInput = true,
   }) {
     fixture = MockRender(`
       <lg-input-field [block]="${block}" [showLabel]="${showLabel}">
@@ -82,8 +83,14 @@ describe('LgInputFieldComponent', () => {
         <input lgInput />
         <lg-hint id="${hintId}">Hint</lg-hint>
         <lg-validation id="${errorId}">Error</lg-validation>
-        ${hasPrefix && `<span lgPrefix id="${prefixId}">${prefixText}</span>`}
-        ${hasSuffix && `<span lgSuffix id="${suffixId}">${suffixText}</span>`}
+        ${
+  hasPrefix &&
+          `<span lgPrefix id="${prefixId}" [ariaDescribeInput]="${ariaDescribeInput}">${prefixText}</span>`
+}
+        ${
+  hasSuffix &&
+          `<span lgSuffix id="${suffixId}" [ariaDescribeInput]="${ariaDescribeInput}">${suffixText}</span>`
+}
       </lg-input-field>
     `);
 
@@ -279,6 +286,12 @@ describe('LgInputFieldComponent', () => {
     it('links the hint to the input field with the correct aria attributes', () => {
       expect(inputDirectiveInstance.ariaDescribedBy).toContain(suffixId);
     });
+
+    it('should not link the suffix to the input field', () => {
+      renderComponent({ hasSuffix: true, ariaDescribeInput: false });
+
+      expect(inputDirectiveInstance.ariaDescribedBy).not.toContain(suffixId);
+    });
   });
 
   describe('prefixes', () => {
@@ -292,6 +305,12 @@ describe('LgInputFieldComponent', () => {
 
     it('links the hint to the input field with the correct aria attributes', () => {
       expect(inputDirectiveInstance.ariaDescribedBy).toContain(prefixId);
+    });
+
+    it('should not link the prefix to the input field', () => {
+      renderComponent({ hasPrefix: true, ariaDescribeInput: false });
+
+      expect(inputDirectiveInstance.ariaDescribedBy).not.toContain(prefixId);
     });
   });
 });

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -128,11 +128,13 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
   @ContentChildren(LgSuffixDirective)
   set suffixChildren(elements: QueryList<LgSuffixDirective>) {
     elements.forEach(element => {
-      this.inputElement.ariaDescribedBy = this.domService.toggleIdInStringProperty(
-        this.inputElement.ariaDescribedBy,
-        this._validationElement,
-        element,
-      );
+      if (element.ariaDescribeInput) {
+        this.inputElement.ariaDescribedBy = this.domService.toggleIdInStringProperty(
+          this.inputElement.ariaDescribedBy,
+          this._validationElement,
+          element,
+        );
+      }
     });
 
     this._suffixChildren = elements;
@@ -144,11 +146,13 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
   @ContentChildren(LgPrefixDirective)
   set prefixChildren(elements: QueryList<LgSuffixDirective>) {
     elements.forEach(element => {
-      this.inputElement.ariaDescribedBy = this.domService.toggleIdInStringProperty(
-        this.inputElement.ariaDescribedBy,
-        this._validationElement,
-        element,
-      );
+      if (element.ariaDescribeInput) {
+        this.inputElement.ariaDescribedBy = this.domService.toggleIdInStringProperty(
+          this.inputElement.ariaDescribedBy,
+          this._validationElement,
+          element,
+        );
+      }
     });
 
     this._prefixChildren = elements;

--- a/projects/canopy/src/lib/prefix/prefix.directive.ts
+++ b/projects/canopy/src/lib/prefix/prefix.directive.ts
@@ -9,4 +9,7 @@ export class LgPrefixDirective {
   @Input()
   @HostBinding('attr.id')
   id = `lg-prefix-${nextUniqueId++}`;
+
+  @Input()
+  ariaDescribeInput = false;
 }

--- a/projects/canopy/src/lib/suffix/suffix.directive.ts
+++ b/projects/canopy/src/lib/suffix/suffix.directive.ts
@@ -9,4 +9,12 @@ export class LgSuffixDirective {
   @Input()
   @HostBinding('attr.id')
   id = `lg-suffix-${nextUniqueId++}`;
+
+  /**
+   * - the suffix can be targeted or not by the input's aria-describedBy attribute
+   * - it is useful for cases where the suffix is applied upon focusable elements
+   * - and it should be `false` for cases where the suffix is only text to be trully accessible
+   */
+  @Input()
+  ariaDescribeInput = false;
 }


### PR DESCRIPTION
# Description

In some cases the suffix/prefix directives should not be linked to the input. 

For example when the input contains a hint and a suffix, Voice Over reads the description of the input in a weird way.

The issue revolved around **aria-describedBy**, in the code the suffix/prefix was directly linked to the input, in this case **aria-hidden** wasn't doing anything.

More details can be found in the linked issue.

Fixes [Input with text suffix: VoiceOver reads suffix even though aria-hidden is present](https://github.com/Legal-and-General/canopy/issues/1069#top)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
