### PR TITLE
fix(date-field): fix -- date value and partial values

### DIFF
--- a/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
@@ -169,13 +169,12 @@ describe('LgDateFieldComponent', () => {
     expect(dateInput.nativeElement.value).toEqual(date);
   });
 
-  it('joins the individual input fields and sets the value even if some are null', () => {
+  it('disallows partial dates', () => {
     fixture.detectChanges();
     dateFieldInstance.year.setValue('1970');
     dateFieldInstance.month.setValue('5');
-    dateFieldInstance.date.setValue('');
 
-    expect(component.form.controls.dateOfBirth.value).toEqual('1970-05-');
+    expect(component.form.controls.dateOfBirth.value).toEqual('');
   });
 
   it('sets the individual input fields to the empty string when no date value is provided', () => {
@@ -224,18 +223,6 @@ describe('LgDateFieldComponent', () => {
     fixture.detectChanges();
 
     expect(component.form.controls.dateOfBirth.value).toEqual('1944-03-07');
-  });
-
-  it('replaces empty fields with an empty string if date is not complete', done => {
-    fixture.detectChanges();
-
-    component.dateChange.pipe(skip(1)).subscribe(change => {
-      expect(change.dateOfBirth).toBe('1944-03-');
-      done();
-    });
-
-    dateFieldInstance.year.setValue('1944');
-    dateFieldInstance.month.setValue('3');
   });
 
   it('updates the date value on each input change', () => {

--- a/projects/canopy/src/lib/forms/date/date-field.component.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.ts
@@ -163,7 +163,13 @@ export class LgDateFieldComponent implements OnInit, ControlValueAccessor, OnDes
           ? date.year
           : '';
 
-        this.onChange(`${year}-${month}-${day}`);
+        let formattedDate = '';
+
+        if (day && month && year) {
+          formattedDate = `${year}-${month}-${day}`;
+        }
+
+        this.onChange(formattedDate);
       }),
 
       // submit the group when the parent form is submitted


### PR DESCRIPTION
# Description

Currently, if the date field is **required** and a user fills the date fields (day, month, year) and then clears them out the FormControl will have a status of valid.

This PR fixes the issue. Additionally, it will disallow partial invalid dates such as:
- `--`
- `1999--`
- `1999-04-`
- `-04-`
- `--25`
- `-04-25`

Fixes https://github.com/Legal-and-General/canopy/issues/184

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
