### PR TITLE
fix(header): update so that the shadow appears correctly on sm devices

### DIFF
--- a/projects/canopy/src/lib/header/header.component.scss
+++ b/projects/canopy/src/lib/header/header.component.scss
@@ -2,7 +2,6 @@
 
 .lg-header {
   background-color: var(--header-bg-color);
-  box-shadow: var(--header-shadow);
   height: var(--header-height);
   left: 0;
   position: fixed;
@@ -13,6 +12,17 @@
   @include lg-breakpoint(lg) {
     height: var(--header-height-lg);
     position: static;
+  }
+
+  &:after {
+    content: '';
+    display: block;
+    height: var(--header-shadow-height);
+    margin-top: calc(var(--header-shadow-height) * -1);
+    background-color: transparent;
+    box-shadow: var(--header-shadow);
+    position: relative;
+    width: 100%;
   }
 }
 

--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
@@ -12,7 +12,7 @@ $primary-nav-border-bottom-height: 0.25rem;
   padding: var(--space-sm);
   position: fixed;
   right: 0;
-  top: calc(var(--header-height) + var(--space-xxxs));
+  top: var(--header-height);
 
   &--active {
     display: block;

--- a/projects/canopy/src/styles/variables/components/_header.scss
+++ b/projects/canopy/src/styles/variables/components/_header.scss
@@ -4,7 +4,8 @@
   --header-height-lg: 5.5rem;
   --header-logo-width: 4rem;
   --header-logo-width-lg: 4rem;
-  --header-shadow: 0 0.25rem 0 rgba(0, 0, 0, 0.03);
+  --header-shadow-height: 0.25rem;
+  --header-shadow: 0 var(--header-shadow-height) 0 rgba(0, 0, 0, 0.03);
 
   --nav-item-border-radius: 0.25rem;
   --nav-item-icon-height: 1.5rem;


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1zd9hlQalpXYBY5YNoBPZTckVvvyj5pKA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=s_LWR77)

# Description

This fixes an issue where the header shadow was showing the page underneath on small devices.

Before:
![Screenshot 2022-12-20 at 13 16 48](https://user-images.githubusercontent.com/8397116/208677527-c5cdd77b-f764-4b04-8744-68453c0298ed.png)

After:
![Screenshot 2022-12-20 at 13 24 30](https://user-images.githubusercontent.com/8397116/208677553-494beb16-3027-4a9d-bdaa-66651370f26a.png)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
