### PR TITLE
Fix link styling

### DIFF
--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -101,6 +101,8 @@
 }
 
 .lg-btn--link {
+  padding: 0;
+  margin: 0;
   border: 0;
   background-color: transparent;
   cursor: pointer;
@@ -111,18 +113,6 @@
   text-align: start;
 
   @include mixins.lg-link();
-
-  &:focus-visible,
-  &:hover:focus-visible {
-    box-shadow: none;
-  }
-
-  &:hover,
-  &:hover:visited,
-  &:focus-visible,
-  &:focus-visible:hover {
-    padding-bottom: 0.125rem;
-  }
 }
 
 .lg-btn-toggle--active > .lg-icon[name='chevron-down'] {

--- a/projects/canopy/src/lib/button/docs/button.stories.ts
+++ b/projects/canopy/src/lib/button/docs/button.stories.ts
@@ -319,3 +319,19 @@ export const Link = {
     backgrounds: { value: setBackground('link') },
   },
 };
+
+export const LinkWithIcon = {
+  name: 'Link with icon',
+  render: (args: LgButtonComponent) => ({
+    props: args,
+    template: buttonTemplate,
+  }),
+  argTypes: {
+    icon: iconArgType,
+  },
+  args: {
+    ...defaultArgValues,
+    variant: 'link',
+    icon: lgIconsArray[0].name,
+  },
+};

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -33,31 +33,26 @@
   $focus-color: var(--link-focus-color),
   $focus-bg-color: var(--link-focus-bg-color)
 ) {
-  $box-shadow-inset-width: -0.063rem;
-
-  border-bottom: 0.125rem solid $default-color;
   color: $default-color;
   line-height: initial;
-  padding: 0 0.125rem;
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: $default-color;
 
   &:hover,
   &:hover:visited {
     color: $hover-color;
-    border-bottom: 0;
-    box-shadow:
-      inset 0 $box-shadow-inset-width 0 0 $hover-color,
-      0 0.188rem 0 0 $hover-color;
+    text-decoration-color: $hover-color;
+    text-decoration-thickness: 0.188rem;
   }
 
   &:visited {
     color: $visited-color;
-    border-color: $visited-color;
+    text-decoration-color: $visited-color;
   }
 
   &:active {
     background-color: $active-bg-color;
-    border-bottom-color: $active-color;
+    text-decoration-color: $active-color;
     color: $active-color;
     outline: 0;
   }
@@ -65,7 +60,7 @@
   &:focus-visible,
   &:focus-visible:hover {
     background-color: $focus-bg-color;
-    border-bottom: 0;
+    text-decoration: none;
     color: $focus-color;
     outline: 0.063rem solid $focus-bg-color;
     outline-offset: 0;


### PR DESCRIPTION
# Description

**DO NOTICE** that this fix removes the underline from the icon.
Previously:
<img width="540" height="176" alt="image" src="https://github.com/user-attachments/assets/6a090fd4-b34b-4b00-9d0b-87d7c6198b48" />
Now:
<img width="456" height="152" alt="image" src="https://github.com/user-attachments/assets/aa69543a-b072-4879-81d5-ffd97ef0d686" />
This should be fine as it follows GOV.UK design standards https://design-system.service.gov.uk/components/details/ and from that I read it's also not recommended to underline the icon.

Fixes # (issue)
https://github.com/Legal-and-General/canopy/issues/1567


Screenshots:
lg-button of type link with very long text:
<img width="1750" height="354" alt="link_button_icon_long_text" src="https://github.com/user-attachments/assets/8703d4a9-da6c-475d-abfc-b50ddb96a335" />
lg-button of type link with alternating state: normal, hover, active, focus-visible
<img width="522" height="416" alt="link_normal_hover_active_focus-visible" src="https://github.com/user-attachments/assets/9d998f3b-1846-4064-bd1f-a4bb881da354" />

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
