### PR TITLE
feat(card-group): add a new card group component

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -89,6 +89,59 @@
 
   <div lgContainer>
     <div lgRow>
+      <div lgCol="12">
+        <aside lg-card-group lgMarginBottom="xl">
+          <lg-card>
+            <lg-card-header>
+              <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+            </lg-card-header>
+            <lg-card-content>
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </lg-card-content>
+            <lg-card-footer lgMarginTop="md" lgPaddingTop="none">
+              <lg-link-menu>
+                <a href="" target="_blank">
+                  <lg-link-menu-item>
+                    <lg-link-menu-item-text isBold="true">Link menu item 1</lg-link-menu-item-text>
+                  </lg-link-menu-item>
+                </a>
+                <a href="">
+                  <lg-link-menu-item>
+                    <lg-link-menu-item-text isBold="true">Link menu item 2</lg-link-menu-item-text>
+                  </lg-link-menu-item>
+                </a>
+              </lg-link-menu>
+            </lg-card-footer>
+          </lg-card>
+          <lg-card>
+            <lg-card-header>
+              <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+            </lg-card-header>
+            <lg-card-content>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            </lg-card-content>
+          </lg-card>
+          <lg-card>
+            <lg-card-header>
+              <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+            </lg-card-header>
+            <lg-card-content>
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </lg-card-content>
+          </lg-card>
+          <lg-card>
+            <lg-card-header>
+              <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+            </lg-card-header>
+            <lg-card-content>
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </lg-card-content>
+          </lg-card>
+        </aside>
+      </div>
+    </div>
+
+    <div lgRow>
       <div lgCol="12" lgColLg="9" lgColMdOffset="0">
         <lg-card>
           <lg-card-content>

--- a/projects/canopy/src/lib/card/card-content/card-content.component.scss
+++ b/projects/canopy/src/lib/card/card-content/card-content.component.scss
@@ -1,0 +1,3 @@
+.lg-card-content {
+  flex-grow: 1;
+}

--- a/projects/canopy/src/lib/card/card-content/card-content.component.ts
+++ b/projects/canopy/src/lib/card/card-content/card-content.component.ts
@@ -3,6 +3,7 @@ import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 @Component({
   selector: 'lg-card-content',
   templateUrl: './card-content.component.html',
+  styleUrls: [ './card-content.component.scss' ],
   encapsulation: ViewEncapsulation.None,
 })
 export class LgCardContentComponent {

--- a/projects/canopy/src/lib/card/card-group/card-group.component.html
+++ b/projects/canopy/src/lib/card/card-group/card-group.component.html
@@ -1,0 +1,1 @@
+<ng-content select="lg-card"></ng-content>

--- a/projects/canopy/src/lib/card/card-group/card-group.component.scss
+++ b/projects/canopy/src/lib/card/card-group/card-group.component.scss
@@ -1,0 +1,28 @@
+@import '../../../styles/mixins.scss';
+
+.lg-card-group {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: var(--space-lg);
+
+  @include lg-breakpoint('md') {
+    column-gap: calc(var(--space-sm) - 0.5%);
+  }
+
+  @include lg-breakpoint('lg') {
+    column-gap: calc(var(--space-md) - 0.5%);
+  }
+
+  .lg-card {
+    flex: 0 0 100%;
+    margin-bottom: 0;
+
+    @include lg-breakpoint('md') {
+      flex-basis: 49%;
+    }
+
+    @include lg-breakpoint('lg') {
+      flex-basis: 32%;
+    }
+  }
+}

--- a/projects/canopy/src/lib/card/card-group/card-group.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-group/card-group.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LgCardGroupComponent } from './card-group.component';
+
+describe('LgCardGroupComponent', () => {
+  let component: LgCardGroupComponent;
+  let fixture: ComponentFixture<LgCardGroupComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LgCardGroupComponent ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgCardGroupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain the default class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-card-group');
+  });
+});

--- a/projects/canopy/src/lib/card/card-group/card-group.component.ts
+++ b/projects/canopy/src/lib/card/card-group/card-group.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: '[lg-card-group]',
+  templateUrl: './card-group.component.html',
+  styleUrls: [ './card-group.component.scss' ],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'lg-card-group',
+  },
+})
+export class LgCardGroupComponent {}

--- a/projects/canopy/src/lib/card/card.component.scss
+++ b/projects/canopy/src/lib/card/card.component.scss
@@ -1,12 +1,12 @@
 @import '../../styles/mixins.scss';
 
 .lg-card {
-  display: block;
+  display: flex;
+  flex-direction: column;
+
   @include lg-card;
 
   &--promotion {
-    display: flex;
-    flex-direction: column;
     overflow: hidden;
 
     .lg-card-hero-img__img + .lg-card-content {
@@ -18,16 +18,22 @@
   &--navigation {
     padding-top: 0;
     transition: box-shadow 250ms;
-    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.01), 0 0.0625rem 0.0625rem 0 rgba(0, 0, 0, 0.02),
-      0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02), 0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.02),
-      0 0.1875rem 0.4375rem 0 rgba(0, 0, 0, 0.03), 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.04);
+    box-shadow:
+      0 0 0 0 rgba(0, 0, 0, 0.01),
+      0 0.0625rem 0.0625rem 0 rgba(0, 0, 0, 0.02),
+      0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02),
+      0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.02),
+      0 0.1875rem 0.4375rem 0 rgba(0, 0, 0, 0.03),
+      0 0.5rem 1rem 0 rgba(0, 0, 0, 0.04);
 
     &:hover {
-      box-shadow: 0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02),
+      box-shadow:
+        0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02),
         0 0.125rem 0.0125rem 0 rgba(0, 0, 0, 0.03),
         0 0.25rem 0.625rem 0 rgba(0, 0, 0, 0.04),
         0 0.4375rem 1.125rem 0 rgba(0, 0, 0, 0.04),
-        0 0.8125rem 2.0625rem 0 rgba(0, 0, 0, 0.05), 0 2rem 5rem 0 rgba(0, 0, 0, 0.07);
+        0 0.8125rem 2.0625rem 0 rgba(0, 0, 0, 0.05),
+        0 2rem 5rem 0 rgba(0, 0, 0, 0.07);
     }
 
     .lg-card-header__title {

--- a/projects/canopy/src/lib/card/card.module.ts
+++ b/projects/canopy/src/lib/card/card.module.ts
@@ -20,6 +20,7 @@ import { LgCardToggableContentComponent } from './card-toggable-content/card-tog
 import { LgCardNavigationTitleComponent } from './card-navigation-title/card-navigation-title.component';
 import { LgCardContentInnerDataPointsComponent } from './card-content-inner-data-points/card-content-inner-data-points.component';
 import { LgCardHeroImageComponent } from './card-hero-img/card-hero-img.component';
+import { LgCardGroupComponent } from './card-group/card-group.component';
 
 const components = [
   LgCardComponent,
@@ -28,6 +29,7 @@ const components = [
   LgCardTitleComponent,
   LgCardSubheadingComponent,
   LgCardFooterComponent,
+  LgCardGroupComponent,
   LgCardSubtitleComponent,
   LgCardPrincipleDataPointComponent,
   LgCardPrincipleDataPointLabelComponent,

--- a/projects/canopy/src/lib/card/docs/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/docs/card/card.stories.ts
@@ -22,6 +22,7 @@ import { LgCardComponent } from '../../card.component';
 import { LgCardModule } from '../../card.module';
 import { LgDataPointModule } from '../../../data-point';
 import { LgLinkMenuModule } from '../../../link-menu';
+import { LgCardGroupComponent } from '../../card-group/card-group.component';
 
 const content =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
@@ -238,7 +239,7 @@ const navigationCardStory: StoryFn<LgCardComponent> = (args: LgCardComponent) =>
 });
 
 export const navigationCard = navigationCardStory.bind({});
-navigationCard.storyName = 'Card Navigation';
+navigationCard.storyName = 'Card navigation';
 
 navigationCard.args = {
   link: 'https://www.landg.com',
@@ -436,4 +437,134 @@ dataPointsCard.args = {
       value: 'Data value 3',
     },
   ],
+};
+
+const cardGroupTemplate = `
+<div lgContainer>
+  <div lgRow>
+    <div lgCol="12">
+      <aside lg-card-group>
+        <lg-card>
+          <lg-card-header>
+            <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+          </lg-card-header>
+          <lg-card-content>
+            {{cardContent}} <a href="#">Test link</a>.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          </lg-card-content>
+        </lg-card>
+        <lg-card *ngFor="let i of [].constructor(additionalCards)">
+          <lg-card-header>
+            <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+          </lg-card-header>
+          <lg-card-content>
+            {{cardContent}} <a href="#">Test link</a>.
+          </lg-card-content>
+          <lg-card-footer lgMarginTop="md" lgPaddingTop="none">
+            <lg-link-menu>
+              <a href="" target="_blank">
+                <lg-link-menu-item>
+                  <lg-link-menu-item-text isBold="true">Link menu item 1</lg-link-menu-item-text>
+                </lg-link-menu-item>
+              </a>
+              <a href="">
+                <lg-link-menu-item>
+                  <lg-link-menu-item-text isBold="true">Link menu item 2</lg-link-menu-item-text>
+                </lg-link-menu-item>
+              </a>
+            </lg-link-menu>
+          </lg-card-footer>
+        </lg-card>
+      </aside>
+    </div>
+  </div>
+</div>
+`;
+
+const cardGroupTemplateStory: StoryFn<LgCardGroupComponent> = (
+  args: LgCardGroupComponent,
+) => ({
+  props: args,
+  template: cardGroupTemplate,
+});
+
+export const cardGroup = cardGroupTemplateStory.bind({});
+cardGroup.storyName = 'Card group';
+
+cardGroup.args = {
+  cardContent: content,
+  additionalCards: 1,
+};
+
+cardGroup.parameters = {
+  docs: {
+    source: {
+      code: `
+<div lgContainer>
+  <div lgRow>
+    <div lgCol="12">
+      <aside lg-card-group>
+        <lg-card>
+          <lg-card-header>
+            <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+          </lg-card-header>
+          <lg-card-content>
+            {{cardContent}} <a href="#">Test link</a>.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          </lg-card-content>
+        </lg-card>
+        <lg-card>
+          <lg-card-header>
+            <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+          </lg-card-header>
+          <lg-card-content>
+            {{cardContent}} <a href="#">Test link</a>.
+          </lg-card-content>
+          <lg-card-footer lgMarginTop="md" lgPaddingTop="none">
+            <lg-link-menu>
+              <a href="" target="_blank">
+                <lg-link-menu-item>
+                  <lg-link-menu-item-text isBold="true">Link menu item 1</lg-link-menu-item-text>
+                </lg-link-menu-item>
+              </a>
+              <a href="">
+                <lg-link-menu-item>
+                  <lg-link-menu-item-text isBold="true">Link menu item 2</lg-link-menu-item-text>
+                </lg-link-menu-item>
+              </a>
+            </lg-link-menu>
+          </lg-card-footer>
+        </lg-card>
+        <lg-card>
+          <lg-card-header>
+            <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+          </lg-card-header>
+          <lg-card-content>
+            {{cardContent}} <a href="#">Test link</a>.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          </lg-card-content>
+        </lg-card>
+      </aside>
+    </div>
+  </div>
+</div>
+      `,
+    },
+  },
+};
+
+cardGroup.argTypes = {
+  queryParams: {
+    table: {
+      disable: true,
+    },
+  },
+  queryParamsHandling: {
+    table: {
+      disable: true,
+    },
+  },
 };

--- a/projects/canopy/src/lib/card/docs/card/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/card/guide.stories.mdx
@@ -88,6 +88,15 @@ This component uses some extra card components, such as `LgCardContentInnerDataP
 
 <Source id="components-card-examples--data-points-card"></Source>
 
+### Card Group
+
+Cards can be grouped together by using the `LgCardGroupComponent` - a container to group together two or more cards so that they are organised correctly throughout the different breakpoints and have the same height.
+
+The card group should always be wrapped in a `lgCol="12"` container as shown in the example below.
+
+<Source id="components-card-examples--card-group"></Source>
+
+
 ## Additional development details
 
 ### LgCardComponent

--- a/projects/canopy/src/lib/card/index.ts
+++ b/projects/canopy/src/lib/card/index.ts
@@ -13,5 +13,6 @@ export * from './card-toggable-content/card-toggable-content.component';
 export * from './card.interface';
 export * from './card-navigation-title/card-navigation-title.component';
 export * from './card-subheading/card-subheading.component';
+export * from './card-group/card-group.component';
 export * from './card.component';
 export * from './card.module';


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1eYsB7JR7nrNWg2nvuJkSwWjtGkbLZDE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Bm2btjf)

# Description

Add a new `LgCardGroupComponent`: a container to group together two or more cards so that they are organised correctly throughout the different breakpoints and have the same height.

## Requirements

Grouping of cards is required for the new card navigation. It should also make the cards the same heights.

The above was also discussed here: https://github.com/Legal-and-General/canopy/discussions/1212#discussioncomment-6658606

Design links:
- https://www.figma.com/file/Mts4nibXQw6tDW2PTDHlKd/Patterns?type=design&node-id=524%3A6637&mode=design&t=7xPIjzDLOVqmv0Rr-1
- https://www.figma.com/file/1vkD5KNvqp1SOYYmBHlqrn/Templates?type=design&node-id=56%3A6432&mode=design&t=ctx7dKwXBECmEK6E-1

Environment: https://legal-and-general.github.io/canopy/lg-sb-fep-1278-flex-dir/?path=/story/components-card-examples--card-group

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts

# Testing

This was approved by @alexcanning. 

https://github.com/Legal-and-General/canopy/assets/8397116/f00c3790-4dd5-4c43-a2f3-6868151c8813

