### PR TITLE
feat(lgshadow): update drop shadow to new design 

### DIFF
--- a/projects/canopy/src/lib/card/card.component.scss
+++ b/projects/canopy/src/lib/card/card.component.scss
@@ -18,22 +18,10 @@
   &--navigation {
     padding-top: 0;
     transition: box-shadow 250ms;
-    box-shadow:
-      0 0 0 0 rgba(0, 0, 0, 0.01),
-      0 0.0625rem 0.0625rem 0 rgba(0, 0, 0, 0.02),
-      0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02),
-      0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.02),
-      0 0.1875rem 0.4375rem 0 rgba(0, 0, 0, 0.03),
-      0 0.5rem 1rem 0 rgba(0, 0, 0, 0.04);
+    box-shadow: var(--drop-shadow);
 
     &:hover {
-      box-shadow:
-        0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02),
-        0 0.125rem 0.0125rem 0 rgba(0, 0, 0, 0.03),
-        0 0.25rem 0.625rem 0 rgba(0, 0, 0, 0.04),
-        0 0.4375rem 1.125rem 0 rgba(0, 0, 0, 0.04),
-        0 0.8125rem 2.0625rem 0 rgba(0, 0, 0, 0.05),
-        0 2rem 5rem 0 rgba(0, 0, 0, 0.07);
+      box-shadow: var(--drop-shadow-hover);
     }
 
     .lg-card-header__title {

--- a/projects/canopy/src/lib/card/docs/promotions/guide.stories.mdx
+++ b/projects/canopy/src/lib/card/docs/promotions/guide.stories.mdx
@@ -25,7 +25,7 @@ and in your HTML, for a general promotion card with image:
 
 ```html
 <lg-card
-  lgShadow
+  lgShadow [hasHoverState]="true"
   lgMarginBottom="lg"
   lgPadding="none"
   variant="promotion"
@@ -44,7 +44,7 @@ and in your HTML, for a general promotion card with icon:
 
 ```html
 <lg-card
-  lgShadow
+  lgShadow [hasHoverState]="true"
   lgMarginBottom="lg"
   variant="promotion"
   [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'horizontal' }">
@@ -87,7 +87,7 @@ In the examples bellow, we use the Canopy Grid System to get the desired layout,
   <div lgRow>
     <div lgColSm="12">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -112,7 +112,7 @@ In the examples bellow, we use the Canopy Grid System to get the desired layout,
   <div lgRow>
     <div lgColSm="12" lgColLg="6">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -128,7 +128,7 @@ In the examples bellow, we use the Canopy Grid System to get the desired layout,
     </div>
     <div lgColSm="12" lgColLg="6">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -153,7 +153,7 @@ In the examples bellow, we use the Canopy Grid System to get the desired layout,
   <div lgRow>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -169,7 +169,7 @@ In the examples bellow, we use the Canopy Grid System to get the desired layout,
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -185,7 +185,7 @@ In the examples bellow, we use the Canopy Grid System to get the desired layout,
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -215,7 +215,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -231,7 +231,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -247,44 +247,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
-        lgMarginBottom="lg"
-        lgPadding="none"
-        variant="promotion"
-        [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
-        <lg-card-hero-img [cover]="true" [src]="imageUrl">
-        </lg-card-hero-img>
-        <lg-card-content>
-          <h3 lgMarginBottom="xxs" class="lg-font--expressive">{{ title }}</h3>
-          <p lgMarginBottom="lg">{{ text }}</p>
-          <a href="#">{{ buttonText }}</a>
-        </lg-card-content>
-      </lg-card>
-    </div>
-  </div>
-  <div lgRow>
-    <div lgCol="12">
-      <lg-separator variant="dotted" lgMarginTop="none"></lg-separator>
-    </div>
-    <div lgColSm="12" lgColLg="6">
-      <lg-card
-        lgShadow
-        lgMarginBottom="lg"
-        lgPadding="none"
-        variant="promotion"
-        [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
-        <lg-card-hero-img [cover]="true" [src]="imageUrl">
-        </lg-card-hero-img>
-        <lg-card-content>
-          <h3 lgMarginBottom="xxs" class="lg-font--expressive">{{ title }}</h3>
-          <p lgMarginBottom="lg">{{ text }}</p>
-          <a href="#">{{ buttonText }}</a>
-        </lg-card-content>
-      </lg-card>
-    </div>
-    <div lgColSm="12" lgColLg="6">
-      <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         lgPadding="none"
         variant="promotion"
@@ -303,9 +266,46 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     <div lgCol="12">
       <lg-separator variant="dotted" lgMarginTop="none"></lg-separator>
     </div>
+    <div lgColSm="12" lgColLg="6">
+      <lg-card
+        lgShadow [hasHoverState]="true"
+        lgMarginBottom="lg"
+        lgPadding="none"
+        variant="promotion"
+        [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
+        <lg-card-hero-img [cover]="true" [src]="imageUrl">
+        </lg-card-hero-img>
+        <lg-card-content>
+          <h3 lgMarginBottom="xxs" class="lg-font--expressive">{{ title }}</h3>
+          <p lgMarginBottom="lg">{{ text }}</p>
+          <a href="#">{{ buttonText }}</a>
+        </lg-card-content>
+      </lg-card>
+    </div>
+    <div lgColSm="12" lgColLg="6">
+      <lg-card
+        lgShadow [hasHoverState]="true"
+        lgMarginBottom="lg"
+        lgPadding="none"
+        variant="promotion"
+        [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
+        <lg-card-hero-img [cover]="true" [src]="imageUrl">
+        </lg-card-hero-img>
+        <lg-card-content>
+          <h3 lgMarginBottom="xxs" class="lg-font--expressive">{{ title }}</h3>
+          <p lgMarginBottom="lg">{{ text }}</p>
+          <a href="#">{{ buttonText }}</a>
+        </lg-card-content>
+      </lg-card>
+    </div>
+  </div>
+  <div lgRow>
+    <div lgCol="12">
+      <lg-separator variant="dotted" lgMarginTop="none"></lg-separator>
+    </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         variant="promotion"
         [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
@@ -321,7 +321,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         variant="promotion"
         [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
@@ -337,7 +337,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="4">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         variant="promotion"
         [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
@@ -358,7 +358,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="6">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         variant="promotion"
         [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">
@@ -374,7 +374,7 @@ To achieve this layout add the `LgSeparatorModule` to the module imports.
     </div>
     <div lgColSm="12" lgColLg="6">
       <lg-card
-        lgShadow
+        lgShadow [hasHoverState]="true"
         lgMarginBottom="lg"
         variant="promotion"
         [lgOrientation]="{ sm: 'vertical', md: 'horizontal', lg: 'vertical' }">

--- a/projects/canopy/src/lib/card/docs/promotions/promotions.stories.ts
+++ b/projects/canopy/src/lib/card/docs/promotions/promotions.stories.ts
@@ -19,7 +19,7 @@ import { LgSeparatorComponent } from '../../../separator';
 
 const promotionsGeneralCardTemplate = `
 <lg-card
-  lgShadow
+  lgShadow [hasHoverState]="true"
   lgMarginBottom="lg"
   [lgPadding]="hasIcon ? 'lg' : 'none'"
   variant="promotion"

--- a/projects/canopy/src/lib/shadow/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/shadow/docs/guide.stories.mdx
@@ -23,9 +23,10 @@ and in your HTML:
 <Source id="helpers-directives-shadow-examples--shadow-story"></Source>
 
 ### Inputs
-| Name       | Description                                     |   Type    | Default | Required |
-|------------|-------------------------------------------------|:---------:|:-------:|:--------:|
-| `lgShadow` | Whether the element should have a shadow or not | `boolean` | `null`  |   Yes    |
+| Name            | Description                                                    |   Type    | Default | Required |
+|-----------------|----------------------------------------------------------------|:---------:|:-------:|:--------:|
+| `lgShadow`      | Whether the element should have a shadow or not                | `boolean` | `null`  |   Yes    |
+| `hasHoverState` | Whether the element should have a shadow on hover state or not | `boolean` | `false` |   No     |
 
 ---
 

--- a/projects/canopy/src/lib/shadow/docs/guide.stories.mdx
+++ b/projects/canopy/src/lib/shadow/docs/guide.stories.mdx
@@ -23,10 +23,10 @@ and in your HTML:
 <Source id="helpers-directives-shadow-examples--shadow-story"></Source>
 
 ### Inputs
-| Name            | Description                                                    |   Type    | Default | Required |
-|-----------------|----------------------------------------------------------------|:---------:|:-------:|:--------:|
-| `lgShadow`      | Whether the element should have a shadow or not                | `boolean` | `null`  |   Yes    |
-| `hasHoverState` | Whether the element should have a shadow on hover state or not | `boolean` | `false` |   No     |
+| Name            | Description                                                           |   Type    | Default | Required |
+|-----------------|-----------------------------------------------------------------------|:---------:|:-------:|:--------:|
+| `lgShadow`      | Whether the element should have a shadow or not                       | `boolean` | `null`  |   Yes    |
+| `hasHoverState` | Whether the element should have a deeper shadow on hover state or not | `boolean` | `false` |   No     |
 
 ---
 

--- a/projects/canopy/src/lib/shadow/docs/shadow.stories.ts
+++ b/projects/canopy/src/lib/shadow/docs/shadow.stories.ts
@@ -27,7 +27,15 @@ export default {
 } as Meta;
 
 const template = `
+<!-- lgShadow without hover state -->
 <lg-card lgShadow>
+  <lg-card-content>
+    Look, I have a shadow
+  </lg-card-content>
+</lg-card>
+
+<!-- lgShadow with hover state -->
+<lg-card lgShadow [hasHoverState]="hasHoverState">
   <lg-card-content>
     Look, I have a shadow
   </lg-card-content>
@@ -35,12 +43,19 @@ const template = `
 `;
 
 const shadowTemplate: StoryFn<LgShadowDirective> = (args: LgShadowDirective) => ({
-  props: args,
+  props: {
+    ...args,
+    hasHoverState: args.hasHoverState,
+  },
   template,
 });
 
 export const shadowStory = shadowTemplate.bind({});
 shadowStory.storyName = 'Shadow';
+
+shadowStory.args = {
+  hasHoverState: false,
+};
 
 shadowStory.parameters = {
   docs: {

--- a/projects/canopy/src/lib/shadow/shadow.directive.spec.ts
+++ b/projects/canopy/src/lib/shadow/shadow.directive.spec.ts
@@ -14,4 +14,31 @@ describe('LgShadowDirective', () => {
 
     expect(hostElem.getAttribute('class')).toContain('lg-shadow');
   });
+
+  it('does not set the hover class by default', () => {
+    const fixture = MockRender('<div lgShadow>Shadow</div>');
+    const hostElem: HTMLDivElement = fixture.debugElement.query(
+      By.directive(LgShadowDirective),
+    ).nativeElement;
+
+    expect(hostElem.getAttribute('class')).not.toContain('lg-shadow-hover');
+  });
+
+  it('sets the hover class when hasHoverState is true', () => {
+    const fixture = MockRender('<div lgShadow [hasHoverState]="true">Shadow</div>');
+    const hostElem: HTMLDivElement = fixture.debugElement.query(
+      By.directive(LgShadowDirective),
+    ).nativeElement;
+
+    expect(hostElem.getAttribute('class')).toContain('lg-shadow-hover');
+  });
+
+  it('does not set the hover class when hasHoverState is false', () => {
+    const fixture = MockRender('<div lgShadow [hasHoverState]="false">Shadow</div>');
+    const hostElem: HTMLDivElement = fixture.debugElement.query(
+      By.directive(LgShadowDirective),
+    ).nativeElement;
+
+    expect(hostElem.getAttribute('class')).not.toContain('lg-shadow-hover');
+  });
 });

--- a/projects/canopy/src/lib/shadow/shadow.directive.spec.ts
+++ b/projects/canopy/src/lib/shadow/shadow.directive.spec.ts
@@ -21,7 +21,7 @@ describe('LgShadowDirective', () => {
       By.directive(LgShadowDirective),
     ).nativeElement;
 
-    expect(hostElem.getAttribute('class')).not.toContain('lg-shadow-hover');
+    expect(hostElem.getAttribute('class')).not.toContain('lg-shadow--hover');
   });
 
   it('sets the hover class when hasHoverState is true', () => {
@@ -30,7 +30,7 @@ describe('LgShadowDirective', () => {
       By.directive(LgShadowDirective),
     ).nativeElement;
 
-    expect(hostElem.getAttribute('class')).toContain('lg-shadow-hover');
+    expect(hostElem.getAttribute('class')).toContain('lg-shadow--hover');
   });
 
   it('does not set the hover class when hasHoverState is false', () => {
@@ -39,6 +39,6 @@ describe('LgShadowDirective', () => {
       By.directive(LgShadowDirective),
     ).nativeElement;
 
-    expect(hostElem.getAttribute('class')).not.toContain('lg-shadow-hover');
+    expect(hostElem.getAttribute('class')).not.toContain('lg-shadow--hover');
   });
 });

--- a/projects/canopy/src/lib/shadow/shadow.directive.ts
+++ b/projects/canopy/src/lib/shadow/shadow.directive.ts
@@ -1,9 +1,14 @@
-import { Directive, HostBinding } from '@angular/core';
+import { Directive, HostBinding, input } from '@angular/core';
 
 @Directive({
   selector: '[lgShadow]',
   standalone: true,
 })
 export class LgShadowDirective {
+  hasHoverState = input(false);
+
   @HostBinding('class.lg-shadow') class = true;
+  @HostBinding('class.lg-shadow-hover') get hoverClass() {
+    return this.hasHoverState();
+  }
 }

--- a/projects/canopy/src/lib/shadow/shadow.directive.ts
+++ b/projects/canopy/src/lib/shadow/shadow.directive.ts
@@ -8,7 +8,7 @@ export class LgShadowDirective {
   hasHoverState = input(false);
 
   @HostBinding('class.lg-shadow') class = true;
-  @HostBinding('class.lg-shadow-hover') get hoverClass() {
+  @HostBinding('class.lg-shadow--hover') get hoverClass() {
     return this.hasHoverState();
   }
 }

--- a/projects/canopy/src/styles/shadow.scss
+++ b/projects/canopy/src/styles/shadow.scss
@@ -1,3 +1,7 @@
 .lg-shadow {
   box-shadow: var(--drop-shadow);
 }
+
+.lg-shadow-hover {
+  box-shadow: var(--drop-shadow-hover);
+}

--- a/projects/canopy/src/styles/shadow.scss
+++ b/projects/canopy/src/styles/shadow.scss
@@ -2,6 +2,6 @@
   box-shadow: var(--drop-shadow);
 }
 
-.lg-shadow-hover {
+.lg-shadow--hover:hover {
   box-shadow: var(--drop-shadow-hover);
 }

--- a/projects/canopy/src/styles/variables/_main.scss
+++ b/projects/canopy/src/styles/variables/_main.scss
@@ -3,7 +3,14 @@
   --border-radius-sm: 0.125rem;
   --border-radius-lg: 0.25rem;
 
-  --drop-shadow: 0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.12), 0 0 0.25rem 0 rgba(0, 0, 0, 0.16);
+  --drop-shadow: 0 0 0 0 rgba(0, 0, 0, 0.01), 0 0.0625rem 0.0625rem 0 rgba(0, 0, 0, 0.02),
+    0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02), 0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.02),
+    0 0.1875rem 0.4375rem 0 rgba(0, 0, 0, 0.03), 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.04);
+
+  --drop-shadow-hover: 0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.02),
+    0 0.125rem 0.0125rem 0 rgba(0, 0, 0, 0.03), 0 0.25rem 0.625rem 0 rgba(0, 0, 0, 0.04),
+    0 0.4375rem 1.125rem 0 rgba(0, 0, 0, 0.04),
+    0 0.8125rem 2.0625rem 0 rgba(0, 0, 0, 0.05), 0 2rem 5rem 0 rgba(0, 0, 0, 0.07);
   --bottom-shadow: 0 0.3125rem 0.25rem 0 rgba(0, 0, 0, 0.03);
   --overlay-color: rgba(0, 0, 0, 0.5);
 


### PR DESCRIPTION
# Description

Canopy lgShadow directive added a box-shadow to its host component. However, the box-shadow value was from an older design. Canopy designs has a new desgin for drop shadows. Navigation cards already has the updated drop shadow styles. However, it hardcodes the value in .lg-card--navigation class. 

This PR:
- Updates the `--drop-shadow` CSS custom property the latest Canopy design box-shadow value
- Creates a new CSS custom property called `--box-shadow-hover` and sets its value to the latest Canopy drop shadow hover state value
- Updates .lg-card--navigation to use the `--drop-shadow` CSS custom property, instead of hardcoding it in the class. `box-shadow: var(--drop-shadow);`
- Updates .lg-card--navigation:hover to use the `--box-shadow-hover` CSS custom property, instead of hardcoding it in the class. `box-shadow: var(--drop-shadow-hover);`
- Adds a `hasHoverState` input to `LgShadowDirective`. Users can opt in to add a hover state drop shadow to their component (typically a card), by setting the `hasHoverState`.
- Adds unit tests for `hasHoverState` input in `LgShadowDirective`
- Updates storybook guide and examples for `Shadow`
- Updates storybook guide and examples for `Promotions`

Fixes # (issue)

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Design link: (link to design or delete if not required)
Screenshot: (if appropriate provide a quick screen grab of the changes)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
