### PR TITLE
Fix card content styling

### DIFF
--- a/projects/canopy/src/lib/card/card-content/card-content.component.ts
+++ b/projects/canopy/src/lib/card/card-content/card-content.component.ts
@@ -21,7 +21,7 @@ export class LgCardContentComponent {
     descendants: true,
   })
   dataPoints: QueryList<LgDataPointComponent>;
-  @HostBinding('class.lg-card-content--data-points') dataPointsClass() {
+  @HostBinding('class.lg-card-content--data-points') get dataPointsClass() {
     return this.dataPoints.length;
   }
 }


### PR DESCRIPTION
# Description

Have fixed the logic that applies the `lg-card-content--data-points` class to `lg-card-content` when `lg-data-point` is/are present in it. Previously the class was always being applied.

Fixes #1192


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
