### PR TITLE
Fix table content alignment

### DIFF
--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -16,6 +16,7 @@
     .lg-table-cell__content {
       margin-left: 0;
       margin-bottom: var(--space-md);
+      text-align: start;
     }
 
     &:last-child {
@@ -46,6 +47,7 @@
 
 .lg-table-cell__content--hidden-label {
   margin-left: 0;
+  text-align: start;
 }
 
 .lg-table-cell--expandable-content {

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -40,6 +40,7 @@
 }
 
 .lg-table-cell__content {
+  text-align: end;
   margin-left: auto;
 }
 


### PR DESCRIPTION
# Description

This PR fix the text alignment for the table content text.


Before:
![image](https://github.com/Legal-and-General/canopy/assets/132056063/40f917d8-4248-4d32-b42a-f700143ea05b)
After:
![image](https://github.com/Legal-and-General/canopy/assets/132056063/6cff849d-c1e3-424f-9bbf-f9460de9f700)

Fixes #1190 (https://github.com/Legal-and-General/canopy/issues/1190)

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
