### PR TITLE
fix(radio-button): update position of toggle to account for longer labels

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -22,6 +22,7 @@
   display: flex;
   position: relative;
   font-weight: var(--font-weight-regular);
+  padding-left: calc(var(--radio-outer-lg-width) + var(--space-xxs));
 
   .lg-radio-button__input:disabled + & {
     color: var(--disabled-color);
@@ -44,6 +45,7 @@
   border-radius: 50%;
   border: var(--border-width) solid var(--radio-border-color);
   margin: auto var(--space-sm) auto 0;
+  position: absolute;
 
   .lg-radio-button__input:focus-visible + & {
     border-color: var(--border-focus-color);


### PR DESCRIPTION
# Description

Fixes #827 

Sets the position of the radio button to absolute and adds fixed padding to prevent the radio button stretching when the label text goes over multiple lines

| Issue | Fix |
| --- | ---|
|<img width="80%" alt="image" src="https://github.com/Legal-and-General/canopy/assets/95081643/2169a0c1-6e7d-4d78-a6c1-10bfee74fd23">|<img width="80%" alt="image" src="https://github.com/Legal-and-General/canopy/assets/95081643/53c980d8-8390-41e1-8e11-dc995338d5bc">|


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
