### PR TITLE
FEP-1772: remove top padding from card-footer story

### DIFF
--- a/projects/canopy/src/lib/card/docs/card.stories.ts
+++ b/projects/canopy/src/lib/card/docs/card.stories.ts
@@ -411,7 +411,7 @@ const dataPointsCardTemplate = `
       </lg-data-point>
     </lg-card-content-inner-data-points>
   </lg-card-content>
-  <lg-card-footer>
+  <lg-card-footer lgPaddingTop="none">
     <lg-link-menu>
       <a href="" target="_blank">
         <lg-link-menu-item>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19X2p4vVe6exuqLxPzG7OZXYoUGOgFmCg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=z3l3fp7)
# Description

Removes top padding for lg-card-footer items that have lg-link-menu as first child

Fixes https://github.com/Legal-and-General/canopy/issues/1192

# Checklist:

- [X] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [X] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [X] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
