### PR TITLE
Add link styles to banner message

### DIFF
--- a/projects/canopy/src/lib/banner/banner.component.html
+++ b/projects/canopy/src/lib/banner/banner.component.html
@@ -5,7 +5,7 @@
         <span class="lg-banner__icon">
           <ng-content select="lg-icon"></ng-content>
         </span>
-        <ng-content></ng-content>
+        <div><ng-content></ng-content></div>
       </div>
     </div>
   </div>

--- a/projects/canopy/src/lib/banner/banner.component.scss
+++ b/projects/canopy/src/lib/banner/banner.component.scss
@@ -1,13 +1,42 @@
+@import '../../styles/mixins';
+
 .lg-banner {
   display: block;
   background-color: var(--color-battleship-grey);
   color: var(--color-white);
   box-shadow: 0 0.25rem 0 0 rgba(0, 0, 0, 0.03);
+
+  a:not(.lg-btn) {
+    border-bottom-color: var(--color-white);
+    color: var(--color-white);
+
+    @include lg-link(
+      $default-color: var(--color-white),
+      $hover-color: var(--color-white),
+      $visited-color: var(--color-white),
+      $active-color: var(--color-white),
+      $active-bg-color: var(--color-charcoal),
+      $focus-color: var(--color-charcoal),
+      $focus-bg-color: var(--color-white)
+    );
+  }
 }
 
 .lg-banner-variant--warning {
   background-color: var(--color-dandelion-yellow);
   color: var(--color-charcoal);
+
+  a:not(.lg-btn) {
+    @include lg-link(
+      $default-color: var(--color-charcoal),
+      $hover-color: var(--color-charcoal),
+      $visited-color: var(--color-charcoal),
+      $active-color: var(--color-charcoal),
+      $active-bg-color: var(--color-white),
+      $focus-color: var(--link-focus-color),
+      $focus-bg-color: var(--color-charcoal)
+    );
+  }
 }
 
 .lg-banner__container {

--- a/projects/canopy/src/lib/banner/banner.component.scss
+++ b/projects/canopy/src/lib/banner/banner.component.scss
@@ -2,39 +2,36 @@
 
 .lg-banner {
   display: block;
-  background-color: var(--color-battleship-grey);
-  color: var(--color-white);
+  background-color: var(--banner-generic-bg-color);
+  color: var(--banner-generic-color);
   box-shadow: 0 0.25rem 0 0 rgba(0, 0, 0, 0.03);
 
   a:not(.lg-btn) {
-    border-bottom-color: var(--color-white);
-    color: var(--color-white);
-
     @include lg-link(
-      $default-color: var(--color-white),
-      $hover-color: var(--color-white),
-      $visited-color: var(--color-white),
-      $active-color: var(--color-white),
-      $active-bg-color: var(--color-charcoal),
-      $focus-color: var(--color-charcoal),
-      $focus-bg-color: var(--color-white)
+      $default-color: var(--light-foreground-link-color),
+      $hover-color: var(--light-foreground-link-hover-color),
+      $visited-color: var(--light-foreground-link-visited-color),
+      $active-color: var(--light-foreground-link-active-color),
+      $active-bg-color: var(--light-foreground-link-active-bg-color),
+      $focus-color: var(--light-foreground-link-focus-color),
+      $focus-bg-color: var(--light-foreground-link-focus-bg-color)
     );
   }
 }
 
 .lg-banner-variant--warning {
-  background-color: var(--color-dandelion-yellow);
-  color: var(--color-charcoal);
+  background-color: var(--banner-warning-bg-color);
+  color: var(--banner-warning-color);
 
   a:not(.lg-btn) {
     @include lg-link(
-      $default-color: var(--color-charcoal),
-      $hover-color: var(--color-charcoal),
-      $visited-color: var(--color-charcoal),
-      $active-color: var(--color-charcoal),
-      $active-bg-color: var(--color-white),
-      $focus-color: var(--link-focus-color),
-      $focus-bg-color: var(--color-charcoal)
+      $default-color: var(--dark-foreground-link-color),
+      $hover-color: var(--dark-foreground-link-hover-color),
+      $visited-color: var(--dark-foreground-link-visited-color),
+      $active-color: var(--dark-foreground-link-active-color),
+      $active-bg-color: var(--dark-foreground-link-active-bg-color),
+      $focus-color: var(--dark-foreground-link-focus-color),
+      $focus-bg-color: var(--dark-foreground-link-focus-bg-color)
     );
   }
 }

--- a/projects/canopy/src/lib/banner/docs/banner.stories.ts
+++ b/projects/canopy/src/lib/banner/docs/banner.stories.ts
@@ -13,7 +13,7 @@ const variantTypes = [ 'generic', 'warning' ];
   template: `
     <lg-banner [variant]="variant">
       <lg-icon [name]="icon"></lg-icon>
-      {{ content }}
+      {{ content }} Here is some <a href="#"> link text</a>.
     </lg-banner>
   `,
   standalone: true,

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -1,6 +1,7 @@
 @import 'variables/colors';
 @import 'variables/variants';
 @import 'variables/components/accordion';
+@import 'variables/components/banner';
 @import 'variables/components/breadcrumb';
 @import 'variables/components/button/main';
 @import 'variables/components/card';

--- a/projects/canopy/src/styles/variables/components/_banner.scss
+++ b/projects/canopy/src/styles/variables/components/_banner.scss
@@ -1,0 +1,7 @@
+:root {
+  --banner-generic-bg-color: var(--color-battleship-grey);
+  --banner-generic-color: var(--color-white);
+
+  --banner-warning-bg-color: var(--color-dandelion-yellow);
+  --banner-warning-color: var(--color-charcoal);
+}


### PR DESCRIPTION
# Description

- adds link colours to the banner message component so any links used in the projected content are contrast compliant
- adds a container to the projected content so links are aligned correctly (and to allow for dismiss functionality later)
- adds link text to the component example

Fixes #1417

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [x] I have added any new public feature modules to public-api.ts
