### PR TITLE
fix(header): re-render menu toggle button when primary nav items change

### DIFF
--- a/projects/canopy/src/lib/header/header.component.spec.ts
+++ b/projects/canopy/src/lib/header/header.component.spec.ts
@@ -100,7 +100,9 @@ describe('HeaderComponent', () => {
 
     beforeEach(() => {
       ngMocks.flushTestBed();
+    });
 
+    it('should not be rendered when no nav items', () => {
       fixture = MockRender(`
         <header lg-header>
           <lg-header-logo src="http://a.b/logo.png" href="http://a.b"></lg-header-logo>
@@ -108,10 +110,26 @@ describe('HeaderComponent', () => {
       `);
 
       toggle = fixture.debugElement.queryAll(By.css('.primary-nav-toggle'));
+
+      expect(toggle.length).toBe(0);
     });
 
-    it('should not be rendered when no nav items', () => {
-      expect(toggle.length).toBe(0);
+    it('should be rendered when nav items exist', () => {
+      fixture = MockRender(`
+        <header lg-header>
+          <lg-header-logo src="http://a.b/logo.png" href="http://a.b"></lg-header-logo>
+
+          <lg-primary-nav>
+            <lg-primary-nav-list-item>
+              <a href="" lgPrimaryNavItem>Link</a>
+            </lg-primary-nav-list-item>
+          </lg-primary-nav>
+        </header>
+      `);
+
+      toggle = fixture.debugElement.queryAll(By.css('.primary-nav-toggle'));
+
+      expect(toggle.length).toBe(1);
     });
   });
 

--- a/projects/canopy/src/lib/header/header.component.ts
+++ b/projects/canopy/src/lib/header/header.component.ts
@@ -149,6 +149,11 @@ export class LgHeaderComponent implements AfterContentInit, OnDestroy {
             this.menuToggleButton.nativeElement.focus();
             this.cdr.markForCheck();
           }),
+
+        // Ensure we show/hide the burger menu if the number of nav items change to/from 0
+        this.navItems.changes.subscribe(() => {
+          this.cdr.markForCheck();
+        }),
       );
     }
 


### PR DESCRIPTION
# Description

This fixes an issue where a consumer hides/shows the navigation  but the burger menu does not re-appear. It now forces a re-render when primary navigation items change

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
