### PR TITLE
Fix lg-alert role attibute not being read by VoiceOver

### DIFF
--- a/projects/canopy/src/lib/alert/alert.component.spec.ts
+++ b/projects/canopy/src/lib/alert/alert.component.spec.ts
@@ -70,7 +70,7 @@ describe('LgAlertComponent', () => {
       component.ngOnChanges();
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.getAttribute('none')).toBe(null);
+      expect(fixture.nativeElement.getAttribute('role')).toBe(null);
     });
   });
 

--- a/projects/canopy/src/lib/alert/alert.component.spec.ts
+++ b/projects/canopy/src/lib/alert/alert.component.spec.ts
@@ -37,34 +37,40 @@ describe('LgAlertComponent', () => {
   });
 
   describe('role', () => {
-    it('does not add a Aria role for the info variant', () => {
-      component.variant = 'info';
+    function testVariant(variant: Variant, expectedRole: null | 'alert' | 'status') {
+      component.variant = variant;
+      component.ngOnChanges();
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.getAttribute('role')).toBeNull();
-    });
+      expect(fixture.nativeElement.getAttribute('role')).toBe(expectedRole);
+    }
 
-    it('does not add a Aria role for the generic variant', () => {
-      component.variant = 'generic';
-      fixture.detectChanges();
-
-      expect(fixture.nativeElement.getAttribute('role')).toBeNull();
-    });
+    for (const variant of [ 'info', 'generic' ]) {
+      it(`does not add a Aria role for the ${variant} variant`, () => {
+        testVariant(variant as Variant, null);
+      });
+    }
 
     for (const variant of [ 'success', 'warning', 'error' ]) {
       it(`adds the Aria role "alert" for the ${variant} variant`, () => {
-        component.variant = variant as Variant;
-        fixture.detectChanges();
-
-        expect(fixture.nativeElement.getAttribute('role')).toBe('alert');
+        testVariant(variant as Variant, 'alert');
       });
     }
 
     it('overrides the role attribute when role input is set', () => {
       component.role = 'status';
+      component.ngOnChanges();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.getAttribute('role')).toBe('status');
+    });
+
+    it('sets no role attribute when role input is set to "none"', () => {
+      component.role = 'none';
+      component.ngOnChanges();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('none')).toBe(null);
     });
   });
 

--- a/projects/canopy/src/lib/alert/alert.component.ts
+++ b/projects/canopy/src/lib/alert/alert.component.ts
@@ -59,10 +59,13 @@ export class LgAlertComponent implements OnChanges {
       if (this.explicitRole !== 'none') {
         this.roleAttr = this.explicitRole;
       }
-    } else if (this.variant === 'info' || this.variant === 'generic') {
-      this.roleAttr = null;
     } else {
-      this.roleAttr = 'alert';
+      switch (this.variant) {
+        case 'error':
+        case 'warning':
+        case 'success':
+          this.roleAttr = 'alert';
+      }
     }
   }
 }

--- a/projects/canopy/src/lib/alert/alert.component.ts
+++ b/projects/canopy/src/lib/alert/alert.component.ts
@@ -3,6 +3,7 @@ import {
   ElementRef,
   HostBinding,
   Input,
+  OnChanges,
   Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
@@ -15,8 +16,9 @@ import type { Variant } from '../variant/variant.interface';
   styleUrls: [ './alert.component.scss' ],
   encapsulation: ViewEncapsulation.None,
 })
-export class LgAlertComponent {
+export class LgAlertComponent implements OnChanges {
   private _variant: Variant;
+  private explicitRole: string;
 
   @Input() showIcon = true;
   @Input()
@@ -30,14 +32,13 @@ export class LgAlertComponent {
 
     this.renderer.addClass(this.hostElement.nativeElement, `lg-variant--${variant}`);
     this._variant = variant;
-    this.setRole();
   }
   get variant() {
     return this._variant;
   }
 
   @HostBinding('class.lg-alert') class = true;
-  @HostBinding('attr.role') _role: string;
+  @HostBinding('attr.role') roleAttr: string;
 
   constructor(
     private renderer: Renderer2,
@@ -46,12 +47,22 @@ export class LgAlertComponent {
     this.variant = 'generic';
   }
 
-  @Input() set role(role: string) {
-    this._role = role;
+  ngOnChanges() {
+    this.initRole();
   }
-  private setRole() {
-    if (!this._role && this.variant !== 'info' && this.variant !== 'generic') {
-      this._role = 'alert';
+
+  @Input() set role(role: string) {
+    this.explicitRole = role;
+  }
+  private initRole() {
+    if (this.explicitRole) {
+      if (this.explicitRole !== 'none') {
+        this.roleAttr = this.explicitRole;
+      }
+    } else if (this.variant === 'info' || this.variant === 'generic') {
+      this.roleAttr = null;
+    } else {
+      this.roleAttr = 'alert';
     }
   }
 }

--- a/projects/canopy/src/lib/alert/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/alert/docs/guide.stories.mdx
@@ -69,7 +69,7 @@ A basic inline message that should only be used if the others are unsuitable. Th
 
 ## Role
 
-It can be manually set through property binding or by passing the "none" value, preventing it from being set altogether. Otherwise, the role attribute is automatically assigned as 'alert' for any non-info and generic variants.
+It can be manually set through property binding or by passing the "none" value, preventing it from being set altogether. Otherwise, the role attribute is automatically assigned as 'alert' for anything other than `info` and `generic` variants.
 
 ## How it works
 

--- a/projects/canopy/src/lib/alert/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/alert/docs/guide.stories.mdx
@@ -69,7 +69,7 @@ A basic inline message that should only be used if the others are unsuitable. Th
 
 ## Role
 
-The role attribute is automatically set to 'alert' for any non-info and generic variants. It can be manually set or overridden through property binding.
+It can be manually set through property binding or by passing the "none" value, preventing it from being set altogether. Otherwise, the role attribute is automatically assigned as 'alert' for any non-info and generic variants.
 
 ## How it works
 


### PR DESCRIPTION
# Description

Currently, the variant setter code is unable to read the role input and automatically sets one. Subsequently, the role is read afterward and adjusted accordingly. Consequently, VoiceOver will behave according to the role set by the variant setter code, despite the role being changed immediately afterward.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
