### PR TITLE
ci(storybook): update prefix for folders to build in

### DIFF
--- a/.github/workflow-scripts/gh-pages/deploy.js
+++ b/.github/workflow-scripts/gh-pages/deploy.js
@@ -14,13 +14,13 @@ module.exports = async ({
   if (branch === 'master') {
     console.info('ℹ️ Branch to deploy: master');
     console.info('ℹ️ Running storybook build');
-    await exec.exec('npm', ['run', 'build:storybook', '--', '--output-dir', 'sb-build']);
+    await exec.exec('npm', ['run', 'build:storybook', '--', '--output-dir', 'lg-sb-build']);
 
     await deploy({ branch, sha, repo, owner, docsPath, github, exec });
   } else {
     console.info(`ℹ️ Branch to deploy: ${branch}`);
 
-    docsPath = `./docs/sb-${branch}`;
+    docsPath = `./docs/lg-sb-${branch}`;
 
     const checksPassed = await evaluatePullChecks({
       sha,
@@ -89,14 +89,14 @@ async function deploy({ branch, sha, repo, owner, docsPath, github, exec }) {
       if (branch === 'master') {
         // for master we want to clean everything from `./docs` with the exception of the directories of the deployed branches
         const filesToRemove = fs.readdirSync('./docs', { withFileTypes: true })
-          .filter(item => !item.name.startsWith('sb-'))
+          .filter(item => !item.name.startsWith('lg-sb-'))
           .map(({ name }) => name);
 
         for (const file of filesToRemove) {
           await exec.exec('rm', ['-rf', `./docs/${file}`]);
         }
       } else {
-        // for a branch we want to clean the specific branch folder e.g. `./docs/sb-<branch-name>`
+        // for a branch we want to clean the specific branch folder e.g. `./docs/lg-sb-<branch-name>`
         await exec.exec('rm', ['-rf', docsPath]);
       }
 
@@ -115,14 +115,14 @@ async function deploy({ branch, sha, repo, owner, docsPath, github, exec }) {
     if (branch === 'master') {
       // gh-pages only works in the root directory, or '/docs'
       // moving one file at the time because using `*` in the mv command breaks the code
-      const sbFiles = fs.readdirSync('./sb-build', { withFileTypes: true }).map(({ name }) => name);
+      const sbFiles = fs.readdirSync('./lg-sb-build', { withFileTypes: true }).map(({ name }) => name);
 
       for (const file of sbFiles) {
-        await exec.exec('mv', [`./sb-build/${file}`, './docs/']);
+        await exec.exec('mv', [`./lg-sb-build/${file}`, './docs/']);
       }
 
-      await exec.exec('rm', ['-rf', './sb-build']);
-      await exec.exec('git', ['add', './sb-build']);
+      await exec.exec('rm', ['-rf', './lg-sb-build']);
+      await exec.exec('git', ['add', './lg-sb-build']);
     }
 
     console.info('ℹ️ Adding storybook static files');
@@ -150,8 +150,8 @@ async function undeploy({ branch, repo, owner, github, exec }) {
   try {
     // get the existing deployed branches from the docs folder (removing the prefix)
     const branches = fs.readdirSync('./docs', { withFileTypes: true })
-      .filter(item => item.isDirectory() && item.name.startsWith('sb-') && item.name !== `sb-${branch}`)
-      .map(({ name }) => name.replace(/^sb-/, ''));
+      .filter(item => item.isDirectory() && item.name.startsWith('lg-sb-') && item.name !== `lg-sb-${branch}`)
+      .map(({ name }) => name.replace(/^lg-sb-/, ''));
 
     if (!branches.length) {
       console.info(`✅️ Skipping: no environments to un-deploy`);
@@ -175,8 +175,8 @@ async function undeploy({ branch, repo, owner, github, exec }) {
 
     for (const branch of branchesToUndeploy) {
       console.info(`ℹ️ Removing storybook static files for branch ${branch}`);
-      await exec.exec('rm', ['-rf', `./docs/sb-${branch}`]);
-      await exec.exec('git', ['add', `./docs/sb-${branch}`]);
+      await exec.exec('rm', ['-rf', `./docs/lg-sb-${branch}`]);
+      await exec.exec('git', ['add', `./docs/lg-sb-${branch}`]);
 
       try {
         console.info('ℹ️ Committing changes');

--- a/.github/workflow-scripts/gh-pages/download-branch-deploy-artifact.js
+++ b/.github/workflow-scripts/gh-pages/download-branch-deploy-artifact.js
@@ -22,11 +22,11 @@ module.exports = async ({
     const { data } = await github.rest.actions.downloadArtifact({
       owner,
       repo,
-      artifact_id: artifacts.find(({ name }) => name === 'sb-build').id,
+      artifact_id: artifacts.find(({ name }) => name === 'lg-sb-build').id,
       archive_format: 'zip'
     });
 
-    fs.writeFileSync('./sb-build.zip', Buffer.from(data));
+    fs.writeFileSync('./lg-sb-build.zip', Buffer.from(data));
   } catch {
     throw `🚫 Error: no artifacts found`;
   }

--- a/.github/workflow-scripts/gh-pages/get-pr-data.js
+++ b/.github/workflow-scripts/gh-pages/get-pr-data.js
@@ -16,7 +16,7 @@ module.exports = async ({
       sha,
       branch,
       pullNumber,
-      environmentUrl: `https://legal-and-general.github.io/canopy/sb-${branch}`
+      environmentUrl: `https://legal-and-general.github.io/canopy/lg-sb-${branch}`
     };
   } catch {
     throw `🚫 Error: PR #${pullNumber} was not found`;

--- a/.github/workflows/branch_pages_deploy.yml
+++ b/.github/workflows/branch_pages_deploy.yml
@@ -45,8 +45,8 @@ jobs:
             });
 
       - run: |
-          unzip sb-build.zip -d ./docs/sb-'${{ fromJSON(steps.prData.outputs.result).branch }}'
-          rm sb-build.zip
+          unzip lg-sb-build.zip -d ./docs/lg-sb-'${{ fromJSON(steps.prData.outputs.result).branch }}'
+          rm lg-sb-build.zip
 
       - name: 'Notify GitHub of branch deployment'
         uses: actions/github-script@v6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,8 +50,8 @@ jobs:
         run: npm run build:test-app
 
       - name: 'Build storybook'
-        run: npm run build:storybook -- --output-dir ./sb-build
+        run: npm run build:storybook -- --output-dir ./lg-sb-build
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: sb-build
-          path: ./sb-build
+          name: lg-sb-build
+          path: ./lg-sb-build


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18sUE1LaqFLvbY5AuTv1elGhuBAqh9k%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=U-oXJ23)

# Description

The `sb-` prefix we use is now conflicting with the one from Storybook. In our scripts for `master` deployment we remove some of the folders with `sb-` as prefix and this now breaks the main environment as it removes some folder assets needed by Storybook to run ([`.github/workflow-scripts/gh-pages/deploy.js`](https://github.com/Legal-and-General/canopy/blob/master/.github/workflow-scripts/gh-pages/deploy.js#L153)). Our prefix is now more specific: `lg-sb-`.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
