### PR TITLE
fix: link-menu-item so a11y text is set based on parent anchor target

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -773,6 +773,57 @@
               </lg-card>
             </div>
           </div>
+          <div lgRow>
+            <div lgCol="12" lgColLg="8" lgColLgOffset="2" lgColMd="10" lgColMdOffset="1">
+              <lg-card>
+                <lg-card-header>
+                  Link Menu
+                </lg-card-header>
+                <lg-card-content>
+                  <lg-link-menu>
+                    <a href="#">
+                      <lg-link-menu-item>
+                        <lg-link-menu-item-heading>An internal link (default)</lg-link-menu-item-heading>
+                        <lg-link-menu-item-content>
+                          This links to an internal page
+                        </lg-link-menu-item-content>
+                      </lg-link-menu-item>
+                    </a>
+                    <a href="#" target="_blank">
+                      <lg-link-menu-item>
+                        <lg-link-menu-item-heading>An internal link (default)</lg-link-menu-item-heading>
+                        <lg-link-menu-item-content>
+                          This links to an internal page but opens in a <em>new</em> tab
+                        </lg-link-menu-item-content>
+                      </lg-link-menu-item>
+                    </a>
+                    <a href="#" >
+                      <lg-link-menu-item [internal]="false">
+                        <lg-link-menu-item-heading>An external link</lg-link-menu-item-heading>
+                        <lg-link-menu-item-content>
+                          This links to an external page opening in the same tab
+                        </lg-link-menu-item-content>
+                      </lg-link-menu-item>
+                    </a>
+                    <a href="#" target="_blank">
+                      <lg-link-menu-item [internal]="false">
+                        <lg-link-menu-item-heading>An external link</lg-link-menu-item-heading>
+                        <lg-link-menu-item-content>
+                          This links to an external page opening in a <em>new</em> tab
+                        </lg-link-menu-item-content>
+                      </lg-link-menu-item>
+                    </a>
+                    <lg-link-menu-item [internal]="false">
+                      <lg-link-menu-item-heading>An external link</lg-link-menu-item-heading>
+                      <lg-link-menu-item-content>
+                        This links to an external page opening in a <em>new</em> tab
+                      </lg-link-menu-item-content>
+                    </lg-link-menu-item>
+                  </lg-link-menu>
+                </lg-card-content>
+              </lg-card>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -791,34 +791,12 @@
                     </a>
                     <a href="#" target="_blank">
                       <lg-link-menu-item>
-                        <lg-link-menu-item-heading>An internal link (default)</lg-link-menu-item-heading>
-                        <lg-link-menu-item-content>
-                          This links to an internal page but opens in a <em>new</em> tab
-                        </lg-link-menu-item-content>
-                      </lg-link-menu-item>
-                    </a>
-                    <a href="#" >
-                      <lg-link-menu-item [internal]="false">
-                        <lg-link-menu-item-heading>An external link</lg-link-menu-item-heading>
-                        <lg-link-menu-item-content>
-                          This links to an external page opening in the same tab
-                        </lg-link-menu-item-content>
-                      </lg-link-menu-item>
-                    </a>
-                    <a href="#" target="_blank">
-                      <lg-link-menu-item [internal]="false">
                         <lg-link-menu-item-heading>An external link</lg-link-menu-item-heading>
                         <lg-link-menu-item-content>
                           This links to an external page opening in a <em>new</em> tab
                         </lg-link-menu-item-content>
                       </lg-link-menu-item>
                     </a>
-                    <lg-link-menu-item [internal]="false">
-                      <lg-link-menu-item-heading>An external link</lg-link-menu-item-heading>
-                      <lg-link-menu-item-content>
-                        This links to an external page opening in a <em>new</em> tab
-                      </lg-link-menu-item-content>
-                    </lg-link-menu-item>
                   </lg-link-menu>
                 </lg-card-content>
               </lg-card>

--- a/projects/canopy-test-app/src/app/app.module.ts
+++ b/projects/canopy-test-app/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {
   lgIconSearch,
   lgIconSecureMessaging,
   LgInputModule,
+  LgLinkMenuModule,
   LgMarginModule,
   LgPaddingModule,
   LgPageModule,
@@ -92,6 +93,7 @@ import { StoryContentComponent } from './story-content.component';
     LgSpinnerModule,
     LgTabsModule,
     LgToggleModule,
+    LgLinkMenuModule,
   ],
   bootstrap: [ AppComponent ],
 })

--- a/projects/canopy/src/lib/link-menu/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/link-menu/docs/guide.stories.mdx
@@ -31,11 +31,8 @@ This is where the links are projected.
 ### LgLinkMenuItemComponent
 This is where the `LgLinkMenuItemHeadingComponent` and `LgLinkMenuItemContentComponent` of the link are projected and positioned.
 
-#### Inputs
-
-| Name       | Description                              |   Type    | Default | Required |
-|------------|------------------------------------------|:---------:|:-------:|:--------:|
-| `internal` | Whether the link is internal or external | `boolean` | `true`  |    No    |
+Depending on whether the parent, `<a>` element has `target="_blank"`, i.e. attempts to open in a new tab, the icon displayed will
+differ.
 
 ### LgLinkMenuItemHeadingComponent
 This is the main label of the link.

--- a/projects/canopy/src/lib/link-menu/docs/link-menu.stories.ts
+++ b/projects/canopy/src/lib/link-menu/docs/link-menu.stories.ts
@@ -6,7 +6,7 @@ import { LgLinkMenuComponent } from '../link-menu.component';
 
 const template = `
 <lg-link-menu>
-  <a href="#" *ngFor="let item of menuItems">
+  <a href="#" *ngFor="let item of menuItems" [attr.target]="item.target">
     <lg-link-menu-item>
       <lg-link-menu-item-heading>{{ item.title }}</lg-link-menu-item-heading>
       <lg-link-menu-item-content *ngIf="item.description">
@@ -46,6 +46,7 @@ const linkMenuTemplate: Story<LgLinkMenuComponent> = (args: LgLinkMenuComponent)
 interface MenuItems {
   title: string;
   description: string;
+  target: '_blank' | null;
 }
 
 function getDefaultMenuItems(): Array<MenuItems> {
@@ -53,14 +54,17 @@ function getDefaultMenuItems(): Array<MenuItems> {
     {
       title: 'Change your bank details',
       description: 'Changes may take up to an hour',
+      target: null,
     },
     {
       title: 'Plan for retirement',
       description: '',
+      target: null,
     },
     {
       title: 'Life Insurance',
       description: 'Learn more',
+      target: '_blank',
     },
   ];
 }

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.html
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.html
@@ -3,6 +3,6 @@
   <ng-content select="lg-link-menu-item-content"></ng-content>
 </div>
 <div class="lg-link-menu-item__icon-container">
-  <lg-icon [name]="internal ? 'chevron-right' : 'link-external'" class="lg-font-size-0-8"></lg-icon>
+  <lg-icon [name]="!openInANewTab ? 'chevron-right' : 'link-external'" class="lg-font-size-0-8"></lg-icon>
   <span *ngIf="openInANewTab" class="lg-visually-hidden"> opens in a new tab</span>
 </div>

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.html
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.html
@@ -4,5 +4,5 @@
 </div>
 <div class="lg-link-menu-item__icon-container">
   <lg-icon [name]="internal ? 'chevron-right' : 'link-external'" class="lg-font-size-0-8"></lg-icon>
-  <span *ngIf="internal" class="lg-visually-hidden"> opens in a new tab</span>
+  <span *ngIf="openInANewTab" class="lg-visually-hidden"> opens in a new tab</span>
 </div>

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.spec.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.spec.ts
@@ -10,13 +10,12 @@ import { LgLinkMenuItemContentComponent } from '../link-menu-item-content/link-m
 import { LgLinkMenuItemComponent } from './link-menu-item.component';
 
 @Component({
-  template: ` <lg-link-menu-item [internal]="internal">
+  template: `<lg-link-menu-item>
     <lg-link-menu-item-heading>Update my direct debit</lg-link-menu-item-heading>
     <lg-link-menu-item-content>Do it online</lg-link-menu-item-content>
   </lg-link-menu-item>`,
 })
 class TestComponent {
-  @Input() internal = true;
   @Input() target: string = undefined;
 }
 
@@ -42,7 +41,6 @@ describe('LgLinkMenuItemComponent', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(TestComponent);
       component = fixture.componentInstance;
-      component.internal = true;
       fixture.detectChanges();
     });
 
@@ -64,19 +62,6 @@ describe('LgLinkMenuItemComponent', () => {
       ).toBeTruthy();
     });
 
-    it('should render the internal icon', () => {
-      expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeDefined();
-      expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
-    });
-
-    it('should render the external icon when the internal input is set to false', () => {
-      component.internal = false;
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeDefined();
-      expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeNull();
-    });
-
     it('should render the heading', () => {
       expect(
         fixture.debugElement.query(By.directive(LgLinkMenuItemHeadingComponent)),
@@ -87,6 +72,11 @@ describe('LgLinkMenuItemComponent', () => {
       expect(
         fixture.debugElement.query(By.directive(LgLinkMenuItemContentComponent)),
       ).toBeTruthy();
+    });
+
+    it('should render the "chevron-right" icon if the parent is not an anchor element', () => {
+      expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
     });
 
     it('should log a warning if the parent is not an anchor element', () => {
@@ -103,10 +93,9 @@ describe('LgLinkMenuItemComponent', () => {
   });
 
   describe('integration', () => {
-    describe('opens in a new tab text', () => {
-      const createComponentWithTarget = (target: string) => {
-        const template = `
-        <a href="#" [target]="target">
+    const createComponentWithTarget = (target: string) => {
+      const template = `
+        <a href="#" [attr.target]="target">
           <lg-link-menu-item>
             <lg-link-menu-item-heading>Update my direct debit</lg-link-menu-item-heading>
             <lg-link-menu-item-content>Do it online</lg-link-menu-item-content>
@@ -114,16 +103,17 @@ describe('LgLinkMenuItemComponent', () => {
         </a>
       `;
 
-        fixture = TestBed.overrideTemplate(TestComponent, template).createComponent(
-          TestComponent,
-        );
+      fixture = TestBed.overrideTemplate(TestComponent, template).createComponent(
+        TestComponent,
+      );
 
-        component = fixture.componentInstance;
-        component.target = target;
+      component = fixture.componentInstance;
+      component.target = target;
 
-        fixture.detectChanges();
-      };
+      fixture.detectChanges();
+    };
 
+    describe('opens in a new tab text', () => {
       const getTextOfElementUnderTest = () =>
         fixture.debugElement.query(By.css('.lg-link-menu-item__icon-container'))
           .nativeElement.textContent;
@@ -138,6 +128,28 @@ describe('LgLinkMenuItemComponent', () => {
         createComponentWithTarget('_blank');
 
         expect(getTextOfElementUnderTest()).toEqual(' opens in a new tab');
+      });
+    });
+
+    describe('icon displayed', () => {
+      it('should render the "chevron-right" icon when the parent anchor target attribute is not "_blank"', () => {
+        createComponentWithTarget('_parent');
+
+        expect(
+          fixture.debugElement.query(By.css('[name="chevron-right"]')),
+        ).toBeDefined();
+
+        expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
+      });
+
+      it('should render the "link-external" icon when the parent anchor target attribute is "_blank"', () => {
+        createComponentWithTarget('_blank');
+
+        expect(
+          fixture.debugElement.query(By.css('[name="link-external"]')),
+        ).toBeDefined();
+
+        expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeNull();
       });
     });
   });

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.spec.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.spec.ts
@@ -17,6 +17,7 @@ import { LgLinkMenuItemComponent } from './link-menu-item.component';
 })
 class TestComponent {
   @Input() internal = true;
+  @Input() target: string = undefined;
 }
 
 describe('LgLinkMenuItemComponent', () => {
@@ -37,53 +38,107 @@ describe('LgLinkMenuItemComponent', () => {
     }).compileComponents();
   });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(TestComponent);
-    component = fixture.componentInstance;
-    component.internal = true;
-    fixture.detectChanges();
+  describe('component tests', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestComponent);
+      component = fixture.componentInstance;
+      component.internal = true;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should contain the default class', () => {
+      expect(
+        fixture.debugElement
+          .query(By.directive(LgLinkMenuItemComponent))
+          .nativeElement.getAttribute('class'),
+      ).toContain('lg-link-menu-item');
+    });
+
+    it('should render the link item component', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgLinkMenuItemComponent)),
+      ).toBeTruthy();
+    });
+
+    it('should render the internal icon', () => {
+      expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
+    });
+
+    it('should render the external icon when the internal input is set to false', () => {
+      component.internal = false;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeDefined();
+      expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeNull();
+    });
+
+    it('should render the heading', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgLinkMenuItemHeadingComponent)),
+      ).toBeTruthy();
+    });
+
+    it('should render the content', () => {
+      expect(
+        fixture.debugElement.query(By.directive(LgLinkMenuItemContentComponent)),
+      ).toBeTruthy();
+    });
+
+    it('should log a warning if the parent is not an anchor element', () => {
+      const consoleSpy = spyOn(console, 'warn').and.stub();
+
+      fixture = TestBed.createComponent(TestComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      expect(consoleSpy).toHaveBeenCalledOnceWith(
+        'expected \'lg-link-menu-item\' parent to be an HTML Anchor but got DIV',
+      );
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  describe('integration', () => {
+    describe('opens in a new tab text', () => {
+      const createComponentWithTarget = (target: string) => {
+        const template = `
+        <a href="#" [target]="target">
+          <lg-link-menu-item>
+            <lg-link-menu-item-heading>Update my direct debit</lg-link-menu-item-heading>
+            <lg-link-menu-item-content>Do it online</lg-link-menu-item-content>
+          </lg-link-menu-item>
+        </a>
+      `;
 
-  it('should contain the default class', () => {
-    expect(
-      fixture.debugElement
-        .query(By.directive(LgLinkMenuItemComponent))
-        .nativeElement.getAttribute('class'),
-    ).toContain('lg-link-menu-item');
-  });
+        fixture = TestBed.overrideTemplate(TestComponent, template).createComponent(
+          TestComponent,
+        );
 
-  it('should render the link item component', () => {
-    expect(
-      fixture.debugElement.query(By.directive(LgLinkMenuItemComponent)),
-    ).toBeTruthy();
-  });
+        component = fixture.componentInstance;
+        component.target = target;
 
-  it('should render the internal icon', () => {
-    expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeDefined();
-    expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
-  });
+        fixture.detectChanges();
+      };
 
-  it('should render the external icon when the internal input is set to false', () => {
-    component.internal = false;
-    fixture.detectChanges();
+      const getTextOfElementUnderTest = () =>
+        fixture.debugElement.query(By.css('.lg-link-menu-item__icon-container'))
+          .nativeElement.textContent;
 
-    expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeDefined();
-    expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeNull();
-  });
+      it('should not render the text when the parent anchor target attribute is not "_blank"', () => {
+        createComponentWithTarget('_parent');
 
-  it('should render the heading', () => {
-    expect(
-      fixture.debugElement.query(By.directive(LgLinkMenuItemHeadingComponent)),
-    ).toBeTruthy();
-  });
+        expect(getTextOfElementUnderTest()).toEqual('');
+      });
 
-  it('should render the content', () => {
-    expect(
-      fixture.debugElement.query(By.directive(LgLinkMenuItemContentComponent)),
-    ).toBeTruthy();
+      it('should render the text when the parent anchor target attribute is "_blank"', () => {
+        createComponentWithTarget('_blank');
+
+        expect(getTextOfElementUnderTest()).toEqual(' opens in a new tab');
+      });
+    });
   });
 });

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   HostBinding,
   Input,
+  OnInit,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -13,8 +15,27 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgLinkMenuItemComponent {
+export class LgLinkMenuItemComponent implements OnInit {
   @HostBinding('class.lg-link-menu-item') class = true;
 
   @Input() internal = true;
+  openInANewTab = false;
+
+  constructor(private elementRef: ElementRef) {}
+
+  ngOnInit(): void {
+    if (this.elementRef) {
+      const parent = this.elementRef.nativeElement.parentElement;
+
+      const tag = parent?.tagName;
+
+      if (tag === 'A') {
+        this.openInANewTab = parent.getAttribute('target') === '_blank';
+      } else {
+        console.warn(
+          `expected 'lg-link-menu-item' parent to be an HTML Anchor but got ${tag}`,
+        );
+      }
+    }
+  }
 }

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   ElementRef,
   HostBinding,
-  Input,
   OnInit,
   ViewEncapsulation,
 } from '@angular/core';
@@ -18,7 +17,6 @@ import {
 export class LgLinkMenuItemComponent implements OnInit {
   @HostBinding('class.lg-link-menu-item') class = true;
 
-  @Input() internal = true;
   openInANewTab = false;
 
   constructor(private elementRef: ElementRef) {}


### PR DESCRIPTION
# Description

* Now references the parent to determine what the target is and if it is "_blank" to then correctly add the 'opens in a new tab' text.

Fixes #1086 

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
