### PR TITLE
fix: button link font weight

### DIFF
--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -107,6 +107,7 @@
   min-width: initial;
   border-radius: 0;
   width: initial;
+  font-weight: var(--font-weight-regular);
 
   @include mixins.lg-link();
 


### PR DESCRIPTION
# Description

Update incorrect 'link' button font weight.

Fixes: #1562 
<img width="2604" height="646" alt="fixed" src="https://github.com/user-attachments/assets/8a8c4664-8c30-434d-b9bc-6d7c75d1a4e5" />


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
