### PR TITLE
Improve accordion accessibility

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -149,7 +149,7 @@
 
             <lg-accordion [headingLevel]="3">
               <lg-accordion-item>
-                <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>
+                <lg-accordion-panel-heading ariaDescription="Test accordion">Item 1</lg-accordion-panel-heading>
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
                   tempor incididunt ut labore et dolore magna aliqua.
@@ -660,7 +660,7 @@
                 <lg-progress-header>
                   Thinking long term
                 </lg-progress-header>
-              </lg-progress-indicator>  
+              </lg-progress-indicator>
             </div>
             <lg-separator></lg-separator>
 

--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -145,11 +145,11 @@
       <div lgCol="12" lgColLg="9" lgColMdOffset="0">
         <lg-card>
           <lg-card-content>
-            <lg-heading level="3">Accordion</lg-heading>
+            <lg-heading level="3" id="accordion-title">Accordion</lg-heading>
 
             <lg-accordion [headingLevel]="3">
               <lg-accordion-item>
-                <lg-accordion-panel-heading ariaDescription="Test accordion">Item 1</lg-accordion-panel-heading>
+                <lg-accordion-panel-heading ariaDescribedBy="accordion-title">Item 1</lg-accordion-panel-heading>
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
                   tempor incididunt ut labore et dolore magna aliqua.

--- a/projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-item/accordion-item.component.ts
@@ -16,6 +16,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
+  HostBinding,
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
@@ -45,6 +46,9 @@ export class LgAccordionItemComponent implements AfterContentInit, OnChanges, On
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _contentTemplate: TemplateRef<any>;
 
+  @HostBinding('role') role = 'listitem';
+  // used for adding more context to the heading
+  @Input() ariaDescribedBy: string = null;
   @Input() isActive = false;
   @Output() opened = new EventEmitter<void>();
   @Output() closed = new EventEmitter<void>();

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
@@ -9,7 +9,7 @@
     [attr.aria-expanded]="_isActive"
     [attr.aria-controls]="_panelId"
     (click)="toggle()"
-    [attr.aria-description]="ariaDescription"
+    [attr.aria-describedBy]="ariaDescribedBy"
   >
     <ng-content></ng-content>
     <lg-icon class="lg-accordion__heading-icon" name="chevron-down"></lg-icon>

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
@@ -1,4 +1,6 @@
-<lg-heading [level]="headingLevel" class="lg-accordion__heading">
+<lg-heading
+  [level]="headingLevel"
+  class="lg-accordion__heading">
   <button
     type="button"
     [id]="_toggleId"
@@ -7,6 +9,7 @@
     [attr.aria-expanded]="_isActive"
     [attr.aria-controls]="_panelId"
     (click)="toggle()"
+    [attr.aria-description]="ariaDescription"
   >
     <ng-content></ng-content>
     <lg-icon class="lg-accordion__heading-icon" name="chevron-down"></lg-icon>

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
@@ -9,7 +9,7 @@
     [attr.aria-expanded]="_isActive"
     [attr.aria-controls]="_panelId"
     (click)="toggle()"
-    [attr.aria-describedBy]="ariaDescribedBy"
+    [attr.aria-describedby]="ariaDescribedBy"
   >
     <ng-content></ng-content>
     <lg-icon class="lg-accordion__heading-icon" name="chevron-down"></lg-icon>

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
@@ -22,6 +22,7 @@ let nextUniqueId = 0;
 })
 export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
   @Input() headingLevel: HeadingLevel;
+  // used for adding more context to the heading
   @Input() ariaDescription;
   @Input()
   get isActive() {

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
@@ -22,8 +22,6 @@ let nextUniqueId = 0;
 })
 export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
   @Input() headingLevel: HeadingLevel;
-  // used for adding more context to the heading
-  @Input() ariaDescription;
   @Input()
   get isActive() {
     return this._isActive;

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
@@ -22,6 +22,7 @@ let nextUniqueId = 0;
 })
 export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
   @Input() headingLevel: HeadingLevel;
+  @Input() ariaDescription;
   @Input()
   get isActive() {
     return this._isActive;

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
@@ -22,6 +22,8 @@ let nextUniqueId = 0;
 })
 export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
   @Input() headingLevel: HeadingLevel;
+  // provide more context to the screen readers about the current accordion item
+  @Input() ariaDescribedBy: string = null;
   @Input()
   get isActive() {
     return this._isActive;

--- a/projects/canopy/src/lib/accordion/accordion.component.spec.ts
+++ b/projects/canopy/src/lib/accordion/accordion.component.spec.ts
@@ -16,9 +16,7 @@ import { LgAccordionComponent } from './accordion.component';
   template: `
     <lg-accordion [headingLevel]="2" [multi]="isMulti">
       <lg-accordion-item>
-        <lg-accordion-panel-heading ariaDescription="Test accordion"
-          >Test</lg-accordion-panel-heading
-        >
+        <lg-accordion-panel-heading>Test</lg-accordion-panel-heading>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
         incididunt ut labore et dolore magna aliqua.
       </lg-accordion-item>
@@ -96,20 +94,6 @@ describe('LgAccordionComponent', () => {
 
       expect(itemOne.componentInstance.isActive).toBeTruthy();
       expect(itemTwo.componentInstance.isActive).toBeFalsy();
-    });
-  });
-
-  describe('accessibility', () => {
-    it('should add aria-description to each panel heading', () => {
-      const items = fixture.debugElement.queryAll(
-        By.css('.lg-accordion__heading button'),
-      );
-
-      expect(items[0].componentInstance.ariaDescription).toBe(
-        'Test accordion, item 1 of 2',
-      );
-
-      expect(items[1].componentInstance.ariaDescription).toBe('item 2 of 2');
     });
   });
 });

--- a/projects/canopy/src/lib/accordion/accordion.component.spec.ts
+++ b/projects/canopy/src/lib/accordion/accordion.component.spec.ts
@@ -16,7 +16,9 @@ import { LgAccordionComponent } from './accordion.component';
   template: `
     <lg-accordion [headingLevel]="2" [multi]="isMulti">
       <lg-accordion-item>
-        <lg-accordion-panel-heading>Test</lg-accordion-panel-heading>
+        <lg-accordion-panel-heading ariaDescription="Test accordion"
+          >Test</lg-accordion-panel-heading
+        >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
         incididunt ut labore et dolore magna aliqua.
       </lg-accordion-item>
@@ -94,6 +96,20 @@ describe('LgAccordionComponent', () => {
 
       expect(itemOne.componentInstance.isActive).toBeTruthy();
       expect(itemTwo.componentInstance.isActive).toBeFalsy();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should add aria-description to each panel heading', () => {
+      const items = fixture.debugElement.queryAll(
+        By.css('.lg-accordion__heading button'),
+      );
+
+      expect(items[0].componentInstance.ariaDescription).toBe(
+        'Test accordion, item 1 of 2',
+      );
+
+      expect(items[1].componentInstance.ariaDescription).toBe('item 2 of 2');
     });
   });
 });

--- a/projects/canopy/src/lib/accordion/accordion.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion.component.ts
@@ -39,8 +39,13 @@ export class LgAccordionComponent implements AfterContentInit {
   panelHeadings: QueryList<LgAccordionPanelHeadingComponent>;
 
   ngAfterContentInit() {
-    this.panelHeadings.forEach(panelHeading => {
+    this.panelHeadings.forEach((panelHeading, index) => {
       panelHeading.headingLevel = this.headingLevel;
+      const itemCounting = `item ${index + 1} of ${this.panelHeadings.length}`;
+
+      panelHeading.ariaDescription = panelHeading.ariaDescription
+        ? `${panelHeading.ariaDescription}, ${itemCounting}`
+        : itemCounting;
     });
   }
 }

--- a/projects/canopy/src/lib/accordion/accordion.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion.component.ts
@@ -43,6 +43,7 @@ export class LgAccordionComponent implements AfterContentInit {
       panelHeading.headingLevel = this.headingLevel;
       const itemCounting = `item ${index + 1} of ${this.panelHeadings.length}`;
 
+      // Add more context to the heading, uses whatever has been provided with @Input ariaDescription property of the panel heading and the item counting
       panelHeading.ariaDescription = panelHeading.ariaDescription
         ? `${panelHeading.ariaDescription}, ${itemCounting}`
         : itemCounting;

--- a/projects/canopy/src/lib/accordion/accordion.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion.component.ts
@@ -30,6 +30,7 @@ let nextUniqueId = 0;
 export class LgAccordionComponent implements AfterContentInit {
   @HostBinding('class.lg-accordion') class = true;
   @HostBinding('id') @Input() id = `lg-accordion-${nextUniqueId++}`;
+  @HostBinding('role') role = 'list';
   @Input() headingLevel: HeadingLevel;
   @Input() multi = true;
 
@@ -39,14 +40,8 @@ export class LgAccordionComponent implements AfterContentInit {
   panelHeadings: QueryList<LgAccordionPanelHeadingComponent>;
 
   ngAfterContentInit() {
-    this.panelHeadings.forEach((panelHeading, index) => {
+    this.panelHeadings.forEach(panelHeading => {
       panelHeading.headingLevel = this.headingLevel;
-      const itemCounting = `item ${index + 1} of ${this.panelHeadings.length}`;
-
-      // Add more context to the heading, uses whatever has been provided with @Input ariaDescription property of the panel heading and the item counting
-      panelHeading.ariaDescription = panelHeading.ariaDescription
-        ? `${panelHeading.ariaDescription}, ${itemCounting}`
-        : itemCounting;
     });
   }
 }

--- a/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
+++ b/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
@@ -64,7 +64,7 @@ const accordionItems = `
 <lg-accordion-item [isActive]="itemOneActive"
                    (opened)="toggle('Item 1 opened')"
                    (closed)="toggle('Item 1 closed')">
-  <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading ariaDescription="Test accordion">Item 1</lg-accordion-panel-heading>
 
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -72,7 +72,7 @@ const accordionItems = `
 <lg-accordion-item [isActive]="itemTwoActive"
                    (opened)="toggle('Item 3 opened')"
                    (closed)="toggle('Item 2 closed')">
-  <lg-accordion-panel-heading>Item 2</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading ariaDescription="Test accordion">Item 2</lg-accordion-panel-heading>
 
   <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
     ut aliquip ex ea commodo consequat. Duis aute irure dolor in
@@ -83,7 +83,7 @@ const accordionItems = `
   </button>
 </lg-accordion-item>
 <lg-accordion-item [isActive]="itemThreeActive">
-  <lg-accordion-panel-heading>Item 3 is Lazy</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading ariaDescription="Test accordion">Item 3 is Lazy</lg-accordion-panel-heading>
 
   <ng-template lgAccordionItemContent>
     <p>This panel content is only initialised when opened</p>

--- a/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
+++ b/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
@@ -92,7 +92,7 @@ const accordionItems = `
 `;
 
 const standardTemplate = `<h1 id="accordion-title">Test accordion</h1>
-<lg-accordion [headingLevel]="headingLevel" [multi]=multi>${accordionItems}</lg-accordion>`;
+<lg-accordion [headingLevel]="headingLevel" [multi]="multi">${accordionItems}</lg-accordion>`;
 
 const accordionTemplate: StoryFn<LgAccordionComponent> = (
   args: LgAccordionComponent,

--- a/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
+++ b/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
@@ -57,6 +57,12 @@ export default {
         disable: true,
       },
     },
+    ariaDescription: {
+      control: {
+        type: 'text',
+      },
+      description: 'Used for adding more context to the heading.',
+    },
   },
 } as Meta;
 
@@ -64,7 +70,7 @@ const accordionItems = `
 <lg-accordion-item [isActive]="itemOneActive"
                    (opened)="toggle('Item 1 opened')"
                    (closed)="toggle('Item 1 closed')">
-  <lg-accordion-panel-heading ariaDescription="Test accordion">Item 1</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading [ariaDescription]="accordionDescription">Item 1</lg-accordion-panel-heading>
 
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -72,7 +78,7 @@ const accordionItems = `
 <lg-accordion-item [isActive]="itemTwoActive"
                    (opened)="toggle('Item 3 opened')"
                    (closed)="toggle('Item 2 closed')">
-  <lg-accordion-panel-heading ariaDescription="Test accordion">Item 2</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading [ariaDescription]="accordionDescription">Item 2</lg-accordion-panel-heading>
 
   <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
     ut aliquip ex ea commodo consequat. Duis aute irure dolor in
@@ -83,7 +89,7 @@ const accordionItems = `
   </button>
 </lg-accordion-item>
 <lg-accordion-item [isActive]="itemThreeActive">
-  <lg-accordion-panel-heading ariaDescription="Test accordion">Item 3 is Lazy</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading [ariaDescription]="accordionDescription">Item 3 is Lazy</lg-accordion-panel-heading>
 
   <ng-template lgAccordionItemContent>
     <p>This panel content is only initialised when opened</p>
@@ -109,6 +115,7 @@ standardAccordion.args = {
   itemTwoActive: true,
   itemThreeActive: false,
   multi: false,
+  accordionDescription: 'Test accordion',
 };
 
 standardAccordion.parameters = {

--- a/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
+++ b/projects/canopy/src/lib/accordion/docs/accordion.stories.ts
@@ -57,12 +57,6 @@ export default {
         disable: true,
       },
     },
-    ariaDescription: {
-      control: {
-        type: 'text',
-      },
-      description: 'Used for adding more context to the heading.',
-    },
   },
 } as Meta;
 
@@ -70,7 +64,7 @@ const accordionItems = `
 <lg-accordion-item [isActive]="itemOneActive"
                    (opened)="toggle('Item 1 opened')"
                    (closed)="toggle('Item 1 closed')">
-  <lg-accordion-panel-heading [ariaDescription]="accordionDescription">Item 1</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading ariaDescribedBy="accordion-title">Item 1</lg-accordion-panel-heading>
 
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -78,7 +72,7 @@ const accordionItems = `
 <lg-accordion-item [isActive]="itemTwoActive"
                    (opened)="toggle('Item 3 opened')"
                    (closed)="toggle('Item 2 closed')">
-  <lg-accordion-panel-heading [ariaDescription]="accordionDescription">Item 2</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading ariaDescribedBy="accordion-title">Item 2</lg-accordion-panel-heading>
 
   <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
     ut aliquip ex ea commodo consequat. Duis aute irure dolor in
@@ -89,7 +83,7 @@ const accordionItems = `
   </button>
 </lg-accordion-item>
 <lg-accordion-item [isActive]="itemThreeActive">
-  <lg-accordion-panel-heading [ariaDescription]="accordionDescription">Item 3 is Lazy</lg-accordion-panel-heading>
+  <lg-accordion-panel-heading ariaDescribedBy="accordion-title">Item 3 is Lazy</lg-accordion-panel-heading>
 
   <ng-template lgAccordionItemContent>
     <p>This panel content is only initialised when opened</p>
@@ -97,7 +91,8 @@ const accordionItems = `
 </lg-accordion-item>
 `;
 
-const standardTemplate = `<lg-accordion [headingLevel]="headingLevel" [multi]=multi>${accordionItems}</lg-accordion>`;
+const standardTemplate = `<h1 id="accordion-title">Test accordion</h1>
+<lg-accordion [headingLevel]="headingLevel" [multi]=multi>${accordionItems}</lg-accordion>`;
 
 const accordionTemplate: StoryFn<LgAccordionComponent> = (
   args: LgAccordionComponent,
@@ -115,7 +110,6 @@ standardAccordion.args = {
   itemTwoActive: true,
   itemThreeActive: false,
   multi: false,
-  accordionDescription: 'Test accordion',
 };
 
 standardAccordion.parameters = {

--- a/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
@@ -100,9 +100,9 @@ Accordions have a chevron to indicate that they are interactive, but clicking an
 
 #### Inputs
 
-| Name              | Description                      | Type      | Default | Required |
-|------------       |----------------------------------|-----------|---------|----------|
-| `ariaDescription` | Add more context to the heading  | `string ` | ``      | No       |
+| Name              | Description                                                                        | Type      | Default | Required |
+|-------------------|------------------------------------------------------------------------------------|-----------|---------|----------|
+| `ariaDescribedBy` | Add more context to the heading by providing the id of other elements in the page  | `string ` | ``      | No       |
 
 #### Outputs
 

--- a/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
@@ -33,7 +33,7 @@ and in your HTML:
 ```html
 <lg-accordion [headingLevel]="2">
   <lg-accordion-item [isActive]="isActive" (opened)="handleItemOpened()" (closed)="handleItemClosed()">
-    <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>
+    <lg-accordion-panel-heading ariaDescription="Test accordion">Item 1</lg-accordion-panel-heading>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua.</p>
   </lg-accordion-item>
@@ -94,6 +94,15 @@ Accordions have a chevron to indicate that they are interactive, but clicking an
 | Name       | Description                            | Type      | Default | Required |
 |------------|----------------------------------------|-----------|---------|----------|
 | `isActive` | The active state of the accordion item | `boolean` | `false` | No       |
+
+
+### LgAccordionPanelHeadingComponent
+
+#### Inputs
+
+| Name              | Description                      | Type      | Default | Required |
+|------------       |----------------------------------|-----------|---------|----------|
+| `ariaDescription` | Add more context to the heading  | `string ` | ``      | No       |
 
 #### Outputs
 

--- a/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/accordion/docs/guide.stories.mdx
@@ -33,7 +33,7 @@ and in your HTML:
 ```html
 <lg-accordion [headingLevel]="2">
   <lg-accordion-item [isActive]="isActive" (opened)="handleItemOpened()" (closed)="handleItemClosed()">
-    <lg-accordion-panel-heading ariaDescription="Test accordion">Item 1</lg-accordion-panel-heading>
+    <lg-accordion-panel-heading>Item 1</lg-accordion-panel-heading>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua.</p>
   </lg-accordion-item>


### PR DESCRIPTION
# Description

After discussing within our team, we thought it would be a good idea to let screen reader users know more details for each accordion item. To provide more context, I used the `aria-describedby` attribute set on the accordion-item heading. By setting `role="list"` on the accordion and `role="listitem"` on each accordion item, the items can be easily selected with screen readers.

## Screenshots

### aria-describedby on an accordion-panel-heading > button
![image](https://github.com/user-attachments/assets/cd2cad5d-3191-4140-8655-c8d93faa25e3)

### role="list" set on the accordion component
![image](https://github.com/user-attachments/assets/a5a7c735-1103-41c6-bbfa-979aba8d5c6c)

### role="listitem" set on an accordion item
![image](https://github.com/user-attachments/assets/856d43ad-ee70-4a8a-a1fa-b7cd83cabd10)

### the accessibility tree for the list
![image](https://github.com/user-attachments/assets/8ec07d15-e0c7-4af8-807f-8da54b7a4260)

### Live demo of the solution
https://github.com/user-attachments/assets/5df5e5a6-d134-4f83-8071-e3498b3eaa54

### Selecting the list using a screen reader
For example, on Voice Over, the list can be selected with the following key combination  **VO + Command + X**.


https://github.com/user-attachments/assets/e2f5705a-292e-4238-a4ab-1c0b8c7a67b7






# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
