### PR TITLE
FEP-1279: create a card subheading component

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -728,7 +728,10 @@
           <lg-card-header>
             <lg-card-title headingLevel="4"> Test card title </lg-card-title>
           </lg-card-header>
-          <lg-card-content> Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna. </lg-card-content>
+          <lg-card-content>
+            <lg-card-subheading headingLevel="5">Subheading</lg-card-subheading>
+            Phasellus enim sem, dignissim nec ullamcorper id, euismod in magna. Sed at egestas urna.
+          </lg-card-content>
         </lg-card>
 
         <lg-card>

--- a/projects/canopy/src/lib/card/card-subheading/card-subheading.component.html
+++ b/projects/canopy/src/lib/card/card-subheading/card-subheading.component.html
@@ -1,0 +1,3 @@
+<lg-heading [level]="headingLevel">
+  <ng-content></ng-content>
+</lg-heading>

--- a/projects/canopy/src/lib/card/card-subheading/card-subheading.component.scss
+++ b/projects/canopy/src/lib/card/card-subheading/card-subheading.component.scss
@@ -1,0 +1,16 @@
+@import '../../../styles/mixins.scss';
+
+.lg-card-subheading {
+  display: block;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @include lg-font-size(1, 'strong');
+
+    margin-bottom: var(--space-xxs);
+  }
+}

--- a/projects/canopy/src/lib/card/card-subheading/card-subheading.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-subheading/card-subheading.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LgCardSubheadingComponent } from './card-subheading.component';
+
+describe('CardSubheadingComponent', () => {
+  let component: LgCardSubheadingComponent;
+  let fixture: ComponentFixture<LgCardSubheadingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LgCardSubheadingComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LgCardSubheadingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-card-subheading');
+  });
+});

--- a/projects/canopy/src/lib/card/card-subheading/card-subheading.component.ts
+++ b/projects/canopy/src/lib/card/card-subheading/card-subheading.component.ts
@@ -1,0 +1,29 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { HeadingLevel } from '../../heading';
+
+@Component({
+  selector: 'lg-card-subheading',
+  templateUrl: './card-subheading.component.html',
+  styleUrls: [ './card-subheading.component.scss' ],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-card-subheading',
+  },
+})
+export class LgCardSubheadingComponent {
+  @Input() headingLevel: HeadingLevel;
+
+  ngOnInit(): void {
+    if (!this.headingLevel) {
+      // eslint-disable-next-line no-console
+      console.error('headingLevel must be set');
+    }
+  }
+}

--- a/projects/canopy/src/lib/card/card.module.ts
+++ b/projects/canopy/src/lib/card/card.module.ts
@@ -13,6 +13,7 @@ import { LgCardContentComponent } from './card-content/card-content.component';
 import { LgCardHeaderComponent } from './card-header/card-header.component';
 import { LgCardSubtitleComponent } from './card-subtitle/card-subtitle.component';
 import { LgCardTitleComponent } from './card-title/card-title.component';
+import { LgCardSubheadingComponent } from './card-subheading/card-subheading.component';
 import { LgCardComponent } from './card.component';
 import { LgCardFooterComponent } from './card-footer/card-footer.component';
 import { LgCardToggableContentComponent } from './card-toggable-content/card-toggable-content.component';
@@ -25,6 +26,7 @@ const components = [
   LgCardHeaderComponent,
   LgCardHeroImageComponent,
   LgCardTitleComponent,
+  LgCardSubheadingComponent,
   LgCardFooterComponent,
   LgCardSubtitleComponent,
   LgCardPrincipleDataPointComponent,

--- a/projects/canopy/src/lib/card/docs/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/docs/card/card.stories.ts
@@ -120,6 +120,7 @@ const showMoreCardTemplate = `
     </lg-card-title>
   </lg-card-header>
   <lg-card-content>
+    <lg-card-subheading headingLevel="3">Subheading</lg-card-subheading>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
     <lg-card-toggable-content>
@@ -191,6 +192,7 @@ const defaultCardTemplate = `
     </lg-card-title>
   </lg-card-header>
   <lg-card-content>
+    <lg-card-subheading [headingLevel]="headingLevel + 1">Subheading</lg-card-subheading>
     {{cardContent}} <a href="#">Test link</a>.
   </lg-card-content>
 </lg-card>
@@ -224,6 +226,7 @@ const navigationCardTemplate = `
     <lg-card-navigation-title [title]="title" [link]="link" [queryParams]="queryParams" [queryParamsHandling]="queryParamsHandling" [headingLevel]="headingLevel"></lg-card-navigation-title>
   </lg-card-header>
   <lg-card-content>
+    <lg-card-subheading [headingLevel]="headingLevel + 1">Subheading</lg-card-subheading>
     {{cardContent}} <a href="#">Test link</a>.
   </lg-card-content>
 </lg-card>

--- a/projects/canopy/src/lib/card/docs/card/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/card/guide.stories.mdx
@@ -155,6 +155,18 @@ This is where the main title and link should be provided. It should be located i
 
 If the card has a subtitle it should be located within this component. If a card has a subtitle it is expected to also implicitly have a title. It should be located inside the card content.
 
+### LgCardSubheadingComponent
+
+This is where the card subheading should be provided. It should be located inside the card content.
+
+#### Inputs
+
+| Name           | Description                                                    | Type     | Default | Required |
+|----------------|----------------------------------------------------------------|----------|---------|----------|
+| `headingLevel` | The level of the card subheading: `1`, `2`, `3`, `4`, `5`, `6` | `number` | n/a     | Yes      |
+
+**Note: The subheading styling will be consistent across all heading levels**
+
 ### LgCardToggableContent
 This is where additional content that can be shown/hidden should be located. This component is part of a pattern and will only work if used together with the `lgButtonToggle` directive.
 

--- a/projects/canopy/src/lib/card/index.ts
+++ b/projects/canopy/src/lib/card/index.ts
@@ -12,5 +12,6 @@ export * from './card-footer/card-footer.component';
 export * from './card-toggable-content/card-toggable-content.component';
 export * from './card.interface';
 export * from './card-navigation-title/card-navigation-title.component';
+export * from './card-subheading/card-subheading.component';
 export * from './card.component';
 export * from './card.module';


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX190HMfb0g6RHLFBjBzXVhWMnKyi3U3Rus%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=mEBJ-_-)
# Description

Add new `lg-card-subheading` component and update the lg-card docs.

## Requirements

Design link: https://www.figma.com/file/Mts4nibXQw6tDW2PTDHlKd/Patterns?node-id=212%3A2589&mode=dev
Screenshot: 
<img width="1149" alt="Screenshot 2023-10-04 at 10 58 59" src="https://github.com/Legal-and-General/canopy/assets/8149965/bef95dc1-1cc6-4b83-bfe3-15839b84a515">

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
