### PR TITLE
Add missing icons on certain components

### DIFF
--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item/breadcrumb-item.component.ts
@@ -14,7 +14,6 @@ import {
   LgIconRegistry,
   lgIconCaretLeft,
   lgIconCaretRight,
-  lgIconHome,
 } from '../../icon';
 
 import { BreadcrumbVariant } from './breadcrumb-item.interface';
@@ -44,7 +43,7 @@ export class LgBreadcrumbItemComponent {
     private cd: ChangeDetectorRef,
     private registry: LgIconRegistry,
   ) {
-    this.registry.registerIcons([ lgIconHome, lgIconCaretLeft, lgIconCaretRight ]);
+    this.registry.registerIcons([ lgIconCaretLeft, lgIconCaretRight ]);
   }
 
   set hideIcons(hideIcons: boolean) {

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.ts
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.ts
@@ -13,7 +13,7 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 import type { HeadingLevel } from '../../heading';
 import isExternalURL from '../../utils/external-links';
-import { LgIconComponent } from '../../icon';
+import { lgIconArrowRight, LgIconComponent, LgIconRegistry } from '../../icon';
 import { LgHeadingComponent } from '../../heading';
 
 @Component({
@@ -36,6 +36,10 @@ export class LgCardNavigationTitleComponent implements OnInit {
   @Input() queryParams?: Params = null;
   @Input() queryParamsHandling?: QueryParamsHandling = null;
   @Output() linkClickedEvent = new EventEmitter<void>();
+
+  constructor(private iconRegistry: LgIconRegistry) {
+    this.iconRegistry.registerIcons([ lgIconArrowRight ]);
+  }
 
   ngOnInit(): void {
     if (!(this.headingLevel && this.title && this.link)) {

--- a/projects/canopy/src/lib/carousel/auto-play/auto-play.component.ts
+++ b/projects/canopy/src/lib/carousel/auto-play/auto-play.component.ts
@@ -8,7 +8,12 @@ import {
 import { BehaviorSubject } from 'rxjs';
 import { NgIf } from '@angular/common';
 
-import { LgIconComponent } from '../../icon';
+import {
+  LgIconComponent,
+  lgIconPauseSpot,
+  lgIconPlaySpot,
+  LgIconRegistry,
+} from '../../icon';
 
 @Component({
   selector: 'lg-auto-play',
@@ -23,5 +28,10 @@ export class LgAutoplayComponent {
 
   @HostBinding('class.lg-carousel-autoplay') class = true;
 
-  constructor(public element: ElementRef) {}
+  constructor(
+    public element: ElementRef,
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([ lgIconPauseSpot, lgIconPlaySpot ]);
+  }
 }

--- a/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
+++ b/projects/canopy/src/lib/details/details-panel-heading/details-panel-heading.component.ts
@@ -9,7 +9,14 @@ import {
 } from '@angular/core';
 import { NgIf, NgSwitch, NgSwitchCase } from '@angular/common';
 
-import { lgIconChevronDown } from '../../icon';
+import {
+  lgIconCheckmarkSpotFill,
+  lgIconChevronDown,
+  lgIconCrossmarkSpotFill,
+  lgIconInformationFill,
+  LgIconRegistry,
+  lgIconWarningFill,
+} from '../../icon';
 import type { Variant } from '../../variant';
 import { LgIconComponent } from '../../icon';
 import { LgHeadingComponent } from '../../heading';
@@ -52,7 +59,18 @@ export class LgDetailsPanelHeadingComponent {
   chevronDown = lgIconChevronDown.name;
   uniqueId: number;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(
+    private cdr: ChangeDetectorRef,
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([
+      lgIconCrossmarkSpotFill,
+      lgIconInformationFill,
+      lgIconWarningFill,
+      lgIconCheckmarkSpotFill,
+      lgIconChevronDown,
+    ]);
+  }
 
   toggle(): void {
     this.isActive = !this.isActive;

--- a/projects/canopy/src/lib/forms/select/select-field.component.ts
+++ b/projects/canopy/src/lib/forms/select/select-field.component.ts
@@ -12,7 +12,7 @@ import { LgHintComponent } from '../hint';
 import { LgLabelComponent } from '../label';
 import { LgErrorStateMatcher } from '../validation';
 import { LgValidationComponent } from '../validation';
-import { LgIconComponent } from '../../icon';
+import { lgIconChevronDown, LgIconComponent, LgIconRegistry } from '../../icon';
 
 import { LgSelectDirective } from './select.directive';
 
@@ -90,5 +90,8 @@ export class LgSelectFieldComponent {
   constructor(
     private errorState: LgErrorStateMatcher,
     private domService: LgDomService,
-  ) {}
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([ lgIconChevronDown ]);
+  }
 }

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.ts
@@ -23,7 +23,13 @@ import { LgDomService } from '../../utils';
 import { LgErrorStateMatcher } from '../validation';
 import { LgValidationComponent } from '../validation';
 import { LgCheckboxGroupComponent } from '../checkbox-group';
-import { LgIconComponent } from '../../icon';
+import {
+  lgIconAdd,
+  lgIconCheckboxMark,
+  lgIconCheckmark,
+  LgIconComponent,
+  LgIconRegistry,
+} from '../../icon';
 import { LgFocusDirective } from '../../focus';
 
 import type { ToggleVariant } from './toggle.interface';
@@ -97,6 +103,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     @SkipSelf()
     private controlContainer: FormGroupDirective,
     private hostElement: ElementRef,
+    private iconRegistry: LgIconRegistry,
   ) {
     this.selectorVariant = this.hostElement.nativeElement.tagName
       .split('-')[1]
@@ -109,6 +116,8 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     if (this.control != null) {
       this.control.valueAccessor = this;
     }
+
+    this.iconRegistry.registerIcons([ lgIconAdd, lgIconCheckmark, lgIconCheckboxMark ]);
   }
 
   onCheck(): void {

--- a/projects/canopy/src/lib/forms/validation/validation.component.ts
+++ b/projects/canopy/src/lib/forms/validation/validation.component.ts
@@ -9,7 +9,14 @@ import {
 import { NgIf, NgSwitch, NgSwitchCase } from '@angular/common';
 
 import type { Variant } from '../../variant';
-import { LgIconComponent } from '../../icon';
+import {
+  lgIconCheckmarkSpotFill,
+  LgIconComponent,
+  lgIconCrossmarkSpotFill,
+  lgIconInformationFill,
+  LgIconRegistry,
+  lgIconWarningFill,
+} from '../../icon';
 
 let nextUniqueId = 0;
 
@@ -50,7 +57,15 @@ export class LgValidationComponent {
   constructor(
     private renderer: Renderer2,
     private hostElement: ElementRef,
+    private iconRegistry: LgIconRegistry,
   ) {
     this.variant = 'error';
+
+    this.iconRegistry.registerIcons([
+      lgIconCrossmarkSpotFill,
+      lgIconInformationFill,
+      lgIconWarningFill,
+      lgIconCheckmarkSpotFill,
+    ]);
   }
 }

--- a/projects/canopy/src/lib/header/header.component.ts
+++ b/projects/canopy/src/lib/header/header.component.ts
@@ -21,7 +21,12 @@ import { DOCUMENT, NgIf } from '@angular/common';
 import { startWith, filter, merge, skipWhile, Subscription, switchMap } from 'rxjs';
 
 import { keyName } from '../utils/keyboard-keys';
-import { LgIconComponent } from '../icon';
+import {
+  lgIconClose,
+  LgIconComponent,
+  lgIconHamburgerMenu,
+  LgIconRegistry,
+} from '../icon';
 import { LgHideAtDirective } from '../hide-at';
 import { LgGridColDirective } from '../grid';
 import { LgGridRowDirective } from '../grid';
@@ -79,8 +84,11 @@ export class LgHeaderComponent implements AfterContentInit, OnDestroy {
   constructor(
     private cdr: ChangeDetectorRef,
     private renderer: Renderer2,
+    private iconRegistry: LgIconRegistry,
     @Inject(DOCUMENT) private document: Document,
-  ) {}
+  ) {
+    this.iconRegistry.registerIcons([ lgIconHamburgerMenu, lgIconClose ]);
+  }
 
   @HostListener('document:click', [ '$event' ])
   onDocumentClickout(event: MouseEvent): void {

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
@@ -9,7 +9,12 @@ import {
 } from '@angular/core';
 import { NgIf } from '@angular/common';
 
-import { LgIconComponent } from '../../icon';
+import {
+  lgIconChevronRight,
+  LgIconComponent,
+  lgIconLinkExternal,
+  LgIconRegistry,
+} from '../../icon';
 import { LgIconComponent as LgIconComponent_1 } from '../../icon/icon.component';
 
 @Component({
@@ -28,7 +33,12 @@ export class LgLinkMenuItemComponent implements OnInit {
 
   openInANewTab = false;
 
-  constructor(private elementRef: ElementRef) {}
+  constructor(
+    private elementRef: ElementRef,
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([ lgIconChevronRight, lgIconLinkExternal ]);
+  }
 
   ngOnInit(): void {
     if (this.elementRef) {

--- a/projects/canopy/src/lib/modal/modal-header/modal-header.component.ts
+++ b/projects/canopy/src/lib/modal/modal-header/modal-header.component.ts
@@ -10,7 +10,7 @@ import {
 
 import type { HeadingLevel } from '../../heading';
 import { LgModalService } from '../modal.service';
-import { LgIconComponent } from '../../icon';
+import { lgIconClose, LgIconComponent, LgIconRegistry } from '../../icon';
 import { LgHeadingComponent } from '../../heading';
 
 @Component({
@@ -32,7 +32,12 @@ export class LgModalHeaderComponent {
 
   @HostBinding('id') id: string;
 
-  constructor(private modalService: LgModalService) {}
+  constructor(
+    private modalService: LgModalService,
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([ lgIconClose ]);
+  }
 
   close(): void {
     this.closed.emit();

--- a/projects/canopy/src/lib/pagination/pagination.component.ts
+++ b/projects/canopy/src/lib/pagination/pagination.component.ts
@@ -11,7 +11,12 @@ import {
 } from '@angular/core';
 import { NgIf, NgFor } from '@angular/common';
 
-import { LgIconComponent } from '../icon';
+import {
+  lgIconChevronLeft,
+  lgIconChevronRight,
+  LgIconComponent,
+  LgIconRegistry,
+} from '../icon';
 import { LgMarginDirective } from '../spacing';
 
 export interface PageData {
@@ -88,6 +93,10 @@ export class LgPaginationComponent implements OnChanges {
     return `Showing ${this.startIndex + 1}-${this.endIndex + 1} of ${
       this.totalItems
     } results`;
+  }
+
+  constructor(private iconRegistry: LgIconRegistry) {
+    this.iconRegistry.registerIcons([ lgIconChevronLeft, lgIconChevronRight ]);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.ts
+++ b/projects/canopy/src/lib/side-nav/side-nav-bar-item/side-nav-bar-item.component.ts
@@ -5,7 +5,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { LgIconComponent } from '../../icon';
+import { lgIconChevronRight, LgIconComponent, LgIconRegistry } from '../../icon';
 
 @Component({
   selector: 'lg-side-nav-bar-item',
@@ -18,4 +18,8 @@ import { LgIconComponent } from '../../icon';
 })
 export class LgSideNavBarItemComponent {
   @HostBinding('class.lg-side-nav-bar-item') class = true;
+
+  constructor(private iconRegistry: LgIconRegistry) {
+    this.iconRegistry.registerIcons([ lgIconChevronRight ]);
+  }
 }

--- a/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.ts
+++ b/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { NgClass } from '@angular/common';
 
-import { LgIconComponent } from '../../icon';
+import { lgIconChevronDown, LgIconComponent, LgIconRegistry } from '../../icon';
 
 @Component({
   selector: 'lg-table-row-toggle',
@@ -28,7 +28,12 @@ export class LgTableRowToggleComponent {
 
   @HostBinding('class') class = 'lg-table-row-toggle';
 
-  constructor(private cd: ChangeDetectorRef) {}
+  constructor(
+    private cd: ChangeDetectorRef,
+    private iconRegistry: LgIconRegistry,
+  ) {
+    this.iconRegistry.registerIcons([ lgIconChevronDown ]);
+  }
 
   set tableId(tableId: number) {
     this._tableId = tableId;


### PR DESCRIPTION
# Description

Fixes #1470

## Testing

I built Canopy locally and tested a component that used a `<lg-validation>` component. As a result, the icon could be seen in the user interface.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
