### PR TITLE
ci(brand-modernisation): update workflows

### DIFF
--- a/.github/workflows/branch_pages_deploy.yml
+++ b/.github/workflows/branch_pages_deploy.yml
@@ -49,10 +49,14 @@ jobs:
           unzip lg-sb-build.zip -d ./docs/lg-sb-'${{ fromJSON(steps.prData.outputs.result).branch }}'
           rm lg-sb-build.zip
 
+      - name: 'Set PERCY_TOKEN env var'
+        run: echo "PERCY_TOKEN_NAME=${{ startsWith(fromJSON(steps.prData.outputs.result).branch, 'bm-') && 'PERCY_TOKEN_BM' || 'PERCY_TOKEN' }}" >> $GITHUB_ENV
+
+
       - name: 'Visual comparison'
         run: npx percy storybook ./docs/lg-sb-${{ fromJSON(steps.prData.outputs.result).branch }} --config=.percy.yml
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_TOKEN: ${{ secrets[env.PERCY_TOKEN_NAME] }}
           PERCY_BRANCH: '${{ fromJSON(steps.prData.outputs.result).branch }}'
           NETWORK_IDLE_WAIT_TIMEOUT: 5000
 

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -91,11 +91,14 @@ jobs:
       - name: 'Build storybook'
         run: npm run build:storybook -- --output-dir ./lg-sb-build
 
+      - name: 'Set PERCY_TOKEN env var'
+        run: echo "PERCY_TOKEN_NAME=${{ startsWith(github.ref_name, 'bm-') && 'PERCY_TOKEN_BM' || 'PERCY_TOKEN' }}" >> $GITHUB_ENV
+
       - name: 'Update visual baselines'
         run: npx percy storybook ./lg-sb-build --config=.percy.yml
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_BRANCH: 'master'
+          PERCY_TOKEN: ${{ secrets[env.PERCY_TOKEN_NAME] }}
+          PERCY_BRANCH: '${{ github.ref_name }}'
           NETWORK_IDLE_WAIT_TIMEOUT: 5000
 
       - name: 'Deployment to GitHub Pages'


### PR DESCRIPTION
# Description

Update workflows to use different `PERCY_TOKEN` based on the branch (whether it's brand modernisation or not).

## Requirements

We have two different instances of Percy; one for our main library and one for the brand modernisation work. 
The correct token must be used.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
