### PR TITLE
Fix Date Field bug when used inside nested forms

### DIFF
--- a/projects/canopy/src/lib/forms/date/date-field.component.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   ContentChild,
-  Host,
   HostBinding,
   Input,
   OnDestroy,
@@ -99,7 +98,6 @@ export class LgDateFieldComponent implements OnInit, ControlValueAccessor, OnDes
     @Optional()
     private ngControl: NgControl,
     @Optional()
-    @Host()
     @SkipSelf()
     private parentFormGroupDirective: FormGroupDirective,
   ) {

--- a/projects/canopy/src/lib/forms/date/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/date/docs/guide.stories.mdx
@@ -64,7 +64,7 @@ and in your HTML:
 // parent class component
 const form = new FormGroup({
   childFormGroup: new FormGroup({
-    date: ['', [Validators.required]]
+    date: new FormControl('', Validators.required)
   })
 });
 

--- a/projects/canopy/src/lib/forms/date/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/date/docs/guide.stories.mdx
@@ -58,6 +58,54 @@ and in your HTML:
 
 **Note: for the validation to work properly it's very important to include the `ngForm` on the form tag and for the submit button to be within the form.**
 
+**Note: if the date field must be used within a child component of the form and is also part of an inner form group, then the formGroupName directive must be used inside the component, else the validation won't work properly. See the below example:**
+
+```ts
+// parent class component
+const form = new FormGroup({
+  childFormGroup: new FormGroup({
+    date: ['', [Validators.required]]
+  })
+});
+
+```
+
+```html
+<!-- parent component -->
+<form [formGroup]="form" (ngSubmit)="..." #validationForm="ngForm">
+  <-- child component -->
+  <lg-child-form-group></lg-child-form-group>
+  <button type="submit">Submit</button>
+</form>
+```
+
+```ts
+  // child class component
+
+  @Component({
+    selector: 'lg-child-form-group',
+    template: 'child-form-group.component.html',
+    // the injection of the ControlContainer is required since the formGroupName requires a visible [formGroup]
+    viewProviders: [
+      {
+        provide: ControlContainer,
+        useExisting: FormGroupDirective,
+      },
+    ],
+  })
+```
+
+```html
+<!-- child component -->
+<ng-container formGroupName="childFormGroup">
+  <lg-date-field formControlName="date">
+      <ng-container *ngIf="date.hasError('required')">
+        Enter a date of birth
+      </ng-container>
+  </lg-date-field>
+</ng-container>
+```
+
 ### LgDateFieldComponent inputs
 | Name              | Description                                                                                                                       |   Type    |              Default               | Required |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------|:---------:|:----------------------------------:|:--------:|

--- a/projects/canopy/src/lib/forms/validation/docs/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/docs/form.stories.ts
@@ -42,7 +42,27 @@ function invalidValidator(): ValidatorFn {
         Inner Date Field
         <lg-validation *ngIf="isControlInvalid(date, formGroupDirective)">
           <ng-container *ngIf="date.hasError('required')">
-            Enter a date of for the inner date field
+            Enter a date for the inner date field
+          </ng-container>
+          <ng-container *ngIf="date.hasError('invalidField')">
+            Enter a valid {{ date.errors.invalidField }}
+          </ng-container>
+          <ng-container *ngIf="date.hasError('invalidFields')">
+            Enter a valid {{ date.errors.invalidFields[0] }} and
+            {{ date.errors.invalidFields[1] }}
+          </ng-container>
+          <ng-container *ngIf="date.hasError('requiredField')">
+            Date must include a {{ date.errors.requiredField }}
+          </ng-container>
+          <ng-container *ngIf="date.hasError('requiredFields')">
+            Date must include a {{ date.errors.requiredFields[0] }} and
+            {{ date.errors.requiredFields[1] }}
+          </ng-container>
+          <ng-container *ngIf="date.hasError('invalidDate')">
+            Enter a valid date of birth
+          </ng-container>
+          <ng-container *ngIf="date.hasError('pastDate')">
+            Date must be in the past
           </ng-container>
         </lg-validation>
       </lg-date-field>
@@ -315,7 +335,7 @@ class ReactiveFormComponent {
       sortCode: [ '', [ Validators.required ] ],
       date: [ '', [ Validators.required, pastDateValidator() ] ],
       innerChildFormGroup: this.fb.group({
-        date: [ '', [ Validators.required ] ],
+        date: [ '', [ Validators.required, pastDateValidator() ] ],
       }),
     });
   }


### PR DESCRIPTION
# Description

This PR fixes a bug where the Date Field validation didn't work properly when used as part of a form group used in a child component. 
This was caused by the `@Host` decorator, which was taking into account only the direct `FormGroupDirective` of the parent component, it just worked if the date field was a direct child of the form where `[formGroup]` was defined.

![image](https://github.com/Legal-and-General/canopy/assets/12414812/94f8a771-ba91-476d-afa1-3b47453c09bf)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes - **extended existing story**
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
