### PR TITLE
FEP-1772: Fix top padding for lg-card-footer with lg-link-menu

### DIFF
--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.ts
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.ts
@@ -1,7 +1,10 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   HostBinding,
+  Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -12,6 +15,17 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LgCardFooterComponent {
+export class LgCardFooterComponent implements AfterViewInit {
   @HostBinding('class.lg-card-footer') class = true;
+
+  constructor(private renderer: Renderer2, private hostElement: ElementRef) {}
+
+  ngAfterViewInit() {
+    const parentElem = this.hostElement.nativeElement as HTMLElement;
+    const firstChildElem = parentElem.firstChild as HTMLElement;
+
+    if (firstChildElem.localName === 'lg-link-menu') {
+      this.renderer.addClass(parentElem, 'lg-padding__top--none');
+    }
+  }
 }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19X2p4vVe6exuqLxPzG7OZXYoUGOgFmCg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=z3l3fp7)
# Description

Removes top padding for lg-card-footer items that have lg-link-menu as first child

Fixes #1192 

# Checklist:

- [X] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [X] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [X] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
