### PR TITLE
Add/fix closed modal outputs

### DIFF
--- a/projects/canopy/src/lib/modal/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/modal/docs/guide.stories.mdx
@@ -120,10 +120,12 @@ Closing a modal dialogue on mobile can vary between each OS but in general tappi
 
 #### Outputs
 
-| Name     | Description                            | Type                 | Default | Required |
-|----------|----------------------------------------|----------------------|---------|----------|
-| `open`   | Event emitted when the modal is opened | `EventEmitter<void>` | n/a     | No       |
-| `closed` | Event emitted when the modal is closed | `EventEmitter<void>` | n/a     | No       |
+| Name                 | Description                                                       | Type                 | Default | Required |
+|----------------------|-------------------------------------------------------------------|----------------------|---------|----------|
+| `open`               | Event emitted when the modal is opened                            | `EventEmitter<void>` | n/a     | No       |
+| `closed`             | Event emitted when the modal is closed (generic)                  | `EventEmitter<void>` | n/a     | No       |
+| `closedOverlayClick` | Event emitted when the modal is closed by clicking the overlay    | `EventEmitter<void>` | n/a     | No       |
+| `closedEscKey`       | Event emitted when the modal is closed by pressing the escape key | `EventEmitter<void>` | n/a     | No       |
 
 ### LgModalHeaderComponent
 

--- a/projects/canopy/src/lib/modal/docs/modal.stories.ts
+++ b/projects/canopy/src/lib/modal/docs/modal.stories.ts
@@ -39,6 +39,16 @@ export default {
         disable: true,
       },
     },
+    closedOverlayClick: {
+      table: {
+        disable: true,
+      },
+    },
+    closedEscKey: {
+      table: {
+        disable: true,
+      },
+    },
     open: {
       table: {
         disable: true,

--- a/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.ts
+++ b/projects/canopy/src/lib/modal/modal-body-timer/modal-body-timer.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
   Input,
   ViewEncapsulation,
 } from '@angular/core';
@@ -12,12 +11,13 @@ import {
   styleUrls: [ './modal-body-timer.component.scss' ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-modal-body__timer',
+  },
 })
 export class LgModalBodyTimerComponent {
   private _timer: number;
   formattedTime: string;
-
-  @HostBinding('class.lg-modal-body__timer') class = true;
 
   @Input()
   set timer(seconds: number | string) {

--- a/projects/canopy/src/lib/modal/modal-body/modal-body.component.ts
+++ b/projects/canopy/src/lib/modal/modal-body/modal-body.component.ts
@@ -11,8 +11,10 @@ import {
   styleUrls: [ './modal-body.component.scss' ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-modal-body',
+  },
 })
 export class LgModalBodyComponent {
-  @HostBinding('class.lg-modal-body') class = true;
   @HostBinding('id') id: string;
 }

--- a/projects/canopy/src/lib/modal/modal-footer/modal-footer.component.ts
+++ b/projects/canopy/src/lib/modal/modal-footer/modal-footer.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'lg-modal-footer',
@@ -11,7 +6,8 @@ import {
   styleUrls: [ './modal-footer.component.scss' ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-modal-footer',
+  },
 })
-export class LgModalFooterComponent {
-  @HostBinding('class.lg-modal-footer') class = true;
-}
+export class LgModalFooterComponent {}

--- a/projects/canopy/src/lib/modal/modal-header/modal-header.component.spec.ts
+++ b/projects/canopy/src/lib/modal/modal-header/modal-header.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { instance, mock, verify } from '@typestrong/ts-mockito';
+import { instance, mock, spy, verify } from '@typestrong/ts-mockito';
 
 import { LgModalService } from '../modal.service';
 
@@ -41,9 +41,12 @@ describe('LgModalHeaderComponent', () => {
   });
 
   it('should close the modal on #close', () => {
+    const closedEmitterSpy = spy(component.closed);
+
     component.modalId = 'test';
     component.close();
 
+    verify(closedEmitterSpy.emit()).once();
     verify(modalServiceMock.close('test')).once();
 
     expect().nothing();

--- a/projects/canopy/src/lib/modal/modal-header/modal-header.component.ts
+++ b/projects/canopy/src/lib/modal/modal-header/modal-header.component.ts
@@ -17,18 +17,21 @@ import { LgModalService } from '../modal.service';
   styleUrls: [ './modal-header.component.scss' ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-modal-header',
+  },
 })
 export class LgModalHeaderComponent {
   @Input() headingLevel: HeadingLevel = 2;
   @Output() closed: EventEmitter<void> = new EventEmitter();
   modalId: string;
 
-  @HostBinding('class.lg-modal-header') class = true;
   @HostBinding('id') id: string;
 
   constructor(private modalService: LgModalService) {}
 
   close(): void {
+    this.closed.emit();
     this.modalService.close(this.modalId);
   }
 }

--- a/projects/canopy/src/lib/modal/modal.component.spec.ts
+++ b/projects/canopy/src/lib/modal/modal.component.spec.ts
@@ -1,6 +1,14 @@
-import { ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, EventEmitter } from '@angular/core';
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { anything, instance, mock, spy, verify, when } from '@typestrong/ts-mockito';
+import {
+  anything,
+  instance,
+  mock,
+  resetCalls,
+  spy,
+  verify,
+  when,
+} from '@typestrong/ts-mockito';
 import { BehaviorSubject } from 'rxjs';
 import { MockComponents, MockedComponentFixture, MockModule, MockRender } from 'ng-mocks';
 
@@ -121,20 +129,28 @@ describe('LgModalComponent', () => {
   });
 
   describe('on keydown', () => {
+    let closedEmitterSpy: EventEmitter<void>;
     const escEvent = new KeyboardEvent('keydown', {
       key: keyName.KEY_ESCAPE,
     });
 
-    it('should close the modal when escape key is pressed and the modal is open', () => {
+    beforeEach(() => {
+      closedEmitterSpy = spy(component.closedEscKey);
+    });
+
+    it('should close the modal and emit an event when the escape key is pressed and the modal is open', () => {
+      resetCalls(closedEmitterSpy);
       component.isOpen = true;
       component.onKeydown(escEvent);
 
       verify(modalServiceMock.close(id)).once();
+      verify(closedEmitterSpy.emit()).once();
 
       expect().nothing();
     });
 
-    it('shouldn\'t close the modal when any other key is pressed', () => {
+    it('shouldn\'t close the modal and emit an event when any other key is pressed', () => {
+      resetCalls(closedEmitterSpy);
       component.isOpen = true;
       const event = new KeyboardEvent('keydown', {
         key: keyName.KEY_UP,
@@ -143,15 +159,18 @@ describe('LgModalComponent', () => {
       component.onKeydown(event);
 
       verify(modalServiceMock.close(id)).never();
+      verify(closedEmitterSpy.emit()).never();
 
       expect().nothing();
     });
 
     it('shouldn\'t close the modal when the modal is already closed', () => {
+      resetCalls(closedEmitterSpy);
       component.isOpen = false;
       component.onKeydown(escEvent);
 
       verify(modalServiceMock.close(id)).never();
+      verify(closedEmitterSpy.emit()).never();
 
       expect().nothing();
     });
@@ -165,6 +184,20 @@ describe('LgModalComponent', () => {
       component.onModalClick(event);
 
       expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clicking on the modal overlay', () => {
+    it('should close the modal and emit an event', () => {
+      component.isOpen = true;
+      const closedEmitterSpy = spy(component.closedOverlayClick);
+
+      component.onOverlayClick();
+
+      verify(modalServiceMock.close(id)).once();
+      verify(closedEmitterSpy.emit()).once();
+
+      expect().nothing();
     });
   });
 });

--- a/projects/canopy/src/lib/modal/modal.component.ts
+++ b/projects/canopy/src/lib/modal/modal.component.ts
@@ -33,17 +33,23 @@ export class LgModalComponent implements OnInit, AfterContentInit, OnDestroy {
   @Input() id: string;
   @Output() open: EventEmitter<void> = new EventEmitter();
   @Output() closed: EventEmitter<void> = new EventEmitter();
+  @Output() closedOverlayClick: EventEmitter<void> = new EventEmitter();
+  @Output() closedEscKey: EventEmitter<void> = new EventEmitter();
 
   @ContentChild(forwardRef(() => LgModalHeaderComponent))
   modalHeaderComponent: LgModalHeaderComponent;
   @ContentChild(forwardRef(() => LgModalBodyComponent))
   modalBodyComponent: LgModalBodyComponent;
 
-  constructor(private cdr: ChangeDetectorRef, private modalService: LgModalService) {}
+  constructor(
+    private cdr: ChangeDetectorRef,
+    private modalService: LgModalService,
+  ) {}
 
   @HostListener('keydown', [ '$event' ]) onKeydown(event: KeyboardEvent): void {
     if (event.key === keyName.KEY_ESCAPE && this.isOpen) {
       this.modalService.close(this.id);
+      this.closedEscKey.emit();
     }
   }
 
@@ -55,6 +61,7 @@ export class LgModalComponent implements OnInit, AfterContentInit, OnDestroy {
   // drag the mouse on the overlay causing the modal to close.
   @HostListener('mousedown') onOverlayClick(): void {
     this.modalService.close(this.id);
+    this.closedOverlayClick.emit();
   }
 
   ngOnInit(): void {

--- a/projects/canopy/src/lib/modal/modal.component.ts
+++ b/projects/canopy/src/lib/modal/modal.component.ts
@@ -26,6 +26,9 @@ import { LgModalBodyComponent } from './modal-body/modal-body.component';
   templateUrl: './modal.component.html',
   styleUrls: [ './modal.component.scss' ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-modal',
+  },
 })
 export class LgModalComponent implements OnInit, AfterContentInit, OnDestroy {
   private subscription: Subscription;


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1upYr4NQes51BuccMyAouKztB6j1ZwuNQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=F4EiJzg)
# Description

Add two new modal outputs specific to closing the modal with the escape key or by clicking on the overlay.
Also fix the modal header `closed` output as it wasn't actually emitting anything.

In addition to that, it removes the host binding of classes and adds them to the component `host` object instead as more performant.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
