### PR TITLE
Fix a visual bug of the accordion with decorative icon variant

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -167,7 +167,7 @@
                 </button>
               </lg-accordion-item>
               <lg-accordion-item>
-                <lg-accordion-panel-heading><lg-icon name="notes"></lg-icon>Accordion item with icon</lg-accordion-panel-heading>
+                <lg-accordion-panel-heading><lg-icon name="notes"></lg-icon>Accordion item with icon and very long heading text</lg-accordion-panel-heading>
                 <p>
                   Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
                   aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
@@ -1,4 +1,4 @@
-<lg-heading class="lg-accordion__heading" [level]="headingLevel">
+<lg-heading [level]="headingLevel" class="lg-accordion__heading">
   <button
     type="button"
     [id]="_toggleId"

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.html
@@ -1,9 +1,10 @@
-<lg-heading [level]="headingLevel" class="lg-accordion__heading">
+<lg-heading class="lg-accordion__heading" [level]="headingLevel">
   <button
     type="button"
     [id]="_toggleId"
     class="lg-accordion__heading-toggle"
     [class.lg-accordion__heading-toggle--active]="_isActive"
+    [class.lg-accordion__heading-toggle--with-icon]="!!decorativeIcon"
     [attr.aria-expanded]="_isActive"
     [attr.aria-controls]="_panelId"
     (click)="toggle()">

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.scss
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.scss
@@ -27,6 +27,10 @@
   text-align: left;
   width: 100%;
 
+  &--with-icon {
+    padding-right: var(--space-xxl);
+  }
+
   &:focus-visible {
     @include lg-focus-outline;
 

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
@@ -3,11 +3,13 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ContentChild,
   EventEmitter,
   Input,
   Output,
   ViewEncapsulation,
 } from '@angular/core';
+import { NgClass } from '@angular/common';
 
 import type { HeadingLevel } from '../../heading';
 import { lgIconChevronDown, LgIconComponent, LgIconRegistry } from '../../icon';
@@ -22,7 +24,7 @@ let nextUniqueId = 0;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [ LgHeadingComponent, LgIconComponent ],
+  imports: [ LgHeadingComponent, LgIconComponent, NgClass ],
 })
 export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
   @Input() headingLevel: HeadingLevel;
@@ -35,12 +37,12 @@ export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
     this.cdr.markForCheck();
   }
   @Output() toggleActive = new EventEmitter<boolean>();
+  @ContentChild(LgIconComponent) decorativeIcon: LgIconComponent;
 
   _id = nextUniqueId++;
   _toggleId = `lg-accordion-panel-heading-${this._id}`;
   _panelId = `lg-accordion-panel-${this._id}`;
   _isActive = false;
-  _hasDecorativeIcon = false;
 
   constructor(
     private cdr: ChangeDetectorRef,

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.ts
@@ -9,7 +9,6 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
-import { NgClass } from '@angular/common';
 
 import type { HeadingLevel } from '../../heading';
 import { lgIconChevronDown, LgIconComponent, LgIconRegistry } from '../../icon';
@@ -24,7 +23,7 @@ let nextUniqueId = 0;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [ LgHeadingComponent, LgIconComponent, NgClass ],
+  imports: [ LgHeadingComponent, LgIconComponent ],
 })
 export class LgAccordionPanelHeadingComponent implements AfterViewChecked {
   @Input() headingLevel: HeadingLevel;


### PR DESCRIPTION
# Description

Fixes a visual bug where the text of the accordion panel heading overlaps the chevron icon when the text is long. This issue is visible on mobile devices.

## Requirements

Screenshot:

**Before**

![Screenshot 2024-09-16 at 13 34 26](https://github.com/user-attachments/assets/6afbe741-4145-4b0e-ae5f-a98cb79b690f)

**After**

![image](https://github.com/user-attachments/assets/09337f8d-1e02-4962-8be7-0bb94a64f9f2)


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [x] I have added any new public feature modules to public-api.ts
