### PR TITLE
Add a new yellow variant to the Promo Card

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -664,6 +664,24 @@
                   </button>
                 </lg-promo-card-footer>
               </lg-promo-card>
+              <lg-promo-card variant="solid-yellow">
+                <lg-promo-card-image imageUrl="assets/promo-card/care.jpg"></lg-promo-card-image>
+                <lg-promo-card-title [headingLevel]="5">
+                  Need help with Care?
+                </lg-promo-card-title>
+                <lg-promo-card-content>
+                  <p>Our care service can help you understand, find and fund care for you or a loved one.</p>
+                </lg-promo-card-content>
+                <lg-promo-card-footer>
+                  <button
+                    lgMarginBottom="none"
+                    lg-button
+                    type="button"
+                    variant="secondary-dark">
+                    Find care options
+                  </button>
+                </lg-promo-card-footer>
+              </lg-promo-card>
             </lg-promo-card-list>
 
             <lg-separator></lg-separator>

--- a/projects/canopy/src/lib/promo-card/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/promo-card/docs/guide.stories.mdx
@@ -63,11 +63,11 @@ and in your HTML, place the promo cards in the promo card list:
 
 ### Inputs
 
-| Name           | Description                                             |        Type        |    Default    | Required |
-|----------------|---------------------------------------------------------|:------------------:|:-------------:|:--------:|
-| `headingLevel` | Allows the card (list) heading level to be set          |      `number`      |      n/a      |   Yes    |
-| `variant`      | The variant of promo card: `solid-white`, `solid-green` | `PromoCardVariant` | `solid-white` |    No    |
-| `imageUrl`     | Identifies the card image                               |      `string`      |      n/a      |   Yes    |
+| Name           | Description                                                             |        Type        |    Default    | Required |
+|----------------|-------------------------------------------------------------------------|:------------------:|:-------------:|:--------:|
+| `headingLevel` | Allows the card (list) heading level to be set                          |      `number`      |      n/a      |   Yes    |
+| `variant`      | The variant of promo card: `solid-white`, `solid-green`, `solid-yellow` | `PromoCardVariant` | `solid-white` |    No    |
+| `imageUrl`     | Identifies the card image                                               |      `string`      |      n/a      |   Yes    |
 
 ---
 

--- a/projects/canopy/src/lib/promo-card/docs/promo-card.stories.ts
+++ b/projects/canopy/src/lib/promo-card/docs/promo-card.stories.ts
@@ -11,7 +11,7 @@ import { LgPromoCardTitleComponent } from '../promo-card/promo-card-title/promo-
 import { LgPromoCardContentComponent } from '../promo-card/promo-card-content/promo-card-content.component';
 import { LgPromoCardFooterComponent } from '../promo-card/promo-card-footer/promo-card-footer.component';
 import { LgMarginDirective } from '../../spacing';
-import { LgButtonComponent } from '../../button';
+import { ButtonVariant, LgButtonComponent } from '../../button';
 import { LgPromoCardListTitleComponent } from '../promo-card-list/promo-card-list-title/promo-card-list-title.component';
 
 const cardListConfig = {
@@ -62,7 +62,7 @@ const cardListConfig = {
             lgMarginBottom="none"
             lg-button
             type="button"
-            [variant]="variants[i] === 'solid-white' ? 'primary-dark' : 'primary-light'"
+            [variant]="buttonVariants[variants[i]]"
           >
             {{ card.ctaText }}
           </button>
@@ -89,9 +89,14 @@ class PromoCardListStoryComponent {
   @Input() variants: Array<PromoCardVariant> = [];
   title = cardListConfig.title;
   cards = cardListConfig.cards;
+  buttonVariants: { [key: string]: ButtonVariant } = {
+    'solid-white': 'primary-dark',
+    'solid-green': 'primary-light',
+    'solid-yellow': 'secondary-dark',
+  };
 }
 
-const variants = [ 'solid-white', 'solid-green' ];
+const variants = [ 'solid-white', 'solid-green', 'solid-yellow' ];
 
 export default {
   title: 'Components/Promo cards/Examples',
@@ -159,8 +164,8 @@ const examplePromoCardTemplate = `
     {{ title }}
   </lg-promo-card-list-title>
   <lg-promo-card
-    *ngFor="let card of cards; let i = index;"
-    variant="variant[i]">
+    *ngFor="let card of cards; let i = index"
+    [variant]="variant[i]">
     <lg-promo-card-image [imageUrl]="card.imageUrl"></lg-promo-card-image>
     <lg-promo-card-title headingLevel="2">
       {{ card.title }}
@@ -173,7 +178,7 @@ const examplePromoCardTemplate = `
         lgMarginBottom="none"
         lg-button
         type="button"
-        [variant]="variant[i] === 'solid-white' ? 'primary-dark' : 'primary-light'">
+        [variant]="buttonVariants[variants[i]]">
         {{ card.ctaText }}
       </button>
     </lg-promo-card-footer>

--- a/projects/canopy/src/lib/promo-card/promo-card.interface.ts
+++ b/projects/canopy/src/lib/promo-card/promo-card.interface.ts
@@ -1,1 +1,1 @@
-export type PromoCardVariant = 'solid-white' | 'solid-green';
+export type PromoCardVariant = 'solid-white' | 'solid-green' | 'solid-yellow';

--- a/projects/canopy/src/lib/promo-card/promo-card/promo-card.component.scss
+++ b/projects/canopy/src/lib/promo-card/promo-card/promo-card.component.scss
@@ -5,6 +5,20 @@
   flex: 1 0;
   position: relative;
 
+  &--solid-green {
+    .lg-promo-card__content-inner {
+      background: var(--color-leafy-green);
+      color: var(--color-white);
+    }
+  }
+
+  &--solid-yellow {
+    .lg-promo-card__content-inner {
+      background: var(--color-dandelion-yellow);
+      color: var(--color-black);
+    }
+  }
+
   @media (min-width: $promo-card-inline-breakpoint) {
     min-height: var(--promo-card-image-dimension);
     display: flex;
@@ -12,13 +26,6 @@
   }
   @include lg-breakpoint('lg') {
     display: block;
-  }
-}
-
-.lg-promo-card--solid-green {
-  .lg-promo-card__content-inner {
-    background: var(--color-leafy-green);
-    color: var(--color-white);
   }
 }
 


### PR DESCRIPTION
# Description

Adds a new, `solid-yellow` colour variant to the Promo Card.

![yellow-promo-card](https://github.com/user-attachments/assets/31cdf0b3-1380-43fa-b57e-6d4943f4c602)

![yellow-promo-card-list](https://github.com/user-attachments/assets/e562b58b-4027-4e5e-90d0-28207f23ca38)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
