### PR TITLE
Update card navigation title to handle internal links

### DIFF
--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.html
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.html
@@ -1,6 +1,13 @@
 <lg-heading [level]="headingLevel" *ngIf="link && title && headingLevel">
-  <a href="{{link}}" (click)="linkClicked()">
-    {{title}}
-    <lg-icon name="arrow-right"></lg-icon>
+  <a *ngIf="externalLink" [href]="link" (click)="linkClicked()">
+    <ng-container [ngTemplateOutlet]="linkContent"></ng-container>
+  </a>
+  <a *ngIf="!externalLink" [routerLink]="[link]" [queryParams]="queryParams" [queryParamsHandling]="queryParamsHandling" (click)="linkClicked()">
+    <ng-container [ngTemplateOutlet]="linkContent"></ng-container>
   </a>
 </lg-heading>
+
+<ng-template #linkContent>
+  {{title}}
+  <lg-icon name="arrow-right"></lg-icon>
+</ng-template>

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { MockComponents, MockedComponentFixture, MockRender } from 'ng-mocks';
+import { MockComponents, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { spy, verify } from '@typestrong/ts-mockito';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { LgHeadingComponent } from '../../heading/heading.component';
 import { LgIconComponent } from '../../icon';
@@ -24,8 +25,13 @@ describe('LgCardNavigationTitleComponent', () => {
         LgCardNavigationTitleComponent,
         MockComponents(LgHeadingComponent, LgIconComponent),
       ],
+      imports: [ RouterTestingModule ],
     }).compileComponents();
   }));
+
+  afterEach(() => {
+    ngMocks.flushTestBed();
+  });
 
   describe('when the link, title and heading level are set', () => {
     beforeEach(() => {
@@ -71,6 +77,27 @@ describe('LgCardNavigationTitleComponent', () => {
       verify(linkClickedEventSpy.emit()).once();
 
       expect().nothing();
+    });
+
+    it('should know whether the link is external or internal', () => {
+      expect(component['externalLink']).toBeTrue();
+
+      fixture = MockRender(
+        `
+        <lg-card-navigation-title [title]="title" [link]="link" [headingLevel]="headingLevel">
+        </lg-card-navigation-title>
+      `,
+        {
+          title: 'Payments',
+          link: '/test-path',
+          headingLevel: 4,
+        },
+      );
+
+      debugElement = fixture.debugElement;
+      component = debugElement.children[0].componentInstance;
+
+      expect(component['externalLink']).toBeFalse();
     });
   });
 

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.ts
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.ts
@@ -5,10 +5,13 @@ import {
   Input,
   OnInit,
   Output,
+  SimpleChanges,
   ViewEncapsulation,
 } from '@angular/core';
+import { Params, QueryParamsHandling } from '@angular/router';
 
 import type { HeadingLevel } from '../../heading';
+import isExternalURL from '../../utils/external-links';
 
 @Component({
   selector: 'lg-card-navigation-title',
@@ -21,15 +24,24 @@ import type { HeadingLevel } from '../../heading';
   },
 })
 export class LgCardNavigationTitleComponent implements OnInit {
+  protected externalLink: boolean;
   @Input() headingLevel: HeadingLevel;
   @Input() title = '';
   @Input() link = '';
+  @Input() queryParams?: Params = null;
+  @Input() queryParamsHandling?: QueryParamsHandling = null;
   @Output() linkClickedEvent = new EventEmitter<void>();
 
   ngOnInit(): void {
     if (!(this.headingLevel && this.title && this.link)) {
       // eslint-disable-next-line no-console
       console.error('headingLevel, title and link must be set');
+    }
+  }
+
+  ngOnChanges({ link }: SimpleChanges): void {
+    if (link?.currentValue) {
+      this.externalLink = isExternalURL(link?.currentValue);
     }
   }
 

--- a/projects/canopy/src/lib/card/card.module.ts
+++ b/projects/canopy/src/lib/card/card.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterLinkWithHref } from '@angular/router';
 
 import { LgHeadingModule } from '../heading/heading.module';
 import { lgIconArrowRight, LgIconModule, LgIconRegistry } from '../icon';
@@ -33,7 +34,7 @@ const components = [
 ];
 
 @NgModule({
-  imports: [ CommonModule, LgHeadingModule, LgIconModule ],
+  imports: [ CommonModule, LgHeadingModule, LgIconModule, RouterLinkWithHref ],
   declarations: [ components ],
   exports: [ components ],
 })

--- a/projects/canopy/src/lib/card/docs/card.stories.ts
+++ b/projects/canopy/src/lib/card/docs/card.stories.ts
@@ -4,6 +4,7 @@ import {
   UntypedFormGroup,
   ReactiveFormsModule,
 } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { moduleMetadata, Story } from '@storybook/angular';
 
 import { LgGridModule } from '../../grid/grid.module';
@@ -164,6 +165,7 @@ export default {
         LgPaddingModule,
         LgMarginModule,
         LgSeparatorModule,
+        RouterModule.forRoot([]),
       ],
     }),
   ],
@@ -214,7 +216,7 @@ defaultCard.parameters = {
 const navigationCardTemplate = `
 <lg-card>
   <lg-card-header>
-    <lg-card-navigation-title [title]="title" link="https://www.landg.com" [headingLevel]="headingLevel"></lg-card-navigation-title>
+    <lg-card-navigation-title [title]="title" [link]="link" [queryParams]="queryParams" [queryParamsHandling]="queryParamsHandling" [headingLevel]="headingLevel"></lg-card-navigation-title>
   </lg-card-header>
   <lg-card-content>
     {{cardContent}} <a href="#">Test link</a>.
@@ -231,6 +233,9 @@ export const navigationCard = navigationCardStory.bind({});
 navigationCard.storyName = 'Card Navigation';
 
 navigationCard.args = {
+  link: 'https://www.landg.com',
+  queryParams: null,
+  queryParamsHandling: null,
   headingLevel: 2,
   title: 'The title',
   cardContent: content,
@@ -240,6 +245,19 @@ navigationCard.parameters = {
   docs: {
     source: {
       code: navigationCardTemplate,
+    },
+  },
+};
+
+navigationCard.argTypes = {
+  queryParams: {
+    table: {
+      disable: true,
+    },
+  },
+  queryParamsHandling: {
+    table: {
+      disable: true,
     },
   },
 };

--- a/projects/canopy/src/lib/card/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/guide.stories.mdx
@@ -121,11 +121,15 @@ This is where the main title and link should be provided. It should be located i
 
 #### Inputs
 
-| Name           | Description                                                            | Type     | Default | Required |
-|----------------|------------------------------------------------------------------------|----------|---------|----------|
-| `headingLevel` | The level of the card navigation heading: `1`, `2`, `3`, `4`, `5`, `6` | `number` | n/a     | Yes      |
-| `title`        | The title of the card navigation heading:                              | `string` | `''`    | Yes      |
-| `link`         | The link for the card navigation heading:                              | `string` | `''`    | Yes      |
+| Name                  | Description                                                            | Type                  | Default | Required |
+|-----------------------|------------------------------------------------------------------------|-----------------------|---------|----------|
+| `headingLevel`        | The level of the card navigation heading: `1`, `2`, `3`, `4`, `5`, `6` | `number`              | n/a     | Yes      |
+| `title`               | The title of the card navigation heading                               | `string`              | `''`    | Yes      |
+| `link`                | The link for the card navigation heading                               | `string`              | `''`    | Yes      |
+| `queryParams`         | The query params for the **internal** link [^*]                        | `Params`              | `null`  | No       |
+| `queryParamsHandling` | The query params handling for the **internal** link [^*]               | `QueryParamsHandling` | `null`  | No       |
+
+[^*]: See Angular documentation for the <a href="https://angular.io/api/router/RouterLink#routerlink" target="_blank">RouterLink</a>.
 
 #### Outputs
 

--- a/projects/canopy/src/lib/utils/external-links.spec.ts
+++ b/projects/canopy/src/lib/utils/external-links.spec.ts
@@ -1,0 +1,15 @@
+import isExternalURL from './external-links';
+
+describe('#isExternalURL', () => {
+  it('should return true when the url is external', () => {
+    expect(isExternalURL('http://test.com')).toBeTrue();
+  });
+
+  it('should return false when the url has the same location origin', () => {
+    expect(isExternalURL(`${location.origin}/this-is-an-internal-path`)).toBeFalse();
+  });
+
+  it('should return false when passing a path is internal', () => {
+    expect(isExternalURL('/this-is-an-internal-path')).toBeFalse();
+  });
+});

--- a/projects/canopy/src/lib/utils/external-links.ts
+++ b/projects/canopy/src/lib/utils/external-links.ts
@@ -1,0 +1,7 @@
+export default function isExternalURL(url): boolean {
+  try {
+    return new URL(url).origin !== location.origin;
+  } catch {
+    return false;
+  }
+}

--- a/projects/canopy/src/lib/utils/external-links.ts
+++ b/projects/canopy/src/lib/utils/external-links.ts
@@ -1,4 +1,4 @@
-export default function isExternalURL(url): boolean {
+export default function isExternalURL(url: string): boolean {
   try {
     return new URL(url).origin !== location.origin;
   } catch {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1mGE4UESnBOdepcCGp60hDytvw5cx7T8A%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=N4Vbj6o)
# Description

This PR fixes a bug where internal links where causing an app to reload when using the `lg-card-navigation-title` (as described here: https://github.com/Legal-and-General/canopy/discussions/1169)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
