### PR TITLE
feat: create a character counter on the input field

### DIFF
--- a/projects/canopy/src/lib/forms/input/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/forms/input/docs/guide.stories.mdx
@@ -106,6 +106,19 @@ There is an additional add-on button variant for adding a button to the input fi
 </lg-input-field>
 ```
 
+### Character counter
+
+A character counter can be added to any input which is using the `lgInput` directive and which has a `maxlength` attribute. The character counter will display when the remaining characters in the field are less than or equal to the `characterCounterTrigger`.
+
+For example, in the below code, the character counter will display after 15 characters have been entered as then there will only be 5 characters remaining.
+
+```html
+<lg-input-field>
+  Occupation
+  <input lgInput formControlName="occupation" maxlength="20" characterCounterTrigger="5"/>
+</lg-input-field>
+```
+
 ## Dos and Don'ts
 
 ### Do
@@ -140,11 +153,13 @@ There is an additional add-on button variant for adding a button to the input fi
 
 ### LgInputFieldComponent inputs
 
-| Name        | Description                                                                                                            | Type      | Default                      | Required |
-|-------------|------------------------------------------------------------------------------------------------------------------------|-----------|------------------------------|----------|
-| `id`        | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | `string`  | `lg-input-${nextUniqueId++}` | No       |
-| `block`     | Property to make the input full width (for small screens only)                                                         | `boolean` | `false`                      | No       |
-| `showLabel` | Show or visually hide the label                                                                                        | `boolean` | `true`                       | No       |
+| Name                      | Description                                                                                                            | Type      | Default                      | Required |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------|-----------|------------------------------|----------|
+| `id`                      | HTML ID attribute, auto generated if not provided. This will also propagate to the input 'id' and form 'for' attribute | `string`  | `lg-input-${nextUniqueId++}` | No       |
+| `block`                   | Property to make the input full width (for small screens only)                                                         | `boolean` | `false`                      | No       |
+| `showLabel`               | Show or visually hide the label                                                                                        | `boolean` | `true`                       | No       |
+| `characterCounterTrigger` | Number of remaining characters at which the character counter will display. Requires `maxlength` to be set.            | `number`  | `null`                       | No       |
+
 
 ------
 

--- a/projects/canopy/src/lib/forms/input/input-field.component.html
+++ b/projects/canopy/src/lib/forms/input/input-field.component.html
@@ -19,4 +19,6 @@
     <ng-content select="[lgSuffix]"></ng-content>
   </div>
 </div>
+<div *ngIf="characterCounterTrigger >= remainingChars" role="status">You have {{ remainingChars }} characters remaining</div>
+
 <ng-content select="lg-validation"></ng-content>

--- a/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
@@ -1,5 +1,5 @@
 import { DebugElement } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import {
@@ -292,6 +292,70 @@ describe('LgInputFieldComponent', () => {
 
     it('links the hint to the input field with the correct aria attributes', () => {
       expect(inputDirectiveInstance.ariaDescribedBy).toContain(prefixId);
+    });
+  });
+
+  describe('ngAfterContentInit', () => {
+    it('should disable the button when the input control status is "DISABLED"', () => {
+      const status = 'DISABLED';
+
+      spyOnProperty(component.inputElement.control, 'status', 'get').and.returnValue(
+        status,
+      );
+
+      fixture.detectChanges();
+
+      expect(component.buttonElement.disabled).toBeTrue();
+    });
+
+    describe('character counter', () => {
+      it('should update the character count and remaining characters when the input value changes', fakeAsync(() => {
+        const inputValue = 'Spider-man';
+        const maxLength = 20;
+        const characterCounterTrigger = 10;
+
+        spyOnProperty(component.inputElement, 'maxlength', 'get').and.returnValue(
+          maxLength,
+        );
+
+        spyOnProperty(
+          component.inputElement,
+          'characterCounterTrigger',
+          'get',
+        ).and.returnValue(characterCounterTrigger);
+
+        fixture.detectChanges();
+
+        component.inputElement.control.value.setValue(inputValue);
+        tick(100);
+
+        expect(component.charCount).toBe(inputValue.length);
+        expect(component.remainingChars).toBe(maxLength - inputValue.length);
+      }));
+
+      it('should update the character count and remaining characters to 0 when the input value exceeds the max length', fakeAsync(() => {
+        const inputValue = 'Spider-man';
+        const maxLength = 20;
+        const characterCounterTrigger = 10;
+
+        spyOnProperty(component.inputElement, 'maxlength', 'get').and.returnValue(
+          maxLength,
+        );
+
+        spyOnProperty(
+          component.inputElement,
+          'characterCounterTrigger',
+          'get',
+        ).and.returnValue(characterCounterTrigger);
+
+        fixture.detectChanges();
+
+        component.inputElement.control.value.setValue(inputValue);
+        tick(100);
+
+        expect(component.charCount).toBe(inputValue.length);
+        expect(component.remainingChars).toBe(0);
+      }));
     });
   });
 });

--- a/projects/canopy/src/lib/forms/input/input.directive.ts
+++ b/projects/canopy/src/lib/forms/input/input.directive.ts
@@ -45,6 +45,9 @@ export class LgInputDirective {
   @HostBinding('disabled')
   disabled = false;
 
+  @Input() maxlength: number | null = null;
+  @Input() characterCounterTrigger: number | null = null;
+
   @Input()
   @HostBinding('attr.aria-describedby')
   ariaDescribedBy: string | null = null;


### PR DESCRIPTION
# Description

Adds an optional character counter to the input field with a configurable element determining after how many entered characters it appears.

## Requirements

- `maxlength` and `characterCounterTrigger` attributes need to be set on the input for the character counter to appear.
  - If the `maxlength` and `characterCounterTrigger` attributes are the same, then the character counter will display before any value has been entered
  - If the `characterCounterTrigger` is `5` for example, the character counter will display when there are only 5 characters remaining. If the `maxlength` were set to `20`, the character counter would display after 15 characters had been entered.

Design link: (link to design or delete if not required) - TBC
Screenshot: ![image](https://github.com/Legal-and-General/canopy/assets/95081643/b296282a-d5c5-40f0-8202-1440fe07e95b)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
