### PR TITLE
ci(master-push): fixes issue when deploying from master

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -85,6 +85,9 @@ jobs:
           name: ${{ github.event.repository.name }}
           path: dist/canopy/
 
+      - name: 'Build icons'
+        run: npm run build:icons
+
       - name: 'Deployment to GitHub Pages'
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX182nyRMqbmdAy86PLbbPVihDA6PQ27040%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=cMvz_hP)
The ui-icons-files and brand-icons-files folders that are generated when building the new icons, were not available for the master storybook build. Running the icons build before the deplyment fixes the issue

# Description

The deployment step for `master` requires the icons to be built so that the `ui-icons-files` and `brand-icons-files` folders within `projects/canopy/src/lib` are available for the Storybook build. This wasn't an issue before because we used to include the main generated file into the source - the new approach produces too many files which we have decided to add to `.gitignore`.

Tested locally and works as expected.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
