### PR TITLE
fix(header-logo): update focus state to use new focus outline mixin

### DIFF
--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.scss
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.scss
@@ -35,7 +35,10 @@
 
     &:focus {
       background-color: transparent;
-      @include lg-inner-focus-outline(var(--default-focus-color));
+      @include lg-focus-outline(
+        var(--default-focus-color),
+        var(--default-inner-focus-color)
+      );
     }
   }
 }


### PR DESCRIPTION
# Description

Updates the header logo link to use the newer focus outline styles to match those used in the header navigation menus

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
