### PR TITLE
fix(card): move data points styles in card-content-inner-data-points

### DIFF
--- a/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.html
+++ b/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.html
@@ -1,0 +1,1 @@
+<ng-content select="lg-data-point, lg-data-point-list"></ng-content>

--- a/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.scss
+++ b/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.scss
@@ -1,4 +1,4 @@
-.lg-card-content--data-points {
+.lg-card-content-inner-data-points {
   display: grid;
   grid-column-gap: var(--space-sm);
   grid-template:

--- a/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LgCardContentInnerDataPointsComponent } from './card-content-inner-data-points.component';
+
+describe('LgCardContentInnerDataPointsComponent', () => {
+  let component: LgCardContentInnerDataPointsComponent;
+  let fixture: ComponentFixture<LgCardContentInnerDataPointsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LgCardContentInnerDataPointsComponent ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgCardContentInnerDataPointsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain(
+      'lg-card-content-inner-data-points',
+    );
+  });
+});

--- a/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.ts
+++ b/projects/canopy/src/lib/card/card-content-inner-data-points/card-content-inner-data-points.component.ts
@@ -1,0 +1,11 @@
+import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'lg-card-content-inner-data-points',
+  templateUrl: './card-content-inner-data-points.component.html',
+  styleUrls: [ './card-content-inner-data-points.component.scss' ],
+  encapsulation: ViewEncapsulation.None,
+})
+export class LgCardContentInnerDataPointsComponent {
+  @HostBinding('class.lg-card-content-inner-data-points') class = true;
+}

--- a/projects/canopy/src/lib/card/card-content/card-content.component.ts
+++ b/projects/canopy/src/lib/card/card-content/card-content.component.ts
@@ -1,27 +1,10 @@
-import {
-  Component,
-  ContentChildren,
-  forwardRef,
-  HostBinding,
-  QueryList,
-  ViewEncapsulation,
-} from '@angular/core';
-
-import { LgDataPointComponent } from '../../data-point';
+import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'lg-card-content',
   templateUrl: './card-content.component.html',
-  styleUrls: [ './card-content.component.scss' ],
   encapsulation: ViewEncapsulation.None,
 })
 export class LgCardContentComponent {
   @HostBinding('class.lg-card-content') class = true;
-  @ContentChildren(forwardRef(() => LgDataPointComponent), {
-    descendants: true,
-  })
-  dataPoints: QueryList<LgDataPointComponent>;
-  @HostBinding('class.lg-card-content--data-points') get dataPointsClass() {
-    return this.dataPoints.length;
-  }
 }

--- a/projects/canopy/src/lib/card/card.module.ts
+++ b/projects/canopy/src/lib/card/card.module.ts
@@ -17,6 +17,7 @@ import { LgCardComponent } from './card.component';
 import { LgCardFooterComponent } from './card-footer/card-footer.component';
 import { LgCardToggableContentComponent } from './card-toggable-content/card-toggable-content.component';
 import { LgCardNavigationTitleComponent } from './card-navigation-title/card-navigation-title.component';
+import { LgCardContentInnerDataPointsComponent } from './card-content-inner-data-points/card-content-inner-data-points.component';
 
 const components = [
   LgCardComponent,
@@ -29,6 +30,7 @@ const components = [
   LgCardPrincipleDataPointValueComponent,
   LgCardPrincipleDataPointDateComponent,
   LgCardContentComponent,
+  LgCardContentInnerDataPointsComponent,
   LgCardToggableContentComponent,
   LgCardNavigationTitleComponent,
 ];

--- a/projects/canopy/src/lib/card/docs/card.stories.ts
+++ b/projects/canopy/src/lib/card/docs/card.stories.ts
@@ -394,43 +394,55 @@ showMoreCard.parameters = {
   },
 };
 
+const dataPointsCardTemplate = `
+<lg-card>
+  <lg-card-header>
+    <lg-card-navigation-title title="Data Points" link="#" [headingLevel]="2"></lg-card-navigation-title>
+  </lg-card-header>
+  <lg-card-content>
+    <lg-card-content-inner-data-points>
+      <lg-data-point *ngFor="let number of [].constructor(dataPoints); let i = index;">
+        <lg-data-point-label [headingLevel]="3">
+          {{data[i].label}}
+        </lg-data-point-label>
+        <lg-data-point-value>
+          {{data[i].value}}
+        </lg-data-point-value>
+      </lg-data-point>
+    </lg-card-content-inner-data-points>
+  </lg-card-content>
+  <lg-card-footer>
+    <lg-link-menu>
+      <a href="" target="_blank">
+        <lg-link-menu-item>
+          <lg-link-menu-item-heading>Link menu item 1</lg-link-menu-item-heading>
+        </lg-link-menu-item>
+      </a>
+      <a href="">
+        <lg-link-menu-item>
+          <lg-link-menu-item-heading>Link menu item 2</lg-link-menu-item-heading>
+        </lg-link-menu-item>
+      </a>
+    </lg-link-menu>
+  </lg-card-footer>
+</lg-card>
+`;
+
 const dataPointsCardStory: Story<LgCardComponent> = (args: LgCardComponent) => ({
   props: args,
-  template: `
-    <lg-card>
-      <lg-card-header>
-        <lg-card-navigation-title title="Data Points" link="#" [headingLevel]="2"></lg-card-navigation-title>
-      </lg-card-header>
-      <lg-card-content>
-        <lg-data-point *ngFor="let number of [].constructor(dataPoints); let i = index;">
-          <lg-data-point-label [headingLevel]="3">
-            {{data[i].label}}
-          </lg-data-point-label>
-          <lg-data-point-value>
-            {{data[i].value}}
-          </lg-data-point-value>
-        </lg-data-point>
-      </lg-card-content>
-      <lg-card-footer>
-        <lg-link-menu>
-          <a href="" target="_blank">
-            <lg-link-menu-item>
-              <lg-link-menu-item-heading>Link menu item 1</lg-link-menu-item-heading>
-            </lg-link-menu-item>
-          </a>
-          <a href="">
-            <lg-link-menu-item>
-              <lg-link-menu-item-heading>Link menu item 2</lg-link-menu-item-heading>
-            </lg-link-menu-item>
-          </a>
-        </lg-link-menu>
-      </lg-card-footer>
-    </lg-card>
-  `,
+  template: dataPointsCardTemplate,
 });
 
 export const dataPointsCard = dataPointsCardStory.bind({});
 dataPointsCard.storyName = 'Data points';
+
+dataPointsCard.parameters = {
+  docs: {
+    source: {
+      code: dataPointsCardTemplate,
+    },
+  },
+};
 
 dataPointsCard.argTypes = {
   dataPoints: {

--- a/projects/canopy/src/lib/card/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/guide.stories.mdx
@@ -87,6 +87,12 @@ This component uses some extra card components, such as `LgCardNavigationTitleCo
 
 <Source id="components-card-examples--navigation-card"></Source>
 
+### Card with Data Points
+
+This component uses some extra card components, such as `LgCardContentInnerDataPoints` to display the correct layout of data points.
+
+<Source id="components-card-examples--data-points-card"></Source>
+
 ## Additional development details
 
 ### LgCardComponent
@@ -104,6 +110,10 @@ This is the primary layout section of the card component, it is used to contain 
 ### LgCardContent
 
 This is the secondary layout section of the card component, it is used to contain the cards main content and provides the inner padding of the card.
+
+### LgCardContentInnerDataPoints
+
+This is the tertiary layout section of the card component, it is used to specifically contain data points components and provides their layout styles.
 
 ### LgCardTitleComponent
 

--- a/projects/canopy/src/lib/card/index.ts
+++ b/projects/canopy/src/lib/card/index.ts
@@ -1,4 +1,5 @@
 export * from './card-content/card-content.component';
+export * from './card-content-inner-data-points/card-content-inner-data-points.component';
 export * from './card-header/card-header.component';
 export * from './card-principle-data-point-date/card-principle-data-point-date.component';
 export * from './card-principle-data-point-label/card-principle-data-point-label.component';


### PR DESCRIPTION
# Description

This fixes more bugs with the data-points within the card content.
Having the styles within the card-content was breaking the layout of the card whenever there was more than just data-points in it. This PR adds a new component that wraps the styles specific to the data points so that they are not applied to everything else.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
