### PR TITLE
FEP-4285: Remove primary/secondary links from side-menu (components/footer)

### DIFF
--- a/projects/canopy/src/lib/footer/docs/footer.stories.ts
+++ b/projects/canopy/src/lib/footer/docs/footer.stories.ts
@@ -7,7 +7,7 @@ import { LgFooterNavItemComponent } from '../footer-nav-item/footer-nav-item.com
 import { LgFooterLogoComponent } from '../footer-logo/footer-logo.component';
 import { LgFooterCopyrightComponent } from '../footer-copyright/footer-copyright.component';
 
-export const PrimaryLinks = [
+export const primaryLinks = [
   { id: 'primary-link-1', text: 'My account', href: 'https://app.somecompany.com' },
   { id: 'primary-link-2', text: 'My quotes', href: 'https://somecompany.com/quotes' },
   {
@@ -18,7 +18,7 @@ export const PrimaryLinks = [
   { id: 'primary-link-4', text: 'Contact', href: 'https://somecompany.com/contact' },
 ];
 
-export const SecondaryLinks = [
+export const secondaryLinks = [
   {
     id: 'secondary-link-1',
     text: 'Accessibility',
@@ -126,8 +126,8 @@ export const StandardFooter = {
     logo: 'legal-and-general-logo.svg',
     logoAlt: 'Company name',
     copyright: '© Some Company plc 2018',
-    secondaryLinks: SecondaryLinks,
-    primaryLinks: PrimaryLinks,
+    secondaryLinks,
+    primaryLinks,
   },
   argTypes: {
     secondaryLogo: {
@@ -170,7 +170,7 @@ export const CompactFooter = {
   }),
   args: {
     copyright: '© Some Company plc 2018',
-    secondaryLinks: SecondaryLinks,
+    secondaryLinks,
   },
   argTypes: {
     primaryLinks: {
@@ -241,8 +241,8 @@ export const CoBrandedFooter = {
     secondaryLogo: 'dummy-logo.svg',
     secondaryLogoAlt: 'Secondary company name',
     copyright: '© Some Company plc 2018',
-    secondaryLinks: SecondaryLinks,
-    primaryLinks: PrimaryLinks,
+    secondaryLinks,
+    primaryLinks,
   },
   parameters: {
     docs: {

--- a/projects/canopy/src/lib/page/docs/page.stories.ts
+++ b/projects/canopy/src/lib/page/docs/page.stories.ts
@@ -2,7 +2,7 @@ import { Meta, moduleMetadata } from '@storybook/angular';
 import { Component, Input } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 
-import { PrimaryLinks, SecondaryLinks } from '../../footer/docs/footer.stories';
+import { primaryLinks, secondaryLinks } from '../../footer/docs/footer.stories';
 import { productHeroHTML } from '../../hero/docs/hero.stories';
 import { LgPageComponent } from '../page.component';
 import { LgHeaderComponent, LgHeaderLogoComponent } from '../../header';
@@ -58,8 +58,8 @@ const createArgs = () => ({
   card3: `Completely synergize resource taxing relationships via premier niche markets. Professionally cultivate one-to-one
     customer service with robust ideas. Dynamically innovate resource-leveling customer service for state of the art
     customer service.`,
-  primaryLinks: PrimaryLinks,
-  secondaryLinks: SecondaryLinks,
+  primaryLinks,
+  secondaryLinks,
 });
 
 const header = `
@@ -173,6 +173,7 @@ class FullWidthWithHeaderComponent {
 
 export default {
   title: 'Templates/Page/Examples',
+  excludeStories: [ 'primaryLinks', 'secondaryLinks' ],
   component: LgPageComponent,
   decorators: [
     moduleMetadata({


### PR DESCRIPTION
# Description

The primaryLinks and secondaryLinks variables from `projects/canopy/src/lib/footer/docs/footer.stories.ts` were treated as real stories by Storybook, so they had to be excluded.

<img width="1920" height="918" alt="Screenshot 2025-07-24 at 16 43 36" src="https://github.com/user-attachments/assets/00c0e332-e68e-4bec-8626-5f5189484f48" />

## Requirements

N/A

Design link: N/A
Screenshot: N/A

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
