### PR TITLE
feat(focus): replace :focus with :focus-visible

### DIFF
--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.scss
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.scss
@@ -27,8 +27,8 @@
   text-align: left;
   width: 100%;
 
-  &:focus {
-    @include lg-inner-focus-outline(var(--default-focus-color));
+  &:focus-visible {
+    @include lg-inner-focus-outline();
   }
 
   .lg-accordion__heading-icon {

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.scss
@@ -65,8 +65,8 @@
       color: var(--breadcrumb-dark-color);
     }
 
-    a:focus {
-      @include lg-outer-focus-outline(var(--default-focus-color));
+    a:focus-visible {
+      @include lg-focus-outline();
 
       background-color: transparent;
     }

--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -22,13 +22,9 @@
   margin-bottom: var(--component-margin);
   text-decoration: none;
 
-  &:focus,
-  &:hover:focus,
-  &:hover:focus:hover {
-    @include lg-focus-outline(
-      var(--default-focus-color),
-      var(--default-inner-focus-color)
-    );
+  &:focus-visible,
+  &:focus-visible:hover {
+    @include lg-focus-outline;
   }
 
   &:not(&--loading):disabled {
@@ -114,15 +110,15 @@
 
   @include lg-link();
 
-  &:focus,
-  &:hover:focus {
+  &:focus-visible,
+  &:hover:focus-visible {
     box-shadow: none;
   }
 
   &:hover,
   &:hover:visited,
-  &:focus,
-  &:focus:hover {
+  &:focus-visible,
+  &:focus-visible:hover {
     padding-bottom: 0.125rem;
   }
 }
@@ -135,7 +131,7 @@ $variants: 'primary-dark', 'primary-light', 'secondary-dark', 'secondary-light',
 
 @each $variant in $variants {
   .lg-btn--#{$variant},
-  .lg-btn--#{$variant}:focus:not(.lg-btn-toggle),
+  .lg-btn--#{$variant}:focus-visible:not(.lg-btn-toggle),
   .lg-btn--#{$variant}:visited {
     background-color: var(--btn-#{$variant}-bg-color);
     border: var(--btn-#{$variant}-border-color) solid var(--border-width);
@@ -162,7 +158,7 @@ $variants: 'primary-dark', 'primary-light', 'secondary-dark', 'secondary-light',
     }
   }
 
-  .lg-btn--#{$variant}:focus {
+  .lg-btn--#{$variant}:focus-visible {
     border-color: transparent;
 
     &:not(:disabled) {

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.scss
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.scss
@@ -69,9 +69,8 @@
       );
     }
 
-    &:focus,
-    &:focus:hover,
-    &:focus:hover:hover {
+    &:focus-visible,
+    &:focus-visible:hover {
       background: transparent;
       border-bottom: var(--card-active-focus-border-bottom-width) solid
         var(--link-active-color);
@@ -87,13 +86,10 @@
           var(--card-active-focus-border-bottom-width)
       );
 
-      @include lg-focus-outline(
-        var(--default-focus-color),
-        var(--default-inner-focus-color)
-      );
+      @include lg-focus-outline;
     }
 
-    &:focus,
+    &:focus-visible,
     &:active {
       .lg-icon {
         background: var(--link-active-color);

--- a/projects/canopy/src/lib/card/card-toggable-content/card-toggable-content.component.scss
+++ b/projects/canopy/src/lib/card/card-toggable-content/card-toggable-content.component.scss
@@ -6,8 +6,8 @@
   padding: 0;
   transition: all var(--animation-duration) var(--animation-fn);
 
-  &:focus {
-    @include lg-focus-outline();
+  &:focus-visible {
+    @include lg-focus-outline;
 
     padding: var(--space-xxxs);
   }

--- a/projects/canopy/src/lib/carousel/auto-play/auto-play.component.scss
+++ b/projects/canopy/src/lib/carousel/auto-play/auto-play.component.scss
@@ -16,8 +16,8 @@
     padding: 0;
     width: var(--space-xxl);
 
-    &:focus {
-      @include lg-outer-focus-outline(var(--default-focus-color));
+    &:focus-visible {
+      @include lg-focus-outline();
     }
 
     .lg-icon {

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.scss
@@ -23,8 +23,8 @@
     text-align: left;
     width: 100%;
 
-    &:focus {
-      @include lg-inner-focus-outline(var(--default-focus-color));
+    &:focus-visible {
+      @include lg-inner-focus-outline();
     }
 
     &--active .lg-details-panel-heading__state-icon {

--- a/projects/canopy/src/lib/docs/principles/accessibility/developer.stories.mdx
+++ b/projects/canopy/src/lib/docs/principles/accessibility/developer.stories.mdx
@@ -57,7 +57,7 @@ You can do that by using the `skip-content` class:
   width: 0.0625em !important;
   white-space: nowrap !important;
 
-  &:focus,
+  &:focus-visible,
   &:active {
     left: 0;
     clip: auto !important;

--- a/projects/canopy/src/lib/footer/footer-nav-item/footer-nav-item.component.scss
+++ b/projects/canopy/src/lib/footer/footer-nav-item/footer-nav-item.component.scss
@@ -54,9 +54,9 @@
   &:hover {
     text-decoration: underline;
 
-    &:focus:hover {
+    &:focus-visible {
       text-decoration: none;
-      @include lg-outer-focus-outline;
+      @include lg-focus-outline();
     }
   }
 

--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -82,7 +82,7 @@
       border-left-width: var(--keyline-width);
       border-color: var(--border-focus-color);
 
-      @include lg-outer-focus-outline();
+      @include lg-focus-outline;
     }
 
     #{$block}--block & {

--- a/projects/canopy/src/lib/forms/radio/radio-button--filter.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--filter.component.scss
@@ -67,9 +67,9 @@
     }
   }
 
-  .lg-radio-button__input:focus {
+  .lg-radio-button__input:focus-visible {
     + .lg-radio-button__label {
-      @include lg-outer-focus-outline();
+      @include lg-focus-outline;
     }
   }
 

--- a/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
@@ -58,13 +58,13 @@
       transition: all var(--animation-duration) var(--animation-fn);
     }
 
-    &:focus + .lg-radio-button__label {
-      @include lg-inner-focus-outline(var(--default-focus-color));
+    &:focus-visible + .lg-radio-button__label {
+      @include lg-inner-focus-outline();
     }
 
-    &:focus:hover + .lg-radio-button__label {
+    &:focus-visible:hover + .lg-radio-button__label {
       background-color: var(--radio-bg-color);
-      @include lg-inner-focus-outline(var(--default-focus-color));
+      @include lg-inner-focus-outline();
     }
   }
 

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -45,9 +45,9 @@
   border: var(--border-width) solid var(--radio-border-color);
   margin: auto var(--space-sm) auto 0;
 
-  .lg-radio-button__input:focus + & {
+  .lg-radio-button__input:focus-visible + & {
     border-color: var(--border-focus-color);
-    @include lg-outer-focus-outline();
+    @include lg-focus-outline();
   }
 
   .lg-radio-button:disabled & {

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.scss
@@ -15,7 +15,7 @@
   }
 }
 
-fieldset[tabindex='-1']:focus {
+fieldset[tabindex='-1']:focus-visible {
   box-shadow: none;
   outline: 0.25rem solid var(--default-focus-color);
 }

--- a/projects/canopy/src/lib/forms/select/select-field.component.scss
+++ b/projects/canopy/src/lib/forms/select/select-field.component.scss
@@ -37,7 +37,7 @@
     color: var(--form-error-border-color);
   }
 
-  .lg-select-field--error *:focus + & {
+  .lg-select-field--error *:focus-visible + & {
     color: inherit;
   }
 

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -17,11 +17,11 @@
     border-color: var(--border-hover-color);
   }
 
-  &:focus {
+  &:focus-visible {
     border-left-width: var(--keyline-width);
     border-color: var(--border-focus-color);
     padding-left: calc(var(--space-sm) - var(--keyline-width) + var(--border-width));
-    @include lg-outer-focus-outline();
+    @include lg-focus-outline();
   }
 
   &:disabled {
@@ -35,7 +35,7 @@
     color: var(--form-error-color);
     border-color: var(--form-error-border-color);
 
-    &:focus {
+    &:focus-visible {
       color: inherit;
       border-color: inherit;
     }

--- a/projects/canopy/src/lib/forms/toggle/toggle--filter.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle--filter.component.scss
@@ -75,9 +75,9 @@
   }
 }
 
-.lg-toggle__input:focus {
+.lg-toggle__input:focus-visible {
   + .lg-toggle__label--filter {
-    @include lg-outer-focus-outline();
+    @include lg-focus-outline();
   }
 }
 

--- a/projects/canopy/src/lib/forms/toggle/toggle--switch.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle--switch.component.scss
@@ -49,9 +49,9 @@
     border-color: var(--border-hover-color);
   }
 
-  .lg-toggle__input:focus + & {
+  .lg-toggle__input:focus-visible + & {
     border-color: var(--border-focus-color);
-    @include lg-outer-focus-outline();
+    @include lg-focus-outline();
   }
 
   .lg-toggle__input:checked + & {

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -47,8 +47,8 @@
     width: auto;
   }
 
-  .lg-toggle__input:focus + & {
-    @include lg-outer-focus-outline();
+  .lg-toggle__input:focus-visible + & {
+    @include lg-focus-outline();
   }
 
   .lg-toggle__input:checked + & {

--- a/projects/canopy/src/lib/header/header-logo/header-logo.component.scss
+++ b/projects/canopy/src/lib/header/header-logo/header-logo.component.scss
@@ -33,12 +33,9 @@
     display: inline-block;
     @include lg-unstyled-link;
 
-    &:focus {
+    &:focus-visible {
       background-color: transparent;
-      @include lg-focus-outline(
-        var(--default-focus-color),
-        var(--default-inner-focus-color)
-      );
+      @include lg-focus-outline;
     }
   }
 }

--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
@@ -80,16 +80,12 @@ button.lg-primary-nav-item {
   text-decoration: none;
   width: 100%;
 
-  &:focus,
-  &:focus:hover,
+  &:focus-visible:hover,
   &:focus-visible {
     border-bottom: $primary-nav-border-bottom-height solid
       var(--primary-nav-item-border-color-hover);
 
-    @include lg-focus-outline(
-      var(--default-focus-color),
-      var(--default-inner-focus-color)
-    );
+    @include lg-focus-outline;
   }
 
   &:visited {
@@ -114,8 +110,8 @@ button.lg-primary-nav-item {
     color: var(--primary-nav-item-color-active);
   }
 
-  &--active:focus,
-  &--active:hover:focus {
+  &--active:focus-visible,
+  &--active:hover:focus-visible {
     border-color: var(--primary-nav-item-border-color-active);
     color: var(--primary-nav-item-color-active);
   }
@@ -137,13 +133,13 @@ button.lg-primary-nav-item {
       color: var(--primary-nav-item-color-active-lg);
     }
 
-    &--active:focus,
-    &--active:hover:focus {
+    &--active:focus-visible,
+    &--active:hover:focus-visible {
       color: var(--primary-nav-item-color-active-lg);
     }
 
-    &:focus,
-    &:focus:hover {
+    &:focus-visible,
+    &:focus-visible:hover {
       border: 0;
     }
   }

--- a/projects/canopy/src/lib/link-menu/link-menu.component.scss
+++ b/projects/canopy/src/lib/link-menu/link-menu.component.scss
@@ -31,14 +31,14 @@
 
     &:active,
     &:hover,
-    &:focus {
+    &:focus-visible {
       margin-bottom: calc(
         var(--border-width) - var(--link-menu-link-border-width-lg)
       ); // prevent bouncing effect caused by border
     }
 
     &:active,
-    &:focus {
+    &:focus-visible {
       color: var(--link-menu-link-active-color);
       border-bottom: var(--link-menu-link-border-width-lg) solid
         var(--link-menu-link-active-color);

--- a/projects/canopy/src/lib/modal/modal-header/modal-header.component.scss
+++ b/projects/canopy/src/lib/modal/modal-header/modal-header.component.scss
@@ -31,11 +31,11 @@
       cursor: pointer;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 0;
 
       > .lg-icon {
-        @include lg-outer-focus-outline(var(--default-focus-color));
+        @include lg-focus-outline();
       }
     }
   }

--- a/projects/canopy/src/lib/modal/modal.component.scss
+++ b/projects/canopy/src/lib/modal/modal.component.scss
@@ -38,7 +38,7 @@
     transform: translate(-50%, -50%);
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
   }
 

--- a/projects/canopy/src/lib/page/page.component.scss
+++ b/projects/canopy/src/lib/page/page.component.scss
@@ -23,7 +23,7 @@
   background: var(--color-white);
   @include lg-visually-hidden;
 
-  &:focus,
+  &:focus-visible,
   &:active {
     left: 0;
     clip: auto !important;

--- a/projects/canopy/src/lib/quick-action/quick-action.component.scss
+++ b/projects/canopy/src/lib/quick-action/quick-action.component.scss
@@ -17,13 +17,13 @@
   color: var(--link-color);
 
   &:hover,
-  &:focus:hover {
+  &:focus-visible:hover {
     background-color: var(--quick-action-hover-bg-color);
     color: var(--quick-action-hover-color);
   }
 
   &:active,
-  &:active:focus {
+  &:active:focus-visible {
     background-color: var(--quick-action-active-bg-color);
     color: var(--quick-action-active-color);
   }
@@ -32,13 +32,13 @@
     color: var(--quick-action-visited-color);
   }
 
-  &:focus {
+  &:focus-visible {
     color: var(--link-color);
   }
 
-  &:focus,
-  &:focus:hover {
-    @include lg-outer-focus-outline(var(--default-focus-color));
+  &:focus-visible,
+  &:focus-visible:hover {
+    @include lg-focus-outline();
 
     background-color: var(--quick-action-bg-color);
     color: var(--link-color);

--- a/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.scss
+++ b/projects/canopy/src/lib/side-nav/side-nav-content/side-nav-content.component.scss
@@ -7,8 +7,8 @@
   width: 100%;
   margin: 0;
 
-  &:focus {
-    @include lg-inner-focus-outline(var(--default-focus-color));
+  &:focus-visible {
+    @include lg-inner-focus-outline();
   }
 
   @include lg-breakpoint('lg') {

--- a/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
+++ b/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
@@ -13,8 +13,8 @@
     min-width: var(--table-toggle-width);
     min-height: var(--table-toggle-width);
 
-    &:focus {
-      @include lg-inner-focus-outline(var(--default-focus-color));
+    &:focus-visible {
+      @include lg-inner-focus-outline();
     }
   }
 

--- a/projects/canopy/src/lib/tabs/scss-modules/_tab-item.scss
+++ b/projects/canopy/src/lib/tabs/scss-modules/_tab-item.scss
@@ -42,8 +42,8 @@
     }
   }
 
-  &:focus {
-    outline: none;
+  &:focus-visible {
+    @include lg-focus-outline();
   }
 
   &:hover {
@@ -54,9 +54,5 @@
       background-color: var(--tabs-hover-color);
       height: var(--tabs-hover-border-width);
     }
-  }
-
-  &[keyboard-focus]:focus {
-    @include lg-outer-focus-outline();
   }
 }

--- a/projects/canopy/src/lib/tabs/tab-nav-bar/tab-nav-bar.component.scss
+++ b/projects/canopy/src/lib/tabs/tab-nav-bar/tab-nav-bar.component.scss
@@ -40,26 +40,22 @@
   @include lg-tab-item;
 
   &:hover,
-  &:hover:focus,
+  &:hover:focus-visible,
   &:hover:active {
     color: var(--tabs-hover-color);
-  }
-
-  &:focus {
-    box-shadow: none;
   }
 
   &:active {
     color: var(--tabs-list-item-color);
   }
 
-  &:focus,
+  &:focus-visible,
   &:visited {
     color: var(--tabs-list-item-color);
   }
 
   &--selected {
-    &:focus,
+    &:focus-visible,
     &:visited,
     &:active {
       color: var(--tabs-active-color);

--- a/projects/canopy/src/styles/docs/mixins.stories.mdx
+++ b/projects/canopy/src/styles/docs/mixins.stories.mdx
@@ -14,15 +14,6 @@ Sets the focus outline inside the element, by using multiple box shadows.
 | `$color`    | The colour of the outline           | `var(--color-white)` |    No    |
 
 
-## lg-outer-focus-outline
-Sets the focus outline outside the element, by using box shadows.
-
-### Arguments
-| Name        | Description                         |           Default            | Required |
-|-------------|-------------------------------------|:----------------------------:|:--------:|
-| `$bg-color` | The background color of the element | `var(--default-focus-color)` |    No    |
-
-
 ## lg-focus-outline
 Sets the focus outline outside the element, by using box shadows. This is currently used on buttons.
 

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -3,17 +3,14 @@
   $color: colour of the outline.
   Sets the focus outline inside the element, by using multiple box shadows
 */
-@mixin lg-inner-focus-outline($bg-color, $color: var(--color-white)) {
+@mixin lg-inner-focus-outline(
+  $bg-color: var(--default-focus-color),
+  $color: var(--color-white)
+) {
   outline: 0;
   box-shadow: inset 0 0 0 0.25rem $bg-color, inset 0 0 0 0.3rem $color;
 }
 
-@mixin lg-outer-focus-outline($bg-color: var(--default-focus-color)) {
-  outline: 0;
-  box-shadow: 0 0 0 0.25rem $bg-color;
-}
-
-// this mixin will replace lg-outer-focus-outline in the future when all the components will have to use this focus styling
 @mixin lg-focus-outline(
   $bg-color: var(--default-focus-color),
   $inner-bg-color: var(--default-inner-focus-color)
@@ -60,17 +57,13 @@
     outline: 0;
   }
 
-  &:focus,
-  &:focus:hover {
+  &:focus-visible,
+  &:focus-visible:hover {
     background-color: $focus-bg-color;
     border-bottom: 0;
     color: $focus-color;
-    outline: 0.063rem solid $focus-bg-color !important;
+    outline: 0.063rem solid $focus-bg-color;
     outline-offset: 0;
-
-    &:hover {
-      box-shadow: none;
-    }
   }
 }
 
@@ -87,15 +80,15 @@
   }
 
   &:active,
-  &:focus,
-  &:focus:hover {
+  &:focus-visible,
+  &:focus-visible:hover {
     background-color: transparent;
     color: inherit;
   }
 
-  &:focus,
-  &:focus:hover {
-    @include lg-outer-focus-outline;
+  &:focus-visible,
+  &:focus-visible:hover {
+    @include lg-focus-outline();
   }
 }
 
@@ -364,9 +357,8 @@ $breakpoints: (
     width: auto;
   }
 
-  &:focus,
-  &:hover:focus,
-  &:focus-visible {
+  &:focus-visible,
+  &:hover:focus-visible {
     background-color: var(--nav-item-bg-color-hover);
     color: var(--nav-item-color-hover);
 
@@ -407,7 +399,7 @@ $breakpoints: (
 
     &[type='button'],
     &[type='button']:hover,
-    &[type='button']:hover:focus {
+    &[type='button']:hover:focus-visible {
       background-color: var(--nav-item-bg-color-expanded);
       color: var(--nav-item-color-expanded);
 


### PR DESCRIPTION
# Description

This PR:
- Replaces instances of `:focus` with `:focus-visible`.
- Removes the old `lg-outer-focus-outline` mixin and updates instances of it in components with the newer one `lg-focus-outline`.
- Adds default color to existing `lg-inner-focus-outline` mixin.

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
