### PR TITLE
Make primary navigation scrollable for smaller screens

### DIFF
--- a/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
+++ b/projects/canopy/src/lib/header/primary-navigation/primary-navigation.component.scss
@@ -43,6 +43,7 @@ $primary-nav-border-bottom-height: 0.25rem;
   justify-content: flex-start;
   list-style-type: none;
   margin: 0;
+  overflow-y: auto;
   padding: var(--space-sm);
   position: relative;
   width: 100%;


### PR DESCRIPTION
# Description

A recent accessibility audit raised an issue with not being able to scroll through the primary navigation items when testing at the small viewport 320x256. In our case it means the user cannot log out. This change allows scrolling when necessary so all navigation can be accessed.

WCAG guideline link - https://www.w3.org/WAI/WCAG21/Understanding/reflow.html

https://github.com/user-attachments/assets/72adeae3-bd81-4b6e-a060-f96af081ba9f

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [x] I have added any new public feature modules to public-api.ts
