### PR TITLE
Fixed input field un-focus on focus

### DIFF
--- a/projects/canopy/src/lib/forms/input/docs/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/docs/input.stories.ts
@@ -349,3 +349,12 @@ setupInputStoryValues(withMultipleButtonSuffixes, inputTemplate, {
   showButtonFirstSuffix: true,
   showButtonSecondSuffix: true,
 });
+
+export const withTextPrefix = inputStory.bind({});
+withTextPrefix.storyName = 'With text prefix';
+
+setupInputStoryValues(withTextPrefix, inputTemplate, {
+  showTextPrefix: true,
+  label: 'Amount',
+  hint: null,
+});

--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -23,13 +23,7 @@
     }
   }
 
-  &--focus .lg-input {
-    padding-left: calc(var(--space-sm) - var(--keyline-width) + var(--border-width));
-  }
-
   &--focus &__prefix {
-    margin-left: calc(var(--suffix-margin) - var(--keyline-width) + var(--border-width));
-
     + .lg-input {
       padding-left: var(--space-sm);
     }

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -18,7 +18,6 @@
   }
 
   &:focus-visible {
-    padding-left: calc(var(--space-sm) - var(--keyline-width) + var(--border-width));
     @include lg-focus-outline();
   }
 


### PR DESCRIPTION
# Description

- Removes keyline padding and margin in the input field and select form that was introduced by changes to the focus on the 10.9.0 version. 
- Update storybook documentation for the input field to includes the prefix example.

Fixes #1200

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [x] I have added any new public feature modules to public-api.ts
