### PR TITLE
Fixes to documentation

### DIFF
--- a/projects/canopy/src/lib/header/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/header/docs/guide.stories.mdx
@@ -27,9 +27,9 @@ and in your HTML:
 The component uses an attribute selector which allows you to use the html <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header" target="_blank">header</a> element as the host.
 
 #### Outputs
-| Name         | Description                                                                  |          Type           | Default | Required |
-|--------------|------------------------------------------------------------------------------|:-----------------------:|:-------:|:--------:|
-| `toggleMenu` | An event emitted with a boolean value when the menu toggle button is clicked | `EventEmitter<boolean>` |   n/a   |   Yes    |
+| Name          | Description                                                                  |          Type           | Default | Required |
+|---------------|------------------------------------------------------------------------------|:-----------------------:|:-------:|:--------:|
+| `menuToggled` | An event emitted with a boolean value when the menu toggle button is clicked | `EventEmitter<boolean>` |   n/a   |   Yes    |
 
 ### LgHeaderLogoComponent inputs
 | Name   | Description                            |   Type   |   Default   | Required |

--- a/projects/canopy/src/lib/spinner/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/spinner/docs/guide.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Markdown, Source } from '@storybook/blocks';
+import Feedback from '../../docs/common/feedback.md?raw';
 
 <Meta title="Components/Spinner/Guide" />
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1o1voV5AYvU1ZRVSDmaDq72VYSWD2q28%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=d2o8D5I)
# Description

This PR fix an issue with a missing import for the `Feedback` section on the Spinner guide and updates an incorrect output name for the Header docs.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
