### PR TITLE
test(percy): add wait for selector to welcome page

### DIFF
--- a/projects/canopy/src/lib/docs/welcome/welcome.stories.ts
+++ b/projects/canopy/src/lib/docs/welcome/welcome.stories.ts
@@ -20,3 +20,9 @@ const welcomeTemplate: StoryFn<DocsWelcomePageComponent> = (
 
 export const welcomeStory = welcomeTemplate.bind({});
 welcomeStory.storyName = 'Welcome page';
+
+welcomeStory.parameters = {
+  percy: {
+    waitForSelector: '.welcome-img',
+  },
+};


### PR DESCRIPTION
# Description

Add wait for the welcome image as it doesn't always appear in the snapshots.


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
