### PR TITLE
docs: fix docs paths as Storybook 7 has updated them

### DIFF
--- a/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
@@ -116,9 +116,9 @@ This component is based on best practice and has not had specific usability test
 
 Consider using an accordion instead of the **details component** if there are multiple related sections of content. **Tabs** would be an alternative way to display if there's a large amount of content.
 
-- [Card](./?path=/docs/components-card-guide--page)
-- [Details](./?path=/docs/components-details-guide--page)
-- [Tabs](./?path=/docs/components-tabs-guide--page)
+- [Card](./?path=/docs/components-card-guide--docs)
+- [Details](./?path=/docs/components-details-guide--docs)
+- [Tabs](./?path=/docs/components-tabs-guide--docs)
 
 <Markdown>{Feedback}</Markdown>
 

--- a/projects/canopy/src/lib/alert/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/alert/docs/guide.stories.mdx
@@ -113,7 +113,7 @@ This is based on best practice.
 
 ## Related
 
-- [Details](./?path=/docs/components-details-guide--page)
-- [Primary message](./?path=/docs/components-primary-message-guide--page)
+- [Details](./?path=/docs/components-details-guide--docs)
+- [Primary message](./?path=/docs/components-primary-message-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/brand-icon/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/brand-icon/docs/guide.stories.mdx
@@ -122,6 +122,6 @@ The halftone and outlines colours can only be applied to a specific icon using t
 
 ## Related
 
-- [UI icon](./?path=/docs/foundations-ui-icon-guide--page)
+- [UI icon](./?path=/docs/foundations-ui-icon-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/button/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/button/docs/guide.stories.mdx
@@ -237,7 +237,7 @@ ngAfterContentInit(): void {
 
 
 
-To see an example of the toggle button set up correctly inside a container, and toggling the visibility of a panel, see the [filter container story](./?path=/docs/patterns-filter-container-guide--page).
+To see an example of the toggle button set up correctly inside a container, and toggling the visibility of a panel, see the [filter container story](./?path=/docs/patterns-filter-container-guide--docs).
 
 ------
 
@@ -249,7 +249,7 @@ States have been updated to be more accessible based on external accessibility t
 
 ## Related
 
-- [Quick action](./?path=/docs/components-quick-action-guide--page)
-- [Link](./?path=/docs/components-quick-action-guide--page)
+- [Quick action](./?path=/docs/components-quick-action-guide--docs)
+- [Link](./?path=/docs/components-quick-action-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/card/docs/card/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/card/guide.stories.mdx
@@ -210,7 +210,7 @@ This component hasn't been subject to any testing, but is based on best practice
 
 Patterns which may perform a similar task, or which should be considered instead:
 
-- [Accordion](./?path=/docs/components-accordion-guide--page)
-- [Details](./?path=/docs/components-details-guide--page)
+- [Accordion](./?path=/docs/components-accordion-guide--docs)
+- [Details](./?path=/docs/components-details-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/card/docs/promotions/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/promotions/guide.stories.mdx
@@ -426,7 +426,7 @@ This component hasn't been subject to any testing, but is based on best practice
 
 Patterns which may perform a similar task, or which should be considered instead:
 
-- [Cards](./?path=/docs/components-card-guide--page)
-- [Promo Cards](./?path=/docs/components-promo-cards-guide--page)
+- [Cards](./?path=/docs/components-card-guide--docs)
+- [Promo Cards](./?path=/docs/components-promo-cards-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/details/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/details/docs/guide.stories.mdx
@@ -34,7 +34,7 @@ The component has **not** been designed for large amounts of information or rich
 
 
 
-The Details component can also be styled to match the [inline message component](./?path=/docs/components-inline-message-alert-guide--page) with `warning`, `info`, `success` and `error` colouring. This lets you highlight information in different ways depending on severity. In the above example, we've used the `info` variation to highlight a message telling the user they triggered a Money Purchase Annual Allowance.
+The Details component can also be styled to match the [inline message component](./?path=/docs/components-inline-message-alert-guide--docs) with `warning`, `info`, `success` and `error` colouring. This lets you highlight information in different ways depending on severity. In the above example, we've used the `info` variation to highlight a message telling the user they triggered a Money Purchase Annual Allowance.
 
 **These colours should be used sparingly; the generic variation should suitable for most situations.**
 
@@ -95,6 +95,6 @@ More research to be conducted into whether the error state should be deprecated,
 
 ## Related
 
-If you need to hide large amounts of content, the [accordion component](./?path=/docs/components-accordion-guide--page) may be more suitable.
+If you need to hide large amounts of content, the [accordion component](./?path=/docs/components-accordion-guide--docs) may be more suitable.
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/docs/foundation/colours/colours.stories.mdx
+++ b/projects/canopy/src/lib/docs/foundation/colours/colours.stories.mdx
@@ -54,7 +54,7 @@ The rest of our colour palette expands on the four core colours. We use compleme
 - Data visualisation
 - Illustration
 - Infographics
-- [Brand icons](./?path=/docs/foundations-brand-icon-guide--page)
+- [Brand icons](./?path=/docs/foundations-brand-icon-guide--docs)
 
 
 

--- a/projects/canopy/src/lib/docs/foundation/layout-grid-and-spacing.stories.mdx
+++ b/projects/canopy/src/lib/docs/foundation/layout-grid-and-spacing.stories.mdx
@@ -90,10 +90,10 @@ Don't be afraid to use liberal vertical spacing – white space is an asset the 
 
 ## Additional directives
 
-- A set of [Angular directives](./?path=/docs/helpers-directives-grid-guide--page) are also supplied which can be used to add grid classes to native HTML and Canopy elements
-- There is also a [row-gap spacing directive](./?path=/docs/helpers-directives-row-gap-guide--page) to enable the use of the CSS row-gap property
+- A set of [Angular directives](./?path=/docs/helpers-directives-grid-guide--docs) are also supplied which can be used to add grid classes to native HTML and Canopy elements
+- There is also a [row-gap spacing directive](./?path=/docs/helpers-directives-row-gap-guide--docs) to enable the use of the CSS row-gap property
 - There are also two utility directives available which allow you to show/hide components at different breakpoints:
-  - [LgShowAt](./?path=/docs/helpers-directives-show-at-guide--page)
-  - [LgHideAt](./?path=/docs/helpers-directives-hide-at-guide--page)
+  - [LgShowAt](./?path=/docs/helpers-directives-show-at-guide--docs)
+  - [LgHideAt](./?path=/docs/helpers-directives-hide-at-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/docs/foundation/typography/typography.stories.mdx
+++ b/projects/canopy/src/lib/docs/foundation/typography/typography.stories.mdx
@@ -42,7 +42,7 @@ The basis for the expressive scale is Lyon Display, which is our brand typeface.
 - **Do** use consistent headings to indicate hierarchy.
 - **Do** use a minimum of 16px text (`.lg-font-size-1`) for paragraph text or data points. Smaller type may be used for non-essential supporting information.
 - **Do** use bold text to emphasise information.
-- **Do** check colour contrast of text on backgrounds (see [colours](./?path=/docs/foundations-colours--page)).
+- **Do** check colour contrast of text on backgrounds (see [colours](./?path=/docs/foundations-colours--docs)).
 - **Do** centre align text for empty or loading states.
 
 ### Don't

--- a/projects/canopy/src/lib/docs/principles/accessibility/developer.stories.mdx
+++ b/projects/canopy/src/lib/docs/principles/accessibility/developer.stories.mdx
@@ -79,7 +79,7 @@ and in your HTML:
 
 
 
-This is automatically added in Canopy by using the [page component](./?path=/docs/components-primary-message-guide--page).
+This is automatically added in Canopy by using the [page component](./?path=/docs/components-primary-message-guide--docs).
 
 ### Images and alt attributes
 
@@ -95,7 +95,7 @@ It's very important that you **don't omit the `alt` attribute**.
 
 To make videos and audio accessible you have to provide a transcript.
 
-The transcript can be added with Canopy by using the [details component](./?path=/docs/components-details-guide--page).
+The transcript can be added with Canopy by using the [details component](./?path=/docs/components-details-guide--docs).
 
 For videos the recommendation is to add captions which are essentially the transcript synchronised with the video or audio.
 
@@ -111,11 +111,11 @@ A caption identifies the overall topic of a table and is useful in most situatio
 
 
 
-A [table component](./?path=/docs/components-table-guide--page) which follows the above standards is available in Canopy.
+A [table component](./?path=/docs/components-table-guide--docs) which follows the above standards is available in Canopy.
 
 ### Forms
 
-Forms should be logical and easy to use; instructions, cues, required form fields, and field formatting requirements must be clearly identified to users. [Error messages must be intuitive and descriptive](./?path=/docs/principles-writing--page).
+Forms should be logical and easy to use; instructions, cues, required form fields, and field formatting requirements must be clearly identified to users. [Error messages must be intuitive and descriptive](./?path=/docs/principles-writing--docs).
 
 Ensure that forms can be understood and operated with keyboard alone.
 
@@ -224,6 +224,6 @@ For more in depth knowledge on how to make your code accessible we recommend rea
 
 ## Related
 
-- [Accessibility - Overview](./?path=/docs/principles-accessibility-overview--page)
+- [Accessibility - Overview](./?path=/docs/principles-accessibility-overview--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/docs/principles/accessibility/overview.stories.mdx
+++ b/projects/canopy/src/lib/docs/principles/accessibility/overview.stories.mdx
@@ -211,6 +211,6 @@ More resources for designers can be found on <a href="https://webaim.org/resourc
 
 ## Related
 
-- [Accessibility - Developer](./?path=/docs/principles-accessibility-developer--page)
+- [Accessibility - Developer](./?path=/docs/principles-accessibility-developer--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/filter-container/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/filter-container/docs/guide.stories.mdx
@@ -26,6 +26,6 @@ and in your HTML:
 
 The toggle button **must have** the `lgButtonToggle` directive on it for the component to work properly.
 
-More information on how to use the `lgButtonToggle` directive is available in the [button documentation](./?path=/docs/components-button-guide--page). Note that there is no need to set the `id` and `ariaControls` properties in this case as they are already handled by the `LgFilterContainerComponent`.
+More information on how to use the `lgButtonToggle` directive is available in the [button documentation](./?path=/docs/components-button-guide--docs). Note that there is no need to set the `id` and `ariaControls` properties in this case as they are already handled by the `LgFilterContainerComponent`.
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/date/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/date/docs/guide.stories.mdx
@@ -254,6 +254,6 @@ const control = new FormControl('', {
 
 ## Related
 
-- [Form validation](./?path=/docs/components-forms-form-validation-guide--page)
+- [Form validation](./?path=/docs/components-forms-form-validation-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/docs/filter-buttons/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/docs/filter-buttons/guide.stories.mdx
@@ -5,7 +5,7 @@ import Feedback from '../../../docs/common/feedback.md';
 
 # Filter buttons
 
-<p class="standfirst">Filter buttons help users to narrow down large data sets, like their documents or payments, by giving them a clear and friendly option for filtering the data. Filter buttons should usually be contained in a filter container - see the design pattern, <a href="./?path=/docs/patterns-filter-container-guide--page">help user to filter results</a>.</p>
+<p class="standfirst">Filter buttons help users to narrow down large data sets, like their documents or payments, by giving them a clear and friendly option for filtering the data. Filter buttons should usually be contained in a filter container - see the design pattern, <a href="./?path=/docs/patterns-filter-container-guide--docs">help user to filter results</a>.</p>
 
 ![Filter button component example](docs/forms/filter-button/example.png)
 
@@ -15,7 +15,7 @@ Use a filter button when you have 10 or fewer filter options. If the user can on
 
 If there are more than 10 filter options, use radio buttons or check boxes instead to avoid cluttering a filter panel.
 
-Filter buttons are best used in conjunction with the pattern - [help user to filter results](./?path=/docs/patterns-filter-container-guide--page). This pattern provides a container into which filter buttons can be grouped:
+Filter buttons are best used in conjunction with the pattern - [help user to filter results](./?path=/docs/patterns-filter-container-guide--docs). This pattern provides a container into which filter buttons can be grouped:
 
 ![Filter container example](docs/forms/filter-button/filter-container.png)
 
@@ -151,9 +151,9 @@ More research is needed to understand if users sufficiently understand the diffe
 
 ## Related
 
-- [Radio buttons for 'Select one'](./?path=/docs/components-forms-radio-guide--page)
-- [Checkboxes for 'Select multiple'](./?path=/docs/components-forms-checkbox-guide--page)
-- [Segment](./?path=/docs/components-forms-segment-guide--page)
+- [Radio buttons for 'Select one'](./?path=/docs/components-forms-radio-guide--docs)
+- [Checkboxes for 'Select multiple'](./?path=/docs/components-forms-checkbox-guide--docs)
+- [Segment](./?path=/docs/components-forms-segment-guide--docs)
 
 <Markdown>{Feedback}</Markdown>
 

--- a/projects/canopy/src/lib/forms/docs/forms-design.stories.mdx
+++ b/projects/canopy/src/lib/forms/docs/forms-design.stories.mdx
@@ -7,7 +7,7 @@ import Feedback from '../../docs/common/feedback.md?raw';
 
 <p class="standfirst">This page gives an overview of how we should design and build our forms, taking usability and accessibility into account. It is intended to give a clear set of guidelines, based on industry research and best practice.</p>
 
-Many of the behaviours and guidelines described here are encapsulated in the [form journey card](https://legal-and-general.github.io/canopy/?path=/story/components-card-examples--form-journey-card), which should be used any time a form journey is needed.
+Many of the behaviours and guidelines described here are encapsulated in the [form journey card](./?path=/story/components-card-examples--form-journey-card), which should be used any time a form journey is needed.
 
 ## Layout
 
@@ -80,7 +80,7 @@ Make sure your field widths are appropriate to the length of the expected inform
 
 ![validation](docs/forms/forms-design/validation.png)
 
-For more information about form validation, [read the form validation guide](./?path=/docs/components-forms-form-validation-guide--page).
+For more information about form validation, [read the form validation guide](./?path=/docs/components-forms-form-validation-guide--docs).
 
 ## References
 

--- a/projects/canopy/src/lib/forms/input/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/input/docs/guide.stories.mdx
@@ -154,6 +154,6 @@ This component is based on best practice and has not had specific usability test
 
 ## Related
 
-If you need to present a list of options, consider a [select component](./?path=/docs/components-forms-select-guide--page).
+If you need to present a list of options, consider a [select component](./?path=/docs/components-forms-select-guide--docs).
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/radio/docs/radio/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/radio/guide.stories.mdx
@@ -97,9 +97,9 @@ This component is based on best practice and reference from the following articl
 
 ## Related
 
-- [Checkbox](./?path=/docs/components-forms-checkbox-guide--page)
-- [Segment](./?path=/docs/components-forms-segment-guide--page)
-- [Select](./?path=/docs/components-forms-select-guide--page)
-- [Switch](./?path=/docs/components-forms-switch-guide--page)
+- [Checkbox](./?path=/docs/components-forms-checkbox-guide--docs)
+- [Segment](./?path=/docs/components-forms-segment-guide--docs)
+- [Select](./?path=/docs/components-forms-select-guide--docs)
+- [Switch](./?path=/docs/components-forms-switch-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/radio/docs/segment/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/segment/guide.stories.mdx
@@ -110,9 +110,9 @@ This is based on best practice.
 
 Patterns which may perform a similar task, or which should be considered instead:
 
-- [Radio buttons](./?path=/docs/components-forms-radio-guide--page)
-- [Select](./?path=/docs/components-forms-select-guide--page)
-- [Switch](./?path=/docs/components-forms-switch-guide--page)
-- [Checkbox](./?path=/docs/components-forms-checkbox-guide--page)
+- [Radio buttons](./?path=/docs/components-forms-radio-guide--docs)
+- [Select](./?path=/docs/components-forms-select-guide--docs)
+- [Switch](./?path=/docs/components-forms-switch-guide--docs)
+- [Checkbox](./?path=/docs/components-forms-checkbox-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/select/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/select/docs/guide.stories.mdx
@@ -93,6 +93,6 @@ Nielsen Norman Group : <a href="https://www.nngroup.com/articles/drop-down-menus
 Patterns which may perform a similar task, or which should be considered instead:
 
 - [Checkbox](./?path=/docs/components-forms-checkbox--checkbox)
-- [Radio buttons](./?path=/docs/components-forms-radio-guide--page)
+- [Radio buttons](./?path=/docs/components-forms-radio-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/sort-code/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/sort-code/docs/guide.stories.mdx
@@ -8,7 +8,7 @@ import Feedback from '../../../docs/common/feedback.md';
 <p class="standfirst">Provides a directive to apply formatting and specific validators to the input component for entering a sort code.</p>
 
 ## Usage
-Import the sort code and the [text input module](./?path=/docs/components-forms-text-input-guide--page) into your application:
+Import the sort code and the [text input module](./?path=/docs/components-forms-text-input-guide--docs) into your application:
 
 ```js
 @NgModule({
@@ -29,7 +29,7 @@ Both the `lgInput` and `lgSortCode` directives have to be present on the input e
 The sort code directive automatically adds the `required` and `pattern` validators by default.
 The `pattern` validator checks that the sort code value has the following patterns: `000000`, `00 00 00` or `00-00-00`.
 
-See the [form validation guide](./?path=/docs/components-forms-form-validation-guide--page) for additional information.
+See the [form validation guide](./?path=/docs/components-forms-form-validation-guide--docs) for additional information.
 
 ### Format of the control value
 On blur of the input we auto-format the value of the control to `00-00-00`.

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.stories.mdx
@@ -125,6 +125,6 @@ This is based on best practice.
 
 ## Related
 
-Where a definitive positive or negative response is required from the user then maybe the [radio button component](./?path=/docs/components-forms-radio-guide--page) would be more suitable.
+Where a definitive positive or negative response is required from the user then maybe the [radio button component](./?path=/docs/components-forms-radio-guide--docs) would be more suitable.
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/toggle/docs/switch/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/toggle/docs/switch/guide.stories.mdx
@@ -89,9 +89,9 @@ We've based our guidance on best practice and research from these sources:
 
 Patterns which may perform a similar task, or which should be considered instead:
 
-- [Radio buttons](./?path=/docs/components-forms-radio-guide--page)
-- [Segment](./?path=/docs/components-forms-segment-guide--page)
-- [Select](./?path=/docs/components-forms-select-guide--page)
-- [Checkbox](./?path=/docs/components-forms-checkbox-guide--page)
+- [Radio buttons](./?path=/docs/components-forms-radio-guide--docs)
+- [Segment](./?path=/docs/components-forms-segment-guide--docs)
+- [Select](./?path=/docs/components-forms-select-guide--docs)
+- [Checkbox](./?path=/docs/components-forms-checkbox-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/validation/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/validation/docs/guide.stories.mdx
@@ -14,7 +14,7 @@ import Feedback from '../../../docs/common/feedback.md';
 When the user submits a form and it is validated as having errors, the following things should happen:
 
 1. All fields with errors are highlighted as having errors.
-2. Inline messages display beneath each field telling the user how to fix the problem. [Read the writing guide](./?path=/docs/principles-writing--page) to find out how to write good error messages.
+2. Inline messages display beneath each field telling the user how to fix the problem. [Read the writing guide](./?path=/docs/principles-writing--docs) to find out how to write good error messages.
 3. The first field with an error automatically gets focus so the user knows where to begin.
 
 ## Usage
@@ -97,7 +97,7 @@ Style error messages in red and use a warning icon to provide a <a href="https:/
 
 ## Tone of voice and copy
 
-[Read our writing guide](./?path=/docs/principles-writing--page).
+[Read our writing guide](./?path=/docs/principles-writing--docs).
 
 ------
 

--- a/projects/canopy/src/lib/hero/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/hero/docs/guide.stories.mdx
@@ -28,7 +28,7 @@ You can extend the basic Hero component and create specific Hero layouts and imp
 
 #### Hero with breadcrumbs
 
-Using the `LgHeroCardHeaderComponent` together with `LgBreadcrumbComponent`, some breadcrumbs can be easily added to the hero. Note that you should use the `light` variant of the [breadcrumb component](./?path=/docs/components-breadcrumb-guide--page), as it's rendering against a dark blue background.
+Using the `LgHeroCardHeaderComponent` together with `LgBreadcrumbComponent`, some breadcrumbs can be easily added to the hero. Note that you should use the `light` variant of the [breadcrumb component](./?path=/docs/components-breadcrumb-guide--docs), as it's rendering against a dark blue background.
 
 ```html
 <lg-hero [overlap]="overlap">

--- a/projects/canopy/src/lib/hide-at/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/hide-at/docs/guide.stories.mdx
@@ -40,6 +40,6 @@ The current available breakpoints are `sm`, `md`, `lg`, `xl`, and `xxl`.
 
 ## Related
 
-- [Show at directive](./?path=/docs/helpers-directives-show-at-guide--page)
+- [Show at directive](./?path=/docs/helpers-directives-show-at-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/icon/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/icon/docs/guide.stories.mdx
@@ -96,7 +96,7 @@ Please note that the `need-help` and `question-mark` icons currently don't have 
 
 ## Related
 
-- [Brand icon](./?path=/docs/foundations-brand-icon-guide--page)
+- [Brand icon](./?path=/docs/foundations-brand-icon-guide--docs)
 
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/modal/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/modal/docs/guide.stories.mdx
@@ -171,7 +171,7 @@ This is based on best practice research.
 
 Patterns which may perform a similar task, or which should be considered instead:
 
-- [Inline message](./?path=/docs/components-inline-message-alert-guide--page)
-- [Primary message](./?path=/docs/components-primary-message-guide--page)
+- [Inline message](./?path=/docs/components-inline-message-alert-guide--docs)
+- [Primary message](./?path=/docs/components-primary-message-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/orientation/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/orientation/docs/guide.stories.mdx
@@ -105,7 +105,7 @@ The current available breakpoints are `sm`, `md`, `lg`, `xl`, `xxl`
 ## Related
 
 - [Promotions pattern](./?path=/docs/patterns-promotions-examples--promotions-general-three-card)
-- [Margin directive](./?path=/docs/helpers-directives-margin-guide--page)
-- [Row gap directive](./?path=/docs/helpers-directives-row-gap-guide--page)
+- [Margin directive](./?path=/docs/helpers-directives-margin-guide--docs)
+- [Row gap directive](./?path=/docs/helpers-directives-row-gap-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/page/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/page/docs/guide.stories.mdx
@@ -9,7 +9,7 @@ import Feedback from '../../docs/common/feedback.md?raw';
 
 ## Usage
 
-The page component works best when combined with the [grid module](./?path=/docs/helpers-directives-grid-guide--page) which can be used to provide a responsive layout for the main content.
+The page component works best when combined with the [grid module](./?path=/docs/helpers-directives-grid-guide--docs) which can be used to provide a responsive layout for the main content.
 
 Import the page and grid modules in your application:
 

--- a/projects/canopy/src/lib/pipes/camel-case/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/pipes/camel-case/docs/guide.stories.mdx
@@ -25,6 +25,6 @@ and in your HTML:
 
 ## Related
 
-- [Kebab case pipe](./?path=/docs/helpers-pipes-kebab-case-guide--page)
+- [Kebab case pipe](./?path=/docs/helpers-pipes-kebab-case-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/pipes/kebab-case/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/pipes/kebab-case/docs/guide.stories.mdx
@@ -25,6 +25,6 @@ and in your HTML:
 
 ## Related
 
-- [Camel case pipe](./?path=/docs/helpers-pipes-camel-case-guide--page)
+- [Camel case pipe](./?path=/docs/helpers-pipes-camel-case-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/primary-message/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/primary-message/docs/guide.stories.mdx
@@ -43,8 +43,8 @@ and in your HTML:
 
 A primary message should be the only content that displays in a container.
 
-- It contains a brand icon that can be tinted. Choose an appropriate brand icon from the [brand icon catalogue](./?path=/story/foundations-brand-icon-catalog--standard-brand-icons), and choose an appropriate tint according to the scenario. For instance, a success state brand icon might be tinted with `--color-lily-green`. Read the [brand icon guide](./?path=/docs/foundations-brand-icon-guide--page) for more details.
-- It contains a title and description. [Read our writing page](./?path=/docs/principles-writing--page) for how to write appropriate copy.
+- It contains a brand icon that can be tinted. Choose an appropriate brand icon from the [brand icon catalogue](./?path=/story/foundations-brand-icon-catalog--standard-brand-icons), and choose an appropriate tint according to the scenario. For instance, a success state brand icon might be tinted with `--color-lily-green`. Read the [brand icon guide](./?path=/docs/foundations-brand-icon-guide--docs) for more details.
+- It contains a title and description. [Read our writing page](./?path=/docs/principles-writing--docs) for how to write appropriate copy.
 - (Optional) It can contain a button. When using a primary message at the end of a journey, adding a button is a great way to guide the user to the next step so they don't get stuck in a dead-end.
 
 ## Dos and Don'ts
@@ -95,7 +95,7 @@ This component is based on best practice and has not had specific usability test
 
 ## Related
 
-- [Inline message](./?path=/docs/components-inline-message-alert-guide--page)
-- [Modal](./?path=/docs/components-modal-guide--page)
+- [Inline message](./?path=/docs/components-inline-message-alert-guide--docs)
+- [Modal](./?path=/docs/components-modal-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/promo-card/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/promo-card/docs/guide.stories.mdx
@@ -73,6 +73,6 @@ and in your HTML, place the promo cards in the promo card list:
 
 ## Related
 
-- [Card](./?path=/docs/components-card-guide--page)
+- [Card](./?path=/docs/components-card-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/quick-action/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/quick-action/docs/guide.stories.mdx
@@ -73,7 +73,7 @@ This component is based on best practice and has not been subject to usability t
 
 ## Related
 
-- [Button](./?path=/docs/components-button-guide--page)
-- [Link](./?path=/docs/components-link-guide--page)
+- [Button](./?path=/docs/components-button-guide--docs)
+- [Link](./?path=/docs/components-link-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/separator/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/separator/docs/guide.stories.mdx
@@ -61,6 +61,6 @@ Include any user testing here. If not, indicate that this is based on best pract
 
 Patterns which may perform a similar task, or which should be considered instead
 
-- [Card](./?path=/docs/components-card-guide--page)
+- [Card](./?path=/docs/components-card-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/show-at/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/show-at/docs/guide.stories.mdx
@@ -40,6 +40,6 @@ The current available breakpoints are `sm`, `md`, `lg`, `xl`, and `xxl`.
 
 ## Related
 
-- [Hide at directive](./?path=/docs/helpers-directives-hide-at-guide--page)
+- [Hide at directive](./?path=/docs/helpers-directives-hide-at-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/spacing/margin/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/spacing/margin/docs/guide.stories.mdx
@@ -131,7 +131,7 @@ The current available breakpoints are `xs`, `sm`, `md`, `lg`, `xl`, `xxl`
 
 ## Related
 
-- [Padding directive](./?path=/docs/helpers-directives-padding-guide--page)
-- [Row gap directive](./?path=/docs/helpers-directives-row-gap-guide--page)
+- [Padding directive](./?path=/docs/helpers-directives-padding-guide--docs)
+- [Row gap directive](./?path=/docs/helpers-directives-row-gap-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/spacing/padding/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/spacing/padding/docs/guide.stories.mdx
@@ -131,7 +131,7 @@ The current available breakpoints are `xs`, `sm`, `md`, `lg`, `xl`, `xxl`
 
 ## Related
 
-- [Margin directive](./?path=/docs/helpers-directives-margin-guide--page)
-- [Row gap directive](./?path=/docs/helpers-directives-row-gap-guide--page)
+- [Margin directive](./?path=/docs/helpers-directives-margin-guide--docs)
+- [Row gap directive](./?path=/docs/helpers-directives-row-gap-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/spacing/row-gap/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/spacing/row-gap/docs/guide.stories.mdx
@@ -10,7 +10,7 @@ The spacing variables are also available as CSS custom properties (CSS variables
 which can be viewed in _**canopy/projects/canopy/src/styles/spacing.scss**_.
 
 This directive and accompanying CSS classes, work great with our
-[Canopy grid](./?path=/docs/helpers-directives-grid-guide--page) but will
+[Canopy grid](./?path=/docs/helpers-directives-grid-guide--docs) but will
 also work with all other HTML elements that support <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap" target="_blank" rel='noopener noreferrer'>CSS row-gap</a>.
 
 ## Usage
@@ -50,7 +50,7 @@ The current available spacing variants are `none`, `xxxs`, `xxs`, `xs`, `sm`, `m
 
 ## Related
 
-- [Margin directive](./?path=/docs/helpers-directives-margin-guide--page)
-- [Padding directive](./?path=/docs/helpers-directives-padding-guide--page)
+- [Margin directive](./?path=/docs/helpers-directives-margin-guide--docs)
+- [Padding directive](./?path=/docs/helpers-directives-padding-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/table/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/table/docs/guide.stories.mdx
@@ -108,7 +108,7 @@ Sometimes a table can be used to display large amounts of copy, including button
 
 Note that each `LgTableCellComponent` has the `stack` input set to true, which stacks the label and content on top of each other on small screens, instead of side by side. Also note the use of `<colgroup>` to control width of the columns on large screens. This can be seen on the [table with long copy story](./?path=/story/components-table-examples--with-long-copy-table).
 
-Also note the use of the [margin directive](./?path=/docs/helpers-directives-margin-guide--page), such as `lgMarginBottom="xs"`, to add extra space around content, making it more readable.
+Also note the use of the [margin directive](./?path=/docs/helpers-directives-margin-guide--docs), such as `lgMarginBottom="xs"`, to add extra space around content, making it more readable.
 
 ```html
 <table lg-table>
@@ -232,7 +232,7 @@ This is based on research and best practice.
 
 ## Related
 
-- [Accordion](./?path=/docs/components-accordion-guide--page)
-- [Card](./?path=/docs/components-card-guide--page)
+- [Accordion](./?path=/docs/components-accordion-guide--docs)
+- [Card](./?path=/docs/components-card-guide--docs)
 
 <Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/variant/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/variant/docs/guide.stories.mdx
@@ -7,7 +7,7 @@ import Feedback from '../../docs/common/feedback.md?raw';
 
 This directive allows you to add one of the five common colour variants to any Canopy component, such as `info` and `success`.
 
-They are already applied to existing Canopy components which use these variants out of the box, such as [alert](./?path=/docs/components-inline-message-alert-guide--page), [details](./?path=/docs/components-details-guide--page) and [form validation](./?path=/docs/components-forms-form-validation-guide--page), but this directive allows you to use them anywhere where required.
+They are already applied to existing Canopy components which use these variants out of the box, such as [alert](./?path=/docs/components-inline-message-alert-guide--docs), [details](./?path=/docs/components-details-guide--docs) and [form validation](./?path=/docs/components-forms-form-validation-guide--docs), but this directive allows you to use them anywhere where required.
 
 This can be useful where you need the particular colour treatment (like the `success` variant for example), but your use-case does not fit one of the existing components.
 

--- a/projects/canopy/src/styles/docs/link/guide.stories.mdx
+++ b/projects/canopy/src/styles/docs/link/guide.stories.mdx
@@ -72,7 +72,7 @@ For example a link with text "Read more" doesn't give enough information to a sc
 
 
 
-For custom components it's possible to override the style of a link by using the `lg-unstyled-link` [scss mixin](./?path=/docs/helpers-style-mixins--page).
+For custom components it's possible to override the style of a link by using the `lg-unstyled-link` [scss mixin](./?path=/docs/helpers-style-mixins--docs).
 
 ------
 
@@ -87,7 +87,7 @@ This is based on best practice, and from the sources listed below.
 
 ## Related
 
-- [Button](./?path=/docs/components-button-guide--page)
-- [Quick action](./?path=/docs/components-button-guide--page)
+- [Button](./?path=/docs/components-button-guide--docs)
+- [Quick action](./?path=/docs/components-button-guide--docs)
 
 <Markdown>{Feedback}</Markdown>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX198TjJkR1YQPqy02fl6h9u4p0TAvzG6E%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=6wj5_wQ)
# Description

The upgrade to Storybook 7 has updated the docs paths (not mentioned in the release notes) and this has broken our links.
This PR updates those.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
