### PR TITLE
Fix modal header font and typography docs

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -84,7 +84,7 @@
     color: var(--color-white);
   }
 
-  .sbdocs.sbdocs-a, .sbdocs p, .sbdocs li {
+  .sbdocs.sbdocs-a, .sbdocs p:not([class*="lg-font-size-"]), .sbdocs li {
     font-size: var(--text-base-size);
   }
 

--- a/projects/canopy/src/lib/modal/modal-header/modal-header.component.scss
+++ b/projects/canopy/src/lib/modal/modal-header/modal-header.component.scss
@@ -17,7 +17,7 @@
   h5,
   h6 {
     margin-bottom: 0;
-    @include lg-font-size(2, 'strong');
+    @include lg-font-size(2, 'medium');
   }
 
   &__close {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1OfdwA96JO50yl5f5i0gj14b8Oek6o1cY%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=DwFRdVH)
# Description

Fix modal header font weight that was incorrect and also fixes the typography docs that was showing incorrectly.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
