### PR TITLE
fix(date-field): a11y issue with labels

### DIFF
--- a/projects/canopy/src/lib/forms/date/date-field.component.html
+++ b/projects/canopy/src/lib/forms/date/date-field.component.html
@@ -13,11 +13,10 @@
     #dateFormDirective="ngForm"
   >
     <div class="lg-date-field__date">
-      <label lg-label [for]="dateId">Day</label>
       <lg-input-field lgMarginBottom="none">
+        Day
         <input
           lgInput
-          [id]="dateId"
           (blur)="onBlur()"
           (input)="date.setValue($event.target.value)"
           formControlName="date"
@@ -31,11 +30,10 @@
     </div>
 
     <div class="lg-date-field__month">
-      <label lg-label [for]="monthId">Month</label>
       <lg-input-field lgMarginBottom="none">
+        Month
         <input
           lgInput
-          [id]="monthId"
           (blur)="onBlur()"
           (input)="month.setValue($event.target.value)"
           formControlName="month"
@@ -49,11 +47,10 @@
     </div>
 
     <div class="lg-date-field__year">
-      <label lg-label [for]="yearId">Year</label>
       <lg-input-field lgMarginBottom="none">
+        Year
         <input
           lgInput
-          [id]="yearId"
           (blur)="onBlur()"
           (input)="year.setValue($event.target.value)"
           formControlName="year"

--- a/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
@@ -226,14 +226,6 @@ describe('LgDateFieldComponent', () => {
     expect(component.form.controls.dateOfBirth.value).toEqual('1944-03-07');
   });
 
-  it('sets unique identifiers for each input field', () => {
-    fixture.detectChanges();
-
-    expect(/lg-input-year-\d{1,3}/.test(yearInput.nativeElement.id)).toBe(true);
-    expect(/lg-input-month-\d{1,3}/.test(monthInput.nativeElement.id)).toBe(true);
-    expect(/lg-input-date-\d{1,3}/.test(dateInput.nativeElement.id)).toBe(true);
-  });
-
   it('replaces empty fields with an empty string if date is not complete', done => {
     fixture.detectChanges();
 


### PR DESCRIPTION
# Description

This PR fixes an issue with the `LgDateFieldComponent` where an empty duplicate label is generated. To fix this, I have removed the custom label and just used the default label generated by the `LgInputComponent` for each of the date inputs. This removes the need to specify custom ids as that will now be handled by the default behaviour in the children`LgInputComponent`s

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
