### PR TITLE
feat(modal): add new input to handle overlay click

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -563,20 +563,20 @@
               <button lg-button type="submit" variant="primary-dark">Submit</button>
             </form>
 
-<!--            <lg-separator></lg-separator>-->
-<!--            <lg-heading level="3">Modal</lg-heading>-->
+            <lg-separator></lg-separator>
+            <lg-heading level="3">Modal</lg-heading>
 
-<!--            <button lgModalTrigger="modal" lg-button type="button" variant="secondary-dark">Open modal</button>-->
-<!--            <lg-modal id="modal">-->
-<!--              <lg-modal-header [headingLevel]="3">Lorem ipsum</lg-modal-header>-->
-<!--              <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>-->
-<!--              <lg-modal-footer>-->
-<!--                <lg-button-group>-->
-<!--                  <button lg-button lgMarginBottom="none" variant="primary-dark" type="button">Primary CTA</button>-->
-<!--                  <button lg-button lgMarginBottom="none" variant="secondary-dark" type="button">Cancel</button>-->
-<!--                </lg-button-group>-->
-<!--              </lg-modal-footer>-->
-<!--            </lg-modal>-->
+            <button lgModalTrigger="modal" lg-button type="button" variant="secondary-dark">Open modal</button>
+            <lg-modal id="modal">
+              <lg-modal-header [headingLevel]="3">Lorem ipsum</lg-modal-header>
+              <lg-modal-body>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</lg-modal-body>
+              <lg-modal-footer>
+                <lg-button-group>
+                  <button lg-button lgMarginBottom="none" variant="primary-dark" type="button">Primary CTA</button>
+                  <button lg-button lgMarginBottom="none" variant="secondary-dark" type="button">Cancel</button>
+                </lg-button-group>
+              </lg-modal-footer>
+            </lg-modal>
 
             <lg-separator></lg-separator>
             <lg-heading level="3">List with Icons</lg-heading>

--- a/projects/canopy-test-app/src/app/app.component.ts
+++ b/projects/canopy-test-app/src/app/app.component.ts
@@ -7,6 +7,13 @@ import {
 import { NgForOf, NgIf } from '@angular/common';
 import { RouterLink, RouterOutlet } from '@angular/router';
 
+import {
+  LgModalBodyComponent,
+  LgModalComponent,
+  LgModalFooterComponent,
+  LgModalHeaderComponent,
+  LgModalTriggerDirective,
+} from '../../../canopy/src/lib/modal';
 import { LgPageComponent } from '../../../canopy/src/lib/page';
 import { LgHeaderComponent, LgHeaderLogoComponent } from '../../../canopy/src/lib/header';
 import {
@@ -294,6 +301,11 @@ import {
     RouterOutlet,
     NgForOf,
     NgIf,
+    LgModalComponent,
+    LgModalTriggerDirective,
+    LgModalHeaderComponent,
+    LgModalBodyComponent,
+    LgModalFooterComponent,
   ],
 })
 export class AppComponent {

--- a/projects/canopy/src/lib/modal/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/modal/docs/guide.stories.mdx
@@ -114,9 +114,10 @@ Closing a modal dialogue on mobile can vary between each OS but in general tappi
 
 #### Inputs
 
-| Name | Description                | Type     | Default     | Required |
-|------|----------------------------|----------|-------------|----------|
-| `id` | The unique id of the modal | `string` | `undefined` | Yes      |
+| Name                  | Description                                                       | Type      | Default     | Required |
+|-----------------------|-------------------------------------------------------------------|-----------|-------------|----------|
+| `id`                  | The unique id of the modal                                        | `string`  | `undefined` | Yes      |
+| `closeOnOverlayClick` | Determines if the modal should close when clicking on the overlay | `boolean` | `true`      | No       |
 
 #### Outputs
 

--- a/projects/canopy/src/lib/modal/docs/modal.stories.ts
+++ b/projects/canopy/src/lib/modal/docs/modal.stories.ts
@@ -1,5 +1,5 @@
 import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { LgModalComponent } from '../modal.component';
 import { LgModalTriggerDirective } from '../modal-trigger/modal-trigger.directive';
@@ -12,7 +12,7 @@ import { LgButtonComponent, LgButtonGroupComponent } from '../../button';
 
 const template = `
 <button lgModalTrigger="modal-story" lg-button type="button" variant="secondary-dark">Open modal</button>
-<lg-modal id="modal-story">
+<lg-modal id="modal-story" closeOnOverlayClick="closeOnOverlayClick">
   <lg-modal-header [headingLevel]="headingLevel">Lorem ipsum</lg-modal-header>
   <lg-modal-body>
     Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
@@ -43,6 +43,9 @@ const template = `
   ],
 })
 class ModalWrapperComponent {
+  @Input() headingLevel = 2;
+  @Input() closeOnOverlayClick = true;
+
   constructor(private registry: LgIconRegistry) {
     this.registry.registerIcons([ lgIconClose ]);
   }
@@ -68,6 +71,20 @@ export default {
       },
       control: {
         type: 'select',
+      },
+    },
+    closeOnOverlayClick: {
+      description: 'Whether the modal should close when the overlay is clicked.',
+      table: {
+        type: {
+          summary: 'boolean',
+        },
+        defaultValue: {
+          summary: true,
+        },
+      },
+      control: {
+        type: 'boolean',
       },
     },
     id: {
@@ -157,7 +174,8 @@ const detailsTemplate: StoryFn<ModalWrapperComponent> = (
   args: ModalWrapperComponent,
 ) => ({
   props: args,
-  template: '<lg-modal-wrapper></lg-modal-wrapper>',
+  template:
+    '<lg-modal-wrapper [headingLevel]="headingLevel" [closeOnOverlayClick]="closeOnOverlayClick"></lg-modal-wrapper>',
 });
 
 export const standardSeparator = detailsTemplate.bind({});
@@ -165,6 +183,7 @@ standardSeparator.storyName = 'Modal';
 
 standardSeparator.args = {
   headingLevel: 2,
+  closeOnOverlayClick: true,
 };
 
 standardSeparator.parameters = {

--- a/projects/canopy/src/lib/modal/modal.component.spec.ts
+++ b/projects/canopy/src/lib/modal/modal.component.spec.ts
@@ -183,12 +183,24 @@ describe('LgModalComponent', () => {
   });
 
   describe('clicking on the modal overlay', () => {
-    it('should close the modal and emit an event', () => {
+    it('should close the modal and emit an event when closeOnOverlayClick is true', () => {
       component.isOpen = true;
+      component.closeOnOverlayClick = true;
       component.onOverlayClick();
 
       verify(modalServiceMock.close(id)).once();
       verify(closedOverlaySpy.emit()).once();
+
+      expect().nothing();
+    });
+
+    it('should not close the modal or emit an event when closeOnOverlayClick is false', () => {
+      component.isOpen = true;
+      component.closeOnOverlayClick = false;
+      component.onOverlayClick();
+
+      verify(modalServiceMock.close(id)).never();
+      verify(closedOverlaySpy.emit()).never();
 
       expect().nothing();
     });

--- a/projects/canopy/src/lib/modal/modal.component.ts
+++ b/projects/canopy/src/lib/modal/modal.component.ts
@@ -50,6 +50,7 @@ export class LgModalComponent implements OnInit, AfterContentInit, OnDestroy {
   private subscription: Subscription;
   isOpen: boolean;
   @Input() id: string;
+  @Input() closeOnOverlayClick = true;
   @Output() open: EventEmitter<void> = new EventEmitter();
   @Output() closed: EventEmitter<void> = new EventEmitter();
   @Output() closedOverlayClick: EventEmitter<void> = new EventEmitter();
@@ -74,14 +75,16 @@ export class LgModalComponent implements OnInit, AfterContentInit, OnDestroy {
   }
 
   // onOverlayClick and onModalClick add the following functionality:
-  // clicking outside the modal closes the modal unless specified
-  // otherwise using closeOnOverlayClick.
-  // We specifically listen to the `mousedown` event because with
-  // the `click` event a user could click inside the modal and
-  // drag the mouse on the overlay causing the modal to close.
+  // clicking outside the modal closes the modal unless specified otherwise;
+  // using closeOnOverlayClick will disable the behaviour. We specifically listen
+  // to the `mousedown` event because with the `click` event a user could click
+  // inside the modal and drag the mouse on the overlay causing the modal to close.
   @HostListener('mousedown') onOverlayClick(): void {
-    this.modalService.close(this.id);
-    this.closedOverlayClick.emit();
+    if (this.closeOnOverlayClick) {
+      this.modalService.close(this.id);
+
+      this.closedOverlayClick.emit();
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX184JB2vDY0gmxRaAWtjwtQTMcPCD9N7ZE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=4DgSJj_)
# Description

Add a new input to the modal called `closeOnOverlayClick` to set wether the modal should close on click of the overlay or not. The new input is set to `true` by default so that it doesn't cause any breaking change.

**Input set to `true`:**

https://github.com/user-attachments/assets/c9969537-7f54-4e2c-a867-dadfafad1aa2


**Input set to `false`:**

https://github.com/user-attachments/assets/b14b118d-4767-4e2f-aeb8-a35bc9d4b772



# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
