### PR TITLE
fix(footer-nav-item): use firstElementChild

### DIFF
--- a/projects/canopy/src/lib/footer/footer-nav-item/footer-nav-item.component.ts
+++ b/projects/canopy/src/lib/footer/footer-nav-item/footer-nav-item.component.ts
@@ -37,7 +37,7 @@ export class LgFooterNavItemComponent implements AfterContentChecked {
       this.currentVariant = this.variant;
       this.renderer.addClass(hostEl, `lg-footer-nav-item--${this.variant}`);
 
-      const childEl = hostEl.firstChild as HTMLAnchorElement | HTMLButtonElement;
+      const childEl = hostEl.firstElementChild as HTMLAnchorElement | HTMLButtonElement;
 
       this.renderer.addClass(childEl, 'lg-footer-action');
 


### PR DESCRIPTION
using firstChild selects comment nodes and therefore gives a console error when adding a class to it

# Description

There is a slight difference in where Angular renders the comment node (ie, the anchor for the view container) slightly differently in the @if(){}@else{} syntax compared to the `*ngIf(condition; else tpl)` syntax. 

That is, in the @else part, the first child is now the comment node which isn't the case with the explicit structural directive syntax. 

`LgFooterNavItemComponent` wants to get hold of the `a` element or `button` element then add a css class to it, `this.renderer.addClass(childEl, 'lg-footer-action');`. The else part errors as the firstChild returns the comment node, and tries to add a class to the comment node . 

Using the `firstElementChild` solves this issue, as it will gets the first element and not the nodes (comments and text). firstChild gets the first comment, text or element.  

Fixes # (issue)

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [ ] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
