### PR TITLE
Fix stripes on table and colour of list counter

### DIFF
--- a/projects/canopy/src/lib/table/table/table.component.scss
+++ b/projects/canopy/src/lib/table/table/table.component.scss
@@ -8,7 +8,7 @@
   border-spacing: 0;
   border-top: solid var(--table-header-border-width) var(--table-header-border-color);
 
-  &--striped:not(&--expandable) tr:nth-child(even) {
+  &--striped:not(&--expandable) tbody tr:nth-child(odd) {
     background-color: var(--table-stripe-color);
   }
 
@@ -22,12 +22,12 @@
 
   &--expandable {
     &.lg-table--striped {
-      tr {
-        &:nth-child(4n + 3) {
+      tbody tr {
+        &:nth-child(4n + 1) {
           background-color: var(--table-stripe-color);
         }
 
-        &:nth-child(4n + 4) {
+        &:nth-child(4n + 2) {
           background-color: var(--table-stripe-color);
         }
       }

--- a/projects/canopy/src/styles/list.scss
+++ b/projects/canopy/src/styles/list.scss
@@ -1,5 +1,5 @@
 :root {
-  --custom-list-counter-color: var(--color-black);
+  --custom-list-counter-color: currentColor;
 }
 
 ol {


### PR DESCRIPTION
# Description

This PR includes a couple of fixes:

1. The striped variant of the table should have the grey on odd rows (raised on Slack and confirmed by Alex C.)
![Screenshot 2025-07-09 at 14 26 49](https://github.com/user-attachments/assets/c9d96b45-21be-494e-9b93-b04cc667f794)
![Screenshot 2025-07-09 at 14 26 39](https://github.com/user-attachments/assets/6520dbfd-50fa-4b9c-b3dc-bcfb003b955f)

2. The colour of the counter on an ordered list with expressive variant is incorrect when using a different text colour
![Screenshot 2025-07-09 at 14 40 12](https://github.com/user-attachments/assets/84e867a4-ab45-4b1f-bee0-0cd8b0c2d1e6)
![Screenshot 2025-07-09 at 14 40 06](https://github.com/user-attachments/assets/376542dd-b2b5-49f7-a437-1685715746dd)
![Screenshot 2025-07-09 at 14 40 01](https://github.com/user-attachments/assets/31c9ce83-0fd6-4eef-9dfe-4a28efbf429f)
![Screenshot 2025-07-09 at 15 04 54](https://github.com/user-attachments/assets/a828c319-5ffc-4c4f-9ea2-7fa1b353b0d2)


Fix: #1509

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
