### PR TITLE
fix(date-field): fix -- date value

### DIFF
--- a/projects/canopy/src/lib/forms/date/date-field.component.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.ts
@@ -163,7 +163,11 @@ export class LgDateFieldComponent implements OnInit, ControlValueAccessor, OnDes
           ? date.year
           : '';
 
-        this.onChange(`${year}-${month}-${day}`);
+        const formatedDate = day || month || year
+          ? `${year}-${month}-${day}`
+          : '';
+
+        this.onChange(formatedDate);
       }),
 
       // submit the group when the parent form is submitted


### PR DESCRIPTION
# Description

Currently, if the date field is required and a user fills the date fields (day, month, year) and then clears them out the FormControl will have a status of valid and the value is set to `--`.

This PR fixes it and returns `''` instead.

Fixes https://github.com/Legal-and-General/canopy/issues/184

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
