### PR TITLE
feat(card-navigation-title): add better handling of external links

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -93,7 +93,7 @@
         <aside lg-card-group lgMarginBottom="xl">
           <lg-card>
             <lg-card-header>
-              <lg-card-navigation-title title="The title" link="https://www.landg.com" [headingLevel]="2"></lg-card-navigation-title>
+              <lg-card-navigation-title title="The title" link="/foo" [headingLevel]="2"></lg-card-navigation-title>
             </lg-card-header>
             <lg-card-content>
               Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
@@ -115,7 +115,7 @@
           </lg-card>
           <lg-card>
             <lg-card-header>
-              <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+              <lg-card-navigation-title title="The title" link="/boo" headingLevel="2"></lg-card-navigation-title>
             </lg-card-header>
             <lg-card-content>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
@@ -131,7 +131,7 @@
           </lg-card>
           <lg-card>
             <lg-card-header>
-              <lg-card-navigation-title title="The title" link="https://www.landg.com" headingLevel="2"></lg-card-navigation-title>
+              <lg-card-navigation-title title="The title" link="/test" headingLevel="2"></lg-card-navigation-title>
             </lg-card-header>
             <lg-card-content>
               Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.html
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.html
@@ -1,5 +1,5 @@
 <lg-heading [level]="headingLevel" *ngIf="link && title && headingLevel">
-  <a *ngIf="externalLink" [href]="link" (click)="linkClicked()">
+  <a *ngIf="externalLink" [href]="link" (click)="linkClicked()" target="_blank">
     <ng-container [ngTemplateOutlet]="linkContent"></ng-container>
   </a>
   <a *ngIf="!externalLink" [routerLink]="[link]" [queryParams]="queryParams" [queryParamsHandling]="queryParamsHandling" (click)="linkClicked()">
@@ -9,5 +9,5 @@
 
 <ng-template #linkContent>
   {{title}}
-  <lg-icon name="arrow-right"></lg-icon>
+  <lg-icon [name]="externalLink ? 'link-external' : 'arrow-right'"></lg-icon>
 </ng-template>

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.scss
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.scss
@@ -20,6 +20,10 @@
     background: var(--link-color);
     border-radius: 50%;
     color: var(--color-white);
+
+    > svg {
+      padding: 0.125rem;
+    }
   }
 
   a {

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.spec.ts
@@ -81,7 +81,11 @@ describe('LgCardNavigationTitleComponent', () => {
     });
 
     it('should know whether the link is external or internal', () => {
+      expect(component.link).toBe('http://www.landg.com');
       expect(component['externalLink']).toBeTrue();
+      let anchorEL = fixture.debugElement.query(By.css('a'));
+
+      expect(anchorEL.nativeElement.getAttribute('target')).toBe('_blank');
 
       fixture = MockRender(
         `
@@ -99,6 +103,10 @@ describe('LgCardNavigationTitleComponent', () => {
       component = debugElement.children[0].componentInstance;
 
       expect(component['externalLink']).toBeFalse();
+      expect(component.link).toBe('/test-path');
+      anchorEL = fixture.debugElement.query(By.css('a'));
+
+      expect(anchorEL.nativeElement.getAttribute('target')).toBeNull();
     });
   });
 

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.ts
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.ts
@@ -3,18 +3,19 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnChanges,
   OnInit,
   Output,
   SimpleChanges,
-  ViewEncapsulation, OnChanges,
+  ViewEncapsulation,
 } from '@angular/core';
 import { Params, QueryParamsHandling, RouterLink } from '@angular/router';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 import type { HeadingLevel } from '../../heading';
 import { LgHeadingComponent } from '../../heading';
-import isExternalURL from '../../utils/external-links';
 import { LgIconComponent } from '../../icon';
+import isExternalURL from '../../utils/external-links';
 
 @Component({
   selector: 'lg-card-navigation-title',
@@ -38,14 +39,13 @@ export class LgCardNavigationTitleComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     if (!(this.headingLevel && this.title && this.link)) {
-
       console.error('headingLevel, title and link must be set');
     }
   }
 
   ngOnChanges({ link }: SimpleChanges): void {
     if (link?.currentValue) {
-      this.externalLink = isExternalURL(link?.currentValue);
+      this.externalLink = isExternalURL(link?.currentValue as string);
     }
   }
 

--- a/projects/canopy/src/lib/card/docs/card/card.stories.ts
+++ b/projects/canopy/src/lib/card/docs/card/card.stories.ts
@@ -318,7 +318,7 @@ const cardGroupTemplate = `
       <aside lg-card-group>
         <lg-card>
           <lg-card-header>
-            <lg-card-navigation-title title="The title" link="https://www.landg.com"
+            <lg-card-navigation-title title="Internal link title" link="/foo"
                                       [headingLevel]="2"></lg-card-navigation-title>
           </lg-card-header>
           <lg-card-content>
@@ -332,7 +332,7 @@ const cardGroupTemplate = `
         </lg-card>
         <lg-card *ngFor="let i of [].constructor(additionalCards)">
           <lg-card-header>
-            <lg-card-navigation-title title="The title" link="https://www.landg.com"
+            <lg-card-navigation-title title="External link title" link="https://www.landg.com"
                                       headingLevel="2"></lg-card-navigation-title>
           </lg-card-header>
           <lg-card-content>
@@ -453,7 +453,7 @@ export const DefaultCard = {
 export const NavigationCard = {
   name: 'Card navigation',
   args: {
-    link: 'https://www.landg.com',
+    link: '/foo',
     queryParams: null,
     queryParamsHandling: null,
     headingLevel: 2,

--- a/projects/canopy/src/lib/card/docs/card/guide.mdx
+++ b/projects/canopy/src/lib/card/docs/card/guide.mdx
@@ -143,6 +143,7 @@ This is where the main title should be provided. It should be located inside the
 ### LgCardNavigationTitleComponent
 
 This is where the main title and link should be provided. It should be located inside the card content.
+The `target` attribute and icon for the link will be automatically determined based on the `link` input.
 
 #### Inputs
 


### PR DESCRIPTION
# Description

This PR adds the `target='_blank'` attribute for external links. It also changes the icon from and arrow to the external link one.

<img width="897" height="414" alt="Screenshot 2025-08-20 at 12 53 40" src="https://github.com/user-attachments/assets/4b28c94a-6308-4673-932b-87076b81c504" />


## Requirements

Using the card navigation title as an external link.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
