### PR TITLE
FEP-3867: Remove missing "registries" property from the Dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,6 @@ updates:
     open-pull-requests-limit: 15
     # Files stored in repository root
     directory: '/'
-    registries:
-      - npm-registry
     commit-message:
       include: 'scope'
       prefix: 'npm'


### PR DESCRIPTION
# Description

Dependabot updates workflow contains a missing option (registries) that needs to be removed.

## Requirements

Please briefly outline any requirements for the work which may aid the testing and review process.

Design link: N/A
Screenshot: N/A

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
