### PR TITLE
Progress bar accessibility bug fix

### DIFF
--- a/projects/canopy/src/lib/progress-indicator/progress-bar/progress-bar.component.html
+++ b/projects/canopy/src/lib/progress-indicator/progress-bar/progress-bar.component.html
@@ -1,10 +1,10 @@
 <div
   role="progressbar"
   class="lg-progress-bar"
+  aria-valuemin="0"
   [attr.aria-label]="ariaLabel"
   [attr.aria-labelledby]="ariaLabelledBy"
   [attr.aria-valuemax]="max"
-  [attr.aria-valuemin]="0"
   [attr.aria-valuenow]="value"
   [attr.aria-live]="isAriaLiveRegion ? 'polite' : 'off'"
 >

--- a/projects/canopy/src/lib/progress-indicator/progress-bar/progress-bar.component.html
+++ b/projects/canopy/src/lib/progress-indicator/progress-bar/progress-bar.component.html
@@ -4,7 +4,7 @@
   [attr.aria-label]="ariaLabel"
   [attr.aria-labelledby]="ariaLabelledBy"
   [attr.aria-valuemax]="max"
-  [attr.aria-valuemin]="value"
+  [attr.aria-valuemin]="0"
   [attr.aria-valuenow]="value"
   [attr.aria-live]="isAriaLiveRegion ? 'polite' : 'off'"
 >

--- a/projects/canopy/src/lib/progress-indicator/progress-bar/progress-bar.component.spec.ts
+++ b/projects/canopy/src/lib/progress-indicator/progress-bar/progress-bar.component.spec.ts
@@ -70,14 +70,10 @@ describe('LgProgressBarComponent', () => {
   });
 
   it('should set aria-valuemin correctly', () => {
-    const min = 2;
-
-    component.value = min;
-    fixture.detectChanges();
     const progressBarElement: HTMLElement =
       fixture.nativeElement.querySelector('.lg-progress-bar');
 
-    expect(progressBarElement.getAttribute('aria-valuemin')).toBe(min.toString());
+    expect(progressBarElement.getAttribute('aria-valuemin')).toBe('0');
   });
 
   it('should set aria-valuenow correctly', () => {


### PR DESCRIPTION
# Description

At the moment, the progress of the bar isn't reflected when the screen reader reads out the details of that element. This is because `aria-valuemin` doesn't represent the correct value. As a result, the percentage value read out will always be 0, since the same value is used for both `aria-valuemin` and `aria-valuenow` attributes.

**Before**

https://github.com/user-attachments/assets/cd4d84bd-b881-46bc-b3ed-16f7b1e1d0a5

Fixes # (issue)

- Sets `aria-valuemin` to 0, ensuring the progress bar percentage reflects the current step.
- Updates unit tests.

**After**


https://github.com/user-attachments/assets/adbeb450-ae76-4359-aeda-2ad4b9d752a5


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
