### PR TITLE
fix(heading): update to always transform the level to a number

### DIFF
--- a/projects/canopy/src/lib/heading/heading.component.html
+++ b/projects/canopy/src/lib/heading/heading.component.html
@@ -2,21 +2,21 @@
 
 <ng-template #transclude><ng-content></ng-content></ng-template>
 
-<h1 *ngIf="level === 1">
+<h1 *ngIf="+level === 1">
   <ng-container *ngTemplateOutlet="transclude"></ng-container>
 </h1>
-<h2 *ngIf="level === 2">
+<h2 *ngIf="+level === 2">
   <ng-container *ngTemplateOutlet="transclude"></ng-container>
 </h2>
-<h3 *ngIf="level === 3">
+<h3 *ngIf="+level === 3">
   <ng-container *ngTemplateOutlet="transclude"></ng-container>
 </h3>
-<h4 *ngIf="level === 4">
+<h4 *ngIf="+level === 4">
   <ng-container *ngTemplateOutlet="transclude"></ng-container>
 </h4>
-<h5 *ngIf="level === 5">
+<h5 *ngIf="+level === 5">
   <ng-container *ngTemplateOutlet="transclude"></ng-container>
 </h5>
-<h6 *ngIf="level === 6">
+<h6 *ngIf="+level === 6">
   <ng-container *ngTemplateOutlet="transclude"></ng-container>
 </h6>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18dx6xxphPrkW0XqqsCH1Sa6xPL7a4Y6k%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=FoOXeGu)
# Description

The logic in the heading template was recently updated to use `===`. This is actually causing issue as the type of the variable is `HeadingLevel` and not a number as expected.
This PR fixes the issue by transforming the variable into a number before evaluating the `if` statement.

Before the change:
![Screenshot 2022-12-20 at 17 39 55](https://user-images.githubusercontent.com/8397116/208732252-c6dc952b-b8a9-40f9-9467-fd098b19a7bf.png)

After the change:
![Screenshot 2022-12-20 at 17 40 12](https://user-images.githubusercontent.com/8397116/208732317-435feb87-319d-4a54-9902-dcba8aebded8.png)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
