### PR TITLE
Fix carousel storybook documentation and unit tests

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,6 +22,7 @@ module.exports = {
     // Components
     '../projects/canopy/src/lib/accordion/docs/guide.stories.mdx',
     '../projects/canopy/src/lib/accordion/docs/accordion.stories.ts',
+    '../projects/canopy/src/lib/carousel/docs/carousel.stories.ts',
     '../projects/canopy/src/lib/alert/docs/guide.stories.mdx',
     '../projects/canopy/src/lib/alert/docs/alert.stories.ts',
     '../projects/canopy/src/lib/banner/docs/guide.stories.mdx',

--- a/projects/canopy/src/lib/carousel/carousel.component.html
+++ b/projects/canopy/src/lib/carousel/carousel.component.html
@@ -13,7 +13,7 @@
     class="lg-carousel__wrapper"
     [style.width.%]="100 * carouselItemCount"
     [style.left.%]="-100 * selectedItemIndex"
-    [style.transition]="'left ease ' + slideDuration / 1000 + 's'"
+    [style.transition]="'left ' + slideDuration / 1000 + 's'"
   >
     <ng-content></ng-content>
   </div>

--- a/projects/canopy/src/lib/carousel/carousel.component.spec.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.spec.ts
@@ -131,7 +131,7 @@ describe('LgCarouselComponent', () => {
     expect(component.carouselItemCount).toBe(3);
 
     expect(wrapperElement.attributes['style']).toBe(
-      'width: 300%; left: 0%; transition: left 0.5s ease 0s;',
+      'width: 300%; left: 0%; transition: left 0.5s;',
     );
   });
 

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -41,6 +41,9 @@ import { LgAutoplayComponent } from './auto-play/auto-play.component';
     NgClass,
   ],
 })
+/**
+ * @deprecated This component will be removed in the future
+ */
 export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   private unsubscribe: Subject<void> = new Subject<void>();
   selectedItem: LgCarouselItemComponent;

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -12,6 +12,7 @@ import {
 import { BehaviorSubject, defer, interval, Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil, withLatestFrom } from 'rxjs/operators';
 import { NgIf, NgFor, NgClass } from '@angular/common';
+import { lgIconChevronLeft, lgIconChevronRight } from 'canopy';
 
 import type { HeadingLevel } from '../heading';
 import { LgIconComponent } from '../icon';
@@ -19,6 +20,7 @@ import { LgHeadingComponent } from '../heading';
 
 import { LgCarouselItemComponent } from './carousel-item/carousel-item.component';
 import { LgAutoplayComponent } from './auto-play/auto-play.component';
+import { LgIconRegistry } from './../icon/icon.registry';
 
 @Component({
   selector: 'lg-carousel',
@@ -56,7 +58,12 @@ export class LgCarouselComponent implements AfterContentInit, OnDestroy {
   @ContentChildren(LgCarouselItemComponent, { read: LgCarouselItemComponent })
   carouselItems = new QueryList<LgCarouselItemComponent>();
 
-  constructor(private cd: ChangeDetectorRef) {}
+  constructor(
+    private cd: ChangeDetectorRef,
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([ lgIconChevronLeft, lgIconChevronRight ]);
+  }
 
   pauseCarousel(): void {
     this.pause.next(true);

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -12,10 +12,9 @@ import {
 import { BehaviorSubject, defer, interval, Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil, withLatestFrom } from 'rxjs/operators';
 import { NgIf, NgFor, NgClass } from '@angular/common';
-import { lgIconChevronLeft, lgIconChevronRight } from 'canopy';
 
 import type { HeadingLevel } from '../heading';
-import { LgIconComponent } from '../icon';
+import { LgIconComponent, lgIconChevronLeft, lgIconChevronRight } from '../icon';
 import { LgHeadingComponent } from '../heading';
 
 import { LgCarouselItemComponent } from './carousel-item/carousel-item.component';

--- a/projects/canopy/src/lib/carousel/carousel.component.ts
+++ b/projects/canopy/src/lib/carousel/carousel.component.ts
@@ -14,12 +14,16 @@ import { filter, map, takeUntil, withLatestFrom } from 'rxjs/operators';
 import { NgIf, NgFor, NgClass } from '@angular/common';
 
 import type { HeadingLevel } from '../heading';
-import { LgIconComponent, lgIconChevronLeft, lgIconChevronRight } from '../icon';
+import {
+  LgIconComponent,
+  LgIconRegistry,
+  lgIconChevronLeft,
+  lgIconChevronRight,
+} from '../icon';
 import { LgHeadingComponent } from '../heading';
 
 import { LgCarouselItemComponent } from './carousel-item/carousel-item.component';
 import { LgAutoplayComponent } from './auto-play/auto-play.component';
-import { LgIconRegistry } from './../icon/icon.registry';
 
 @Component({
   selector: 'lg-carousel',

--- a/projects/canopy/src/lib/carousel/docs/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/docs/carousel.stories.ts
@@ -1,12 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { moduleMetadata, StoryFn } from '@storybook/angular';
 
-import { notes } from './carousel.notes';
-
-import { LgCarouselComponent } from '.';
+import { notes } from '../carousel.notes';
+import { LgCarouselComponent } from '..';
 
 export default {
-  title: 'Components/Carousel',
+  title: 'Components/Carousel/Examples',
   decorators: [
     moduleMetadata({
       imports: [ CommonModule, LgCarouselComponent ],

--- a/projects/canopy/src/lib/carousel/docs/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/docs/carousel.stories.ts
@@ -7,7 +7,7 @@ import { LgIconComponent } from '../../icon';
 import { LgAutoplayComponent } from '../auto-play/auto-play.component';
 
 export default {
-  title: 'Components/Carousel/Examples',
+  title: 'Components/Carousel/[DEPRECATED]/Examples',
   decorators: [
     moduleMetadata({
       imports: [
@@ -150,10 +150,12 @@ const carouselItems = `
 `;
 
 const template = `
+  <h1>[DEPRECATED]</h1>
   <lg-carousel [description]="description" [headingLevel]="headingLevel" [slideDuration]="slideDuration" [loopMode]="loopMode" [autoPlayDelay]="autoPlayDelay" [autoPlay]="autoPlay">${carouselItems}</lg-carousel>
 `;
 
 const defaultTemplate = `
+  <h1>[DEPRECATED]</h1>
   <lg-carousel [description]="description" [headingLevel]="headingLevel" [slideDuration]="slideDuration">${carouselItems}</lg-carousel>
 `;
 
@@ -183,6 +185,7 @@ defaultCarousel.parameters = {
 };
 
 const loopEnabledTemplate = `
+  <h1>[DEPRECATED]</h1>
   <lg-carousel [description]="description" [headingLevel]="headingLevel" [slideDuration]="slideDuration" [loopMode]="loopMode">${carouselItems}</lg-carousel>
 `;
 
@@ -207,6 +210,7 @@ loopModeEnabledCarousel.parameters = {
 };
 
 const autoPlayEnabledTemplate = `
+  <h1>[DEPRECATED]</h1>
   <lg-carousel [description]="description" [headingLevel]="headingLevel" [slideDuration]="slideDuration" [autoPlayDelay]="5000" [autoPlay]="true">${carouselItems}</lg-carousel>
 `;
 

--- a/projects/canopy/src/lib/carousel/docs/carousel.stories.ts
+++ b/projects/canopy/src/lib/carousel/docs/carousel.stories.ts
@@ -2,13 +2,21 @@ import { CommonModule } from '@angular/common';
 import { moduleMetadata, StoryFn } from '@storybook/angular';
 
 import { notes } from '../carousel.notes';
-import { LgCarouselComponent } from '..';
+import { LgCarouselComponent, LgCarouselItemComponent } from '..';
+import { LgIconComponent } from '../../icon';
+import { LgAutoplayComponent } from '../auto-play/auto-play.component';
 
 export default {
   title: 'Components/Carousel/Examples',
   decorators: [
     moduleMetadata({
-      imports: [ CommonModule, LgCarouselComponent ],
+      imports: [
+        CommonModule,
+        LgCarouselComponent,
+        LgIconComponent,
+        LgAutoplayComponent,
+        LgCarouselItemComponent,
+      ],
     }),
   ],
   parameters: {


### PR DESCRIPTION
# Description

At the moment, one of the Carousel unit tests is failing due to how a transition is defined as an inline style.

![image](https://github.com/user-attachments/assets/87fbda16-bba8-4793-b24c-b2fb6a7602c4)


Fixes # (issue)

To fix this, I had to remove the `ease` `transition-timing-property` from the inline style at line 16 in `projects/canopy/src/lib/carousel/carousel.component.html`, as it seems it's ignored by Angular due to being the default value for that property(this is an assumption). After doing this, I also had to update the related unit test case.

![image](https://github.com/user-attachments/assets/82c2cab6-4695-431e-afea-569b375c5679)

Using any other `transition-timing-property` value other than the default results in that value being visible in the DOM.

<img width="583" alt="image" src="https://github.com/user-attachments/assets/46bf2839-4080-4a81-871d-2b6a0d7a64bc">

![image](https://github.com/user-attachments/assets/15420f0b-777d-4109-9480-d289dd7f7067)

To test the transition fix of the carousel, I also had to fix a bug where the Storybook story of the accordion wasn't visible due to a missing configuration import in `.storybook/main.js`.

Also fixes some standalone components imports and uses the `RegistryIconService` to inject missing icons in the carousel.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in Storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to `public-api.ts`
