### PR TITLE
FEP-2113: update header component documentation for outputs

### DIFF
--- a/projects/canopy/src/lib/header/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/header/docs/guide.stories.mdx
@@ -27,9 +27,9 @@ and in your HTML:
 The component uses an attribute selector which allows you to use the html <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header" target="_blank">header</a> element as the host.
 
 #### Outputs
-| Name         | Description                                                                  |          Type           | Default | Required |
-|--------------|------------------------------------------------------------------------------|:-----------------------:|:-------:|:--------:|
-| `toggleMenu` | An event emitted with a boolean value when the menu toggle button is clicked | `EventEmitter<boolean>` |   n/a   |   Yes    |
+| Name          | Description                                                                  |          Type           | Default | Required |
+|---------------|------------------------------------------------------------------------------|:-----------------------:|:-------:|:--------:|
+| `menuToggled` | An event emitted with a boolean value when the menu toggle button is clicked | `EventEmitter<boolean>` |   n/a   |   Yes    |
 
 ### LgHeaderLogoComponent inputs
 | Name   | Description                            |   Type   |   Default   | Required |


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18hUWE1QrWsFSz7K0IZhWlEk6jhArPyVI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=N9T78PF)
# Description

This PR updates the documentation for the `Header` component `Outputs`. The `toggleMenu` output was updated to `menuToggled`, as it is called in the source code:

```
export class LgHeaderComponent implements AfterContentInit, OnDestroy {
  private subscriptions: Array<Subscription> = [];
  showResponsiveMenu = false;

  @Output() menuToggled = new EventEmitter<boolean>();
```

# Checklist:

- [X] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [X] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
