### PR TITLE
test(percy): move visual comparison in branch deploy workflow

### DIFF
--- a/.github/workflows/branch_pages_deploy.yml
+++ b/.github/workflows/branch_pages_deploy.yml
@@ -44,9 +44,17 @@ jobs:
               context
             });
 
-      - run: |
+      - name: 'Unzip storybook build'
+        run: |
           unzip lg-sb-build.zip -d ./docs/lg-sb-'${{ fromJSON(steps.prData.outputs.result).branch }}'
           rm lg-sb-build.zip
+
+      - name: 'Visual comparison'
+        run: npx percy storybook ./docs/lg-sb-${{ fromJSON(steps.prData.outputs.result).branch }} --config=.percy.yml
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_BRANCH: '${{ fromJSON(steps.prData.outputs.result).branch }}'
+          NETWORK_IDLE_WAIT_TIMEOUT: 5000
 
       - name: 'Notify GitHub of branch deployment'
         uses: actions/github-script@v7
@@ -86,13 +94,6 @@ jobs:
               context,
               exec,
             });
-
-      - name: 'Visual comparison'
-        run: npx percy storybook ./docs/lg-sb-${{ fromJSON(steps.prData.outputs.result).branch }} --config=.percy.yml
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_BRANCH: '${{ fromJSON(steps.prData.outputs.result).branch }}'
-          NETWORK_IDLE_WAIT_TIMEOUT: 5000
 
       - name: 'Checking out current branch'
         if: always()


### PR DESCRIPTION
# Description

The previous position meant that the tests were running from the `gh-pages` branch which doesn't contain the Percy config.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
