### PR TITLE
feat(header): add overlay to primary nav and fix tab order

### DIFF
--- a/projects/canopy/src/lib/header/account-menu/account-menu-list-item/account-menu-list-item.component.spec.ts
+++ b/projects/canopy/src/lib/header/account-menu/account-menu-list-item/account-menu-list-item.component.spec.ts
@@ -39,4 +39,14 @@ describe('LgAccountMenuListItemComponent', () => {
 
     expect(clickedSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('emits an event when tab keydown occurs', () => {
+    const tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+    const tabKeyDownSpy = spyOn(component.tabbedOut, 'emit');
+
+    el.focus();
+    el.dispatchEvent(tabKeyDownEvent);
+
+    expect(tabKeyDownSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/projects/canopy/src/lib/header/account-menu/account-menu-list-item/account-menu-list-item.component.ts
+++ b/projects/canopy/src/lib/header/account-menu/account-menu-list-item/account-menu-list-item.component.ts
@@ -7,6 +7,8 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
+import { keyName } from '../../../utils/keyboard-keys';
+
 @Component({
   selector: 'lg-account-menu-list-item',
   template: '<ng-content></ng-content>',
@@ -20,8 +22,15 @@ import {
 })
 export class LgAccountMenuListItemComponent {
   @Output() clicked: EventEmitter<Event> = new EventEmitter();
+  @Output() tabbedOut: EventEmitter<KeyboardEvent> = new EventEmitter();
 
   @HostListener('click', [ '$event' ]) handleClick(event: Event) {
     this.clicked.emit(event);
+  }
+
+  @HostListener('keydown', [ '$event' ]) handleKeyDown(event: KeyboardEvent) {
+    if (event.key === keyName.KEY_TAB) {
+      this.tabbedOut.emit(event);
+    }
   }
 }

--- a/projects/canopy/src/lib/header/account-menu/account-menu.component.ts
+++ b/projects/canopy/src/lib/header/account-menu/account-menu.component.ts
@@ -8,6 +8,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'lg-account-menu',
+    tabindex: '-1',
     role: 'list',
     'aria-label': 'Account menu',
   },

--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.html
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.html
@@ -1,20 +1,14 @@
- <ng-container
-    *ngTemplateOutlet="
-      href ? linkTpl : imgTpl;
-      context: { img: { alt: alt, href: href, src: src } }
-    "
-  ></ng-container>
+<a *ngIf="href" [attr.href]="href" class="lg-header-logo__link" #logolink>
+  <img
+    [attr.alt]="alt"
+    [attr.src]="src"
+    [ngClass]="class"
+  />
+</a>
 
- <ng-template #linkTpl let-img="img">
-   <a [attr.href]="img?.href" class="lg-header-logo__link">
-     <ng-container *ngTemplateOutlet="imgTpl; context: { img: img }"></ng-container>
-   </a>
- </ng-template>
-
- <ng-template #imgTpl let-img="img">
-   <img
-     [attr.alt]="img?.alt"
-     [attr.src]="img?.src"
-     [ngClass]="class"
-   />
- </ng-template>
+<img
+  *ngIf="!href"
+  [attr.alt]="alt"
+  [attr.src]="src"
+  [ngClass]="class"
+/>

--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.spec.ts
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.spec.ts
@@ -45,4 +45,26 @@ describe('LgHeaderLogosComponent', () => {
 
     expect(fixture.debugElement.query(By.css(`a[href="${href}"]`))).toBeTruthy();
   });
+
+  it('emits an event when tab keydown occurs', () => {
+    const tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+    const tabKeyDownSpy = spyOn(component.tabbedOut, 'emit');
+
+    fixture.debugElement.nativeElement.focus();
+    fixture.debugElement.nativeElement.dispatchEvent(tabKeyDownEvent);
+
+    expect(tabKeyDownSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses the logo link', () => {
+    component.href = href;
+    fixture.detectChanges();
+
+    const link = fixture.debugElement.query(By.css(`a[href="${href}"]`));
+    const focusSpy = spyOn(link.nativeElement, 'focus');
+
+    component.focus();
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.ts
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.ts
@@ -53,7 +53,7 @@ export class LgHeaderLogoComponent implements AfterContentChecked {
     }
   }
 
-  focus() {
+  focus(): void {
     this.logoLinkRef.nativeElement.focus();
   }
 }

--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.ts
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.ts
@@ -3,9 +3,16 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
   Input,
+  Output,
+  ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
+
+import { keyName } from '../../utils/keyboard-keys';
 
 type HeaderLogoClass = 'lg-header-logo__img' | 'lg-header-logo__second-img';
 
@@ -27,12 +34,26 @@ export class LgHeaderLogoComponent implements AfterContentChecked {
   @Input() src: string;
   @Input() href: string;
 
+  @ViewChild('logolink') logoLinkRef: ElementRef;
+
+  @Output() tabbedOut: EventEmitter<KeyboardEvent> = new EventEmitter();
+
   constructor(private cdr: ChangeDetectorRef) {}
+
+  @HostListener('keydown', [ '$event' ]) handleKeyDown(event: KeyboardEvent) {
+    if (event.key === keyName.KEY_TAB) {
+      this.tabbedOut.emit(event);
+    }
+  }
 
   ngAfterContentChecked(): void {
     if (this.class && this.class !== this.currentClass) {
       this.currentClass = this.class;
       this.cdr.detectChanges();
     }
+  }
+
+  focus() {
+    this.logoLinkRef.nativeElement.focus();
   }
 }

--- a/projects/canopy/src/lib/header/header.component.spec.ts
+++ b/projects/canopy/src/lib/header/header.component.spec.ts
@@ -161,7 +161,7 @@ describe('HeaderComponent', () => {
             expect(component.showResponsiveMenu).toBe(false);
           }));
 
-          describe('when the toggle button and the primaty nav are undefined', () => {
+          describe('when the toggle button and the primary nav are undefined', () => {
             it('should not close the menu', fakeAsync(() => {
               component.menuToggleButton = undefined;
               component.primaryNav = undefined;
@@ -253,9 +253,58 @@ describe('HeaderComponent', () => {
       let setup: () => void;
 
       beforeEach(() => {
-        tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab' });
         focusSpy = spyOn(toggleEl, 'focus');
-        preventDefaultSpy = spyOn(tabKeyDownEvent, 'preventDefault');
+      });
+
+      describe('shift + tabbing out of first listitem when toggle button is visible', () => {
+        beforeEach(() => {
+          setup = () => {
+            component.navItems.first.tabbedOut.emit(tabKeyDownEvent);
+            tick();
+            fixture.detectChanges();
+          };
+
+          tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+          preventDefaultSpy = spyOn(tabKeyDownEvent, 'preventDefault');
+        });
+
+        it('prevents default event bubbling', fakeAsync(() => {
+          setup();
+
+          expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+        }));
+
+        it('focuses toggle button', fakeAsync(() => {
+          setup();
+
+          expect(focusSpy).toHaveBeenCalledTimes(1);
+        }));
+      });
+
+      describe('shift + tabbing out of last listitem', () => {
+        beforeEach(() => {
+          setup = () => {
+            toggleEl.style.display = 'none';
+            component.navItems.last.tabbedOut.emit(tabKeyDownEvent);
+            tick();
+            fixture.detectChanges();
+          };
+
+          tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+          preventDefaultSpy = spyOn(tabKeyDownEvent, 'preventDefault');
+        });
+
+        it('does not prevent event from bubbling', fakeAsync(() => {
+          setup();
+
+          expect(preventDefaultSpy).not.toHaveBeenCalled();
+        }));
+
+        it('does not focus toggle button', fakeAsync(() => {
+          setup();
+
+          expect(focusSpy).not.toHaveBeenCalled();
+        }));
       });
 
       describe('tabbing out of last listitem when toggle button is visible', () => {
@@ -265,6 +314,9 @@ describe('HeaderComponent', () => {
             tick();
             fixture.detectChanges();
           };
+
+          tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+          preventDefaultSpy = spyOn(tabKeyDownEvent, 'preventDefault');
         });
 
         it('prevents default event bubbling', fakeAsync(() => {
@@ -288,9 +340,12 @@ describe('HeaderComponent', () => {
             tick();
             fixture.detectChanges();
           };
+
+          tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
+          preventDefaultSpy = spyOn(tabKeyDownEvent, 'preventDefault');
         });
 
-        it('does not call prevent event from bubbling', fakeAsync(() => {
+        it('does not prevent event from bubbling', fakeAsync(() => {
           setup();
 
           expect(preventDefaultSpy).not.toHaveBeenCalled();
@@ -308,7 +363,7 @@ describe('HeaderComponent', () => {
       let tabKeyDownEvent: KeyboardEvent;
 
       beforeEach(() => {
-        tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+        tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: false });
       });
 
       it('focuses primary nav when tabbing out of toggle button and menu is open', () => {
@@ -320,6 +375,15 @@ describe('HeaderComponent', () => {
 
       it('does not focus primary nav when tabbing out of toggle button and menu is closed', () => {
         component.showResponsiveMenu = false;
+        component.handleToggleKeydown(tabKeyDownEvent);
+
+        expect(primaryNavFocusSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not focus the toggle button if the user tabs to previous focusable element', () => {
+        tabKeyDownEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+
+        component.showResponsiveMenu = true;
         component.handleToggleKeydown(tabKeyDownEvent);
 
         expect(primaryNavFocusSpy).toHaveBeenCalledTimes(0);

--- a/projects/canopy/src/lib/header/header.component.spec.ts
+++ b/projects/canopy/src/lib/header/header.component.spec.ts
@@ -218,6 +218,10 @@ describe('HeaderComponent', () => {
       it('emits an event', () => {
         expect(menuToggledSpy).toHaveBeenCalledWith(true);
       });
+
+      it('sets the overflow on the document body to hidden', () => {
+        expect(document.body.style.overflow).toBe('hidden');
+      });
     });
 
     describe('toggle responsive menu off', () => {
@@ -243,6 +247,12 @@ describe('HeaderComponent', () => {
 
       it('emits an event', () => {
         expect(menuToggledSpy).toHaveBeenCalledWith(false);
+      });
+
+      it('removes the overflow style from document body', () => {
+        fixture.detectChanges();
+
+        expect(document.body.style.overflow).toBe('');
       });
     });
 

--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation-list-item/primary-navigation-list-item.component.scss
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation-list-item/primary-navigation-list-item.component.scss
@@ -6,6 +6,10 @@
   overflow: visible;
   margin-top: 0.375rem;
 
+  &:last-of-type {
+    border-bottom: 0;
+  }
+
   @include lg-breakpoint(lg) {
     padding-top: 0;
     margin: 0 var(--space-xxs) 0;
@@ -15,5 +19,9 @@
 
   &--right {
     margin-left: auto;
+  }
+
+  .lg-btn {
+    width: auto;
   }
 }

--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.html
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.html
@@ -1,3 +1,5 @@
 <ul class="lg-primary-nav-list">
   <ng-content></ng-content>
 </ul>
+
+<div class="lg-primary-nav-overlay" lgHideAt="lg"></div>

--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
@@ -3,23 +3,17 @@
 $primary-nav-border-bottom-height: 0.25rem;
 
 .lg-primary-nav {
-  background: var(--color-white);
   bottom: 0;
   display: none;
   flex-grow: 1;
   left: 0;
   overflow: visible;
-  padding: var(--space-sm);
   position: fixed;
   right: 0;
   top: var(--header-height);
 
   &--active {
     display: block;
-  }
-
-  @include lg-breakpoint(md) {
-    bottom: auto;
   }
 
   @include lg-breakpoint(lg) {
@@ -31,15 +25,33 @@ $primary-nav-border-bottom-height: 0.25rem;
   }
 }
 
+.lg-primary-nav-overlay {
+  background: var(--overlay-bg-color);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: calc(var(--z-index-header) - 2);
+}
+
 .lg-primary-nav-list {
+  background: var(--color-white);
   align-items: flex-start;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   list-style-type: none;
   margin: 0;
-  padding: var(--space-xxxs) 0 0 0;
+  padding: var(--space-sm);
+  position: relative;
   width: 100%;
+  height: 100%;
+  z-index: calc(var(--z-index-header) - 1);
+
+  @include lg-breakpoint(md) {
+    height: auto;
+  }
 
   @include lg-breakpoint(lg) {
     align-items: center;

--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
@@ -57,7 +57,7 @@ $primary-nav-border-bottom-height: 0.25rem;
     align-items: center;
     flex-direction: row;
     margin-left: var(--space-lg);
-    padding-top: 0;
+    padding: 0;
   }
 }
 

--- a/projects/canopy/src/styles/variables/components/_header.scss
+++ b/projects/canopy/src/styles/variables/components/_header.scss
@@ -7,6 +7,8 @@
   --header-shadow-height: 0.25rem;
   --header-shadow: 0 var(--header-shadow-height) 0 rgba(0, 0, 0, 0.03);
 
+  --overlay-bg-color: rgba(0, 0, 0, 0.4);
+
   --nav-item-border-radius: 0.25rem;
   --nav-item-icon-height: 1.5rem;
 


### PR DESCRIPTION
# Description

1. Fixes the tab order across devices as the menus use flex box to place them in different orders on different devices and this was messing with the tab ordering, when going back and forth on sm devices.
2. Adds a transparent overlay over the page when the primary navigation is open.

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
