### PR TITLE
Remove ts-mockito from the codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
         "@typescript-eslint/utils": "^8.32.1",
-        "@typestrong/ts-mockito": "^2.6.6",
         "autoprefixer": "^10.4.20",
         "codelyzer": "^6.0.2",
         "color-convert": "^3.1.0",
@@ -14774,17 +14773,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typestrong/ts-mockito": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@typestrong/ts-mockito/-/ts-mockito-2.6.6.tgz",
-      "integrity": "sha512-S8nV5NgzejK2IIF/Prnd8U0nDmfviABazqMo8WqsNS4ZtUVeOXJzJF+kgKecKrxvuHylH8a2jUOzzawEk/oDqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.5",
-        "safe-json-stringify": "^1.2.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -37104,12 +37092,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "dev": true
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "@typescript-eslint/utils": "^8.32.1",
-    "@typestrong/ts-mockito": "^2.6.6",
     "autoprefixer": "^10.4.20",
     "codelyzer": "^6.0.2",
     "color-convert": "^3.1.0",

--- a/projects/canopy-test-app/src/app/app.component.spec.ts
+++ b/projects/canopy-test-app/src/app/app.component.spec.ts
@@ -1,21 +1,23 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { UntypedFormBuilder } from '@angular/forms';
-import { instance, mock } from '@typestrong/ts-mockito';
 
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
+  let formBuilderMock: jest.Mocked<UntypedFormBuilder>;
 
   beforeEach(waitForAsync(() => {
-    const formBuilderMock = mock(UntypedFormBuilder);
+    formBuilderMock = {
+      group: jest.fn(),
+      control: jest.fn(),
+      array: jest.fn(),
+    } as unknown as jest.Mocked<UntypedFormBuilder>;
 
     TestBed.configureTestingModule({
       imports: [ AppComponent ],
-      providers: [
-        { provide: UntypedFormBuilder, useFactory: () => instance(formBuilderMock) },
-      ],
+      providers: [ { provide: UntypedFormBuilder, useValue: formBuilderMock } ],
     }).compileComponents();
 
     fixture = TestBed.overrideComponent(AppComponent, {

--- a/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.spec.ts
+++ b/projects/canopy/src/lib/accordion/accordion-panel-heading/accordion-panel-heading.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponents } from 'ng-mocks';
-import { spy, verify } from '@typestrong/ts-mockito';
 import { Component } from '@angular/core';
 
 import { LgHeadingComponent } from '../../heading';
@@ -129,11 +128,11 @@ describe('LgAccordionPanelHeadingComponent', () => {
     });
 
     it('should emit an event with the value of \'isActive\'', () => {
-      const componentEventSpy = spy(component.toggleActive);
+      const componentEventSpy = jest.spyOn(component.toggleActive, 'emit');
 
       component.toggle();
 
-      verify(componentEventSpy.emit(true)).once();
+      expect(componentEventSpy).toHaveBeenNthCalledWith(1, true);
     });
   });
 

--- a/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
+++ b/projects/canopy/src/lib/brand-icon/brand-icon.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgBrandIconComponent } from './brand-icon.component';
 import { LgBrandIconRegistry } from './brand-icon.registry';
@@ -7,17 +6,19 @@ import { LgBrandIconRegistry } from './brand-icon.registry';
 describe('LgBrandIconComponent', () => {
   let component: LgBrandIconComponent;
   let fixture: ComponentFixture<LgBrandIconComponent>;
-  let brandIconRegistryMock: LgBrandIconRegistry;
+  let brandIconRegistryMock: jest.Mocked<LgBrandIconRegistry>;
 
   beforeEach(waitForAsync(() => {
-    brandIconRegistryMock = mock(LgBrandIconRegistry);
+    brandIconRegistryMock = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<LgBrandIconRegistry>;
 
     TestBed.configureTestingModule({
       imports: [ LgBrandIconComponent ],
       providers: [
         {
           provide: LgBrandIconRegistry,
-          useFactory: () => instance(brandIconRegistryMock),
+          useValue: brandIconRegistryMock,
         },
       ],
     }).compileComponents();
@@ -46,7 +47,7 @@ describe('LgBrandIconComponent', () => {
       expect(fixture.nativeElement.querySelector('#test')).toBeNull();
       expect(fixture.nativeElement.querySelector('svg')).toBeNull();
 
-      when(await brandIconRegistryMock.get('sun')).thenReturn(
+      brandIconRegistryMock.get.mockResolvedValue(
         '<svg id="test">test-svg<path id="lg-icon-fill-primary"></path></svg>',
       );
 
@@ -74,8 +75,8 @@ describe('LgBrandIconComponent', () => {
   });
 
   describe('the colour input', () => {
-    beforeEach(async () => {
-      when(await brandIconRegistryMock.get('sun')).thenReturn(
+    beforeEach(() => {
+      brandIconRegistryMock.get.mockResolvedValue(
         '<svg id="test">test-svg<path id="lg-icon-fill-primary"></path></svg>',
       );
 
@@ -106,7 +107,7 @@ describe('LgBrandIconComponent', () => {
     });
 
     it('when the icon isn\'t coloured it should not set the fill style', async () => {
-      when(await brandIconRegistryMock.get('sun')).thenReturn(
+      brandIconRegistryMock.get.mockResolvedValue(
         '<svg id="test">test-svg<path id="no-color"></path></svg>',
       );
 
@@ -123,7 +124,7 @@ describe('LgBrandIconComponent', () => {
 
   describe('the half tone colour input', () => {
     it('should apply the specific colour', async () => {
-      when(await brandIconRegistryMock.get('sun')).thenReturn(
+      brandIconRegistryMock.get.mockResolvedValue(
         '<svg id="test">test-svg<path id="Half-tone"></path></svg>',
       );
 
@@ -142,7 +143,7 @@ describe('LgBrandIconComponent', () => {
 
   describe('the outlines colour input', () => {
     it('should apply the specific colour', async () => {
-      when(await brandIconRegistryMock.get('sun')).thenReturn(
+      brandIconRegistryMock.get.mockResolvedValue(
         '<svg id="test">test-svg<path id="Outlines"></path></svg>',
       );
 

--- a/projects/canopy/src/lib/breadcrumb/breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component.spec.ts
+++ b/projects/canopy/src/lib/breadcrumb/breadcrumb-item-ellipsis/breadcrumb-item-ellipsis.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { MockComponent } from 'ng-mocks';
-import { mock, when } from '@typestrong/ts-mockito';
 
 import { LgIconComponent, LgIconRegistry } from '../../icon';
 import { BreadcrumbVariant } from '../breadcrumb-item/breadcrumb-item.interface';
@@ -11,31 +10,33 @@ import { LgBreadcrumbItemEllipsisComponent } from './breadcrumb-item-ellipsis.co
 describe('LgBreadcrumbItemEllipsisComponent', () => {
   let component: LgBreadcrumbItemEllipsisComponent;
   let fixture: ComponentFixture<LgBreadcrumbItemEllipsisComponent>;
-  let iconRegistryMock: LgIconRegistry;
+  let iconRegistryMock: jest.Mocked<LgIconRegistry>;
   let breadcrumbEllipsisDebugElement: DebugElement;
   let breadcrumbEllipsisEl: HTMLElement;
 
   beforeEach(waitForAsync(() => {
-    iconRegistryMock = mock(LgIconRegistry);
+    iconRegistryMock = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<LgIconRegistry>;
 
     TestBed.configureTestingModule({
       imports: [ LgBreadcrumbItemEllipsisComponent, MockComponent(LgIconComponent) ],
     }).compileComponents();
   }));
 
-  beforeEach(async () => {
+  beforeEach(() => {
     fixture = TestBed.createComponent(LgBreadcrumbItemEllipsisComponent);
     component = fixture.componentInstance;
     breadcrumbEllipsisDebugElement = fixture.debugElement;
     breadcrumbEllipsisEl = breadcrumbEllipsisDebugElement.nativeElement;
 
-    when(await iconRegistryMock.get('caret-right')).thenReturn(
-      '<svg id="test">test-svg</svg>',
-    );
+    iconRegistryMock.get.mockImplementation(name => {
+      if (name === 'caret-right' || name === 'overflow-horizontal') {
+        return Promise.resolve('<svg id="test">test-svg</svg>');
+      }
 
-    when(await iconRegistryMock.get('overflow-horizontal')).thenReturn(
-      '<svg id="test">test-svg</svg>',
-    );
+      return Promise.resolve('');
+    });
 
     fixture.detectChanges();
   });

--- a/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.spec.ts
+++ b/projects/canopy/src/lib/card/card-navigation-title/card-navigation-title.component.spec.ts
@@ -2,8 +2,7 @@ import { TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponents, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-import { spy, verify } from '@typestrong/ts-mockito';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 import { LgHeadingComponent } from '../../heading';
 import { LgIconComponent } from '../../icon';
@@ -22,11 +21,11 @@ describe('LgCardNavigationTitleComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
         LgCardNavigationTitleComponent,
         LgHeadingComponent,
         MockComponents(LgIconComponent),
       ],
+      providers: [ provideRouter([]) ],
     }).compileComponents();
 
     jest.spyOn(console, 'error').mockImplementation();
@@ -75,11 +74,11 @@ describe('LgCardNavigationTitleComponent', () => {
     });
 
     it('should emit events', () => {
-      const linkClickedEventSpy = spy(component.linkClickedEvent);
+      const linkClickedEventSpy = jest.spyOn(component.linkClickedEvent, 'emit');
 
       component.linkClicked();
 
-      verify(linkClickedEventSpy.emit()).once();
+      expect(linkClickedEventSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should know whether the link is external or internal', () => {

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockComponents } from 'ng-mocks';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 import { NgIf } from '@angular/common';
 
 import { LgHintComponent } from '../hint';
@@ -85,10 +84,12 @@ describe('LgCheckboxGroupComponent', () => {
   let groupInstance: LgCheckboxGroupComponent;
   let checkboxInstances: Array<LgToggleComponent>;
   let component: TestCheckboxGroupComponent;
-  let errorStateMatcherMock: LgErrorStateMatcher;
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   beforeEach(waitForAsync(() => {
-    errorStateMatcherMock = mock(LgErrorStateMatcher);
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn(),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
 
     TestBed.configureTestingModule({
       imports: [
@@ -105,7 +106,7 @@ describe('LgCheckboxGroupComponent', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -278,7 +279,7 @@ describe('LgCheckboxGroupComponent', () => {
   });
 
   it('links the error to the fieldset with the correct aria attributes', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
     errorDebugElement = fixture.debugElement.query(By.directive(LgValidationComponent));
 
@@ -290,7 +291,7 @@ describe('LgCheckboxGroupComponent', () => {
   });
 
   it('combines both the hint and error ids to create the aria described attribute', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
     errorDebugElement = fixture.debugElement.query(By.directive(LgValidationComponent));
 
@@ -314,7 +315,7 @@ describe('LgCheckboxGroupComponent', () => {
   });
 
   it('adds the error class if the form field is invalid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
 
     expect(groupDebugElement.nativeElement.className).toContain(
@@ -323,9 +324,7 @@ describe('LgCheckboxGroupComponent', () => {
   });
 
   it('removes the error class if the form field is valid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-      false,
-    );
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(false);
 
     fixture.detectChanges();
 

--- a/projects/canopy/src/lib/forms/date/afterDate.validator.spec.ts
+++ b/projects/canopy/src/lib/forms/date/afterDate.validator.spec.ts
@@ -1,19 +1,17 @@
 import { AbstractControl, ValidatorFn } from '@angular/forms';
 import { addDays, format, subDays } from 'date-fns';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { afterDateValidator } from './afterDate.validator';
 import { dateFormat } from './date-field.interface';
 
 describe('afterDate', () => {
-  let control: AbstractControl;
+  let control: Partial<AbstractControl>;
   let validator: ValidatorFn;
   let dateToCompare: Date;
   let date: Date;
 
   beforeEach(() => {
     dateToCompare = new Date();
-    control = mock(AbstractControl);
     validator = afterDateValidator(dateToCompare);
   });
 
@@ -26,15 +24,15 @@ describe('afterDate', () => {
   describe('date is before the specified date', () => {
     beforeEach(() => {
       date = subDays(dateToCompare, 10);
-      when(control.value).thenReturn(format(date, 'yyyy-MM-dd'));
+      control = { value: format(date, 'yyyy-MM-dd') };
     });
 
     it('adds a afterDate error', () => {
-      expect(validator(instance(control))).toEqual(expect.any(Object));
+      expect(validator(control as AbstractControl)).toEqual(expect.any(Object));
     });
 
     it('includes the date to compare against', () => {
-      expect(validator(instance(control)).afterDate).toEqual(
+      expect(validator(control as AbstractControl)?.afterDate).toEqual(
         expect.objectContaining({
           required: format(dateToCompare, dateFormat),
         }),
@@ -42,7 +40,7 @@ describe('afterDate', () => {
     });
 
     it('includes the date that was entered', () => {
-      expect(validator(instance(control)).afterDate).toEqual(
+      expect(validator(control as AbstractControl)?.afterDate).toEqual(
         expect.objectContaining({
           actual: format(date, dateFormat),
         }),
@@ -51,21 +49,18 @@ describe('afterDate', () => {
   });
 
   it('returns null if the date is null', () => {
-    when(control.value).thenReturn(null);
-
-    expect(validator(instance(control))).toBe(null);
+    control = { value: null };
+    expect(validator(control as AbstractControl)).toBe(null);
   });
 
   it('throws an error if the date is not a valid date', () => {
-    when(control.value).thenReturn(new Date('not a date'));
-
-    expect(() => validator(instance(control))).toThrow();
+    control = { value: new Date('not a date') };
+    expect(() => validator(control as AbstractControl)).toThrow();
   });
 
   it('returns null if date is after the specified date', () => {
     date = addDays(dateToCompare, 10);
-    when(control.value).thenReturn(format(date, 'yyyy-MM-dd'));
-
-    expect(validator(instance(control))).toEqual(null);
+    control = { value: format(date, 'yyyy-MM-dd') };
+    expect(validator(control as AbstractControl)).toEqual(null);
   });
 });

--- a/projects/canopy/src/lib/forms/date/beforeDate.validator.spec.ts
+++ b/projects/canopy/src/lib/forms/date/beforeDate.validator.spec.ts
@@ -1,6 +1,5 @@
-import { AbstractControl, ValidatorFn } from '@angular/forms';
+import { AbstractControl, FormControl, ValidatorFn } from '@angular/forms';
 import { addDays, format, subDays } from 'date-fns';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { beforeDateValidator } from './beforeDate.validator';
 import { dateFormat } from './date-field.interface';
@@ -13,7 +12,7 @@ describe('beforeDate', () => {
 
   beforeEach(() => {
     dateToCompare = new Date();
-    control = mock(AbstractControl);
+    control = new FormControl();
     validator = beforeDateValidator(dateToCompare);
   });
 
@@ -26,15 +25,15 @@ describe('beforeDate', () => {
   describe('date is after the specified date', () => {
     beforeEach(() => {
       date = addDays(dateToCompare, 10);
-      when(control.value).thenReturn(format(date, 'yyyy-MM-dd'));
+      control.setValue(format(date, 'yyyy-MM-dd'));
     });
 
     it('adds a beforeDate error', () => {
-      expect(validator(instance(control))).toEqual(expect.any(Object));
+      expect(validator(control)).toEqual(expect.any(Object));
     });
 
     it('includes the date to compare against', () => {
-      expect(validator(instance(control)).beforeDate).toEqual(
+      expect(validator(control).beforeDate).toEqual(
         expect.objectContaining({
           required: format(dateToCompare, dateFormat),
         }),
@@ -42,7 +41,7 @@ describe('beforeDate', () => {
     });
 
     it('includes the date that was entered', () => {
-      expect(validator(instance(control)).beforeDate).toEqual(
+      expect(validator(control).beforeDate).toEqual(
         expect.objectContaining({
           actual: format(date, dateFormat),
         }),
@@ -51,21 +50,21 @@ describe('beforeDate', () => {
   });
 
   it('returns null if the date is null', () => {
-    when(control.value).thenReturn(null);
+    control.setValue(null);
 
-    expect(validator(instance(control))).toBe(null);
+    expect(validator(control)).toBe(null);
   });
 
   it('throws an error if the date is not a valid date', () => {
-    when(control.value).thenReturn(new Date('not a date'));
+    control.setValue(new Date('not a date'));
 
-    expect(() => validator(instance(control))).toThrow();
+    expect(() => validator(control)).toThrow();
   });
 
   it('returns null if date is before the specified date', () => {
     date = subDays(dateToCompare, 10);
-    when(control.value).thenReturn(format(date, 'yyyy-MM-dd'));
+    control.setValue(format(date, 'yyyy-MM-dd'));
 
-    expect(validator(instance(control))).toEqual(null);
+    expect(validator(control)).toEqual(null);
   });
 });

--- a/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.spec.ts
@@ -17,7 +17,6 @@ import {
 import { By } from '@angular/platform-browser';
 import { MockComponents } from 'ng-mocks';
 import { skip } from 'rxjs/operators';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgHintComponent } from '../hint';
 import { LgErrorStateMatcher } from '../validation';
@@ -27,8 +26,6 @@ import { LgDateFieldComponent } from './date-field.component';
 
 const errorId = 'test-error-id';
 const hintId = 'test-hint-id';
-
-const errorStateMatcherMock = mock(LgErrorStateMatcher);
 
 @Component({
   template: `
@@ -90,8 +87,13 @@ describe('LgDateFieldComponent', () => {
   let monthInput: DebugElement;
   let yearInput: DebugElement;
   let component: TestDateInputComponent;
+  let errorStateMatcherMock: LgErrorStateMatcher;
 
   beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn().mockReturnValue(false),
+    } as unknown as LgErrorStateMatcher;
+
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -103,7 +105,7 @@ describe('LgDateFieldComponent', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -121,10 +123,6 @@ describe('LgDateFieldComponent', () => {
     dateInput = fixture.debugElement.query(By.css('[formcontrolname="date"]'));
     monthInput = fixture.debugElement.query(By.css('[formcontrolname="month"]'));
     yearInput = fixture.debugElement.query(By.css('[formcontrolname="year"]'));
-
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-      false,
-    );
   }));
 
   describe('markup', () => {

--- a/projects/canopy/src/lib/forms/date/futureDate.validator.spec.ts
+++ b/projects/canopy/src/lib/forms/date/futureDate.validator.spec.ts
@@ -1,35 +1,34 @@
 import { AbstractControl, ValidatorFn } from '@angular/forms';
 import { addDays, format, subDays } from 'date-fns';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { futureDateValidator } from './futureDate.validator';
 
 describe('futureDate', () => {
-  let control: AbstractControl;
   let validator: ValidatorFn;
 
   beforeEach(() => {
-    control = mock(AbstractControl);
     validator = futureDateValidator();
   });
 
   it('returns a futureDate error if the date is not in the future', () => {
-    when(control.value).thenReturn(format(subDays(new Date(), 10), 'yyyy-MM-dd'));
+    const pastDate = format(subDays(new Date(), 10), 'yyyy-MM-dd');
+    const control = { value: pastDate } as AbstractControl;
 
-    expect(validator(instance(control))).toEqual({
+    expect(validator(control)).toEqual({
       futureDate: true,
     });
   });
 
   it('returns null if the date is not a valid date', () => {
-    when(control.value).thenReturn(null);
+    const control = { value: null } as AbstractControl;
 
-    expect(validator(instance(control))).toBe(null);
+    expect(validator(control)).toBe(null);
   });
 
   it('returns null if date is in the future', () => {
-    when(control.value).thenReturn(format(addDays(new Date(), 10), 'yyyy-MM-dd'));
+    const futureDate = format(addDays(new Date(), 10), 'yyyy-MM-dd');
+    const control = { value: futureDate } as AbstractControl;
 
-    expect(validator(instance(control))).toBe(null);
+    expect(validator(control)).toBe(null);
   });
 });

--- a/projects/canopy/src/lib/forms/date/pastDate.validator.spec.ts
+++ b/projects/canopy/src/lib/forms/date/pastDate.validator.spec.ts
@@ -1,35 +1,38 @@
-import { AbstractControl, ValidatorFn } from '@angular/forms';
+import { AbstractControl, FormControl } from '@angular/forms';
 import { addDays, format, subDays } from 'date-fns';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { pastDateValidator } from './pastDate.validator';
 
 describe('pastDate', () => {
   let control: AbstractControl;
-  let validator: ValidatorFn;
+  let validator: ReturnType<typeof pastDateValidator>;
 
   beforeEach(() => {
-    control = mock(AbstractControl);
+    control = new FormControl();
     validator = pastDateValidator();
   });
 
   it('returns a pastDate error if the date is not in the past', () => {
-    when(control.value).thenReturn(format(addDays(new Date(), 10), 'yyyy-MM-dd'));
+    const futureDate = format(addDays(new Date(), 10), 'yyyy-MM-dd');
 
-    expect(validator(instance(control))).toEqual({
+    control.setValue(futureDate);
+
+    expect(validator(control)).toEqual({
       pastDate: true,
     });
   });
 
   it('returns null if the date is not a valid date', () => {
-    when(control.value).thenReturn(null);
+    control.setValue(null);
 
-    expect(validator(instance(control))).toBe(null);
+    expect(validator(control)).toBe(null);
   });
 
   it('returns null if date is in the past', () => {
-    when(control.value).thenReturn(format(subDays(new Date(), 10), 'yyyy-MM-dd'));
+    const pastDate = format(subDays(new Date(), 10), 'yyyy-MM-dd');
 
-    expect(validator(instance(control))).toBe(null);
+    control.setValue(pastDate);
+
+    expect(validator(control)).toBe(null);
   });
 });

--- a/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
@@ -3,7 +3,6 @@ import { TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockComponents, MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
-import { instance, mock, spy, when } from '@typestrong/ts-mockito';
 import { NgIf } from '@angular/common';
 
 import { LgHintComponent } from '../hint';
@@ -25,7 +24,7 @@ describe('LgInputFieldComponent', () => {
   let inputDirectiveInstance: LgInputDirective;
   let inputFieldDebugElement: DebugElement;
   let inputWrapperDebugElement: DebugElement;
-  let errorStateMatcherMock: LgErrorStateMatcher;
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
   let labelDebugElement: DebugElement;
 
   const errorId = 'test-error-id';
@@ -37,7 +36,9 @@ describe('LgInputFieldComponent', () => {
   const prefixText = 'prefix';
 
   beforeEach(waitForAsync(() => {
-    errorStateMatcherMock = mock(LgErrorStateMatcher);
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn().mockReturnValue(false),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
 
     TestBed.configureTestingModule({
       imports: [
@@ -56,7 +57,7 @@ describe('LgInputFieldComponent', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -234,16 +235,13 @@ describe('LgInputFieldComponent', () => {
   });
 
   describe('error', () => {
-    let componentSpy: LgInputFieldComponent;
-
     beforeEach(() => {
       renderComponent({});
-      componentSpy = spy(component);
       fixture.detectChanges();
     });
 
     it('adds an error class to the input wrapper when the control is invalid', () => {
-      when(componentSpy.errorClass).thenReturn(true);
+      jest.spyOn(component, 'errorClass', 'get').mockReturnValue(true);
       fixture.detectChanges();
 
       expect(inputFieldDebugElement.nativeElement.getAttribute('class')).toContain(
@@ -252,7 +250,7 @@ describe('LgInputFieldComponent', () => {
     });
 
     it('does not add the error class to the input wrapper when the control is valid', () => {
-      when(componentSpy.errorClass).thenReturn(false);
+      jest.spyOn(component, 'errorClass', 'get').mockReturnValue(false);
       fixture.detectChanges();
 
       expect(inputFieldDebugElement.nativeElement.getAttribute('class')).not.toContain(

--- a/projects/canopy/src/lib/forms/input/input.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input.directive.spec.ts
@@ -8,7 +8,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgErrorStateMatcher } from '../validation';
 
@@ -34,15 +33,19 @@ describe('LgInputDirective', () => {
   let component: TestInputComponent;
   let inputDebugElement: DebugElement;
   let inputInstance: LgInputDirective;
-  const errorStateMatcherMock = mock(LgErrorStateMatcher);
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn().mockReturnValue(false),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
+
     TestBed.configureTestingModule({
       imports: [ FormsModule, ReactiveFormsModule, LgInputDirective, TestInputComponent ],
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -75,7 +78,7 @@ describe('LgInputDirective', () => {
   });
 
   it('adds an error class when the field has a validation error', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
 
     expect(inputDebugElement.nativeElement.className).toContain('lg-input--error');

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockComponent } from 'ng-mocks';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 import { NgIf } from '@angular/common';
 
 import { LgHintComponent } from '../hint';
@@ -81,10 +80,12 @@ describe('LgRadioGroupComponent', () => {
   let groupInstance: LgRadioGroupComponent;
   let radioInstances: Array<LgRadioButtonComponent>;
   let component: TestRadioGroupComponent;
-  let errorStateMatcherMock: LgErrorStateMatcher;
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   beforeEach(waitForAsync(() => {
-    errorStateMatcherMock = mock(LgErrorStateMatcher);
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn().mockReturnValue(false),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
 
     TestBed.configureTestingModule({
       imports: [
@@ -100,7 +101,7 @@ describe('LgRadioGroupComponent', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -220,7 +221,7 @@ describe('LgRadioGroupComponent', () => {
   });
 
   it('links the error to the fieldset with the correct aria attributes', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
     errorDebugElement = fixture.debugElement.query(By.directive(LgValidationComponent));
 
@@ -232,7 +233,7 @@ describe('LgRadioGroupComponent', () => {
   });
 
   it('combines both the hint and error ids to create the aria described attribute', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
     errorDebugElement = fixture.debugElement.query(By.directive(LgValidationComponent));
 
@@ -265,17 +266,14 @@ describe('LgRadioGroupComponent', () => {
   });
 
   it('adds the error class if the form field is invalid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
 
     expect(groupDebugElement.nativeElement.className).toContain('lg-radio-group--error');
   });
 
   it('removes the error class if the form field is valid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-      false,
-    );
-
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(false);
     fixture.detectChanges();
 
     expect(groupDebugElement.nativeElement.className).not.toContain(

--- a/projects/canopy/src/lib/forms/select/select-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/select/select-field.component.spec.ts
@@ -9,7 +9,6 @@ import {
   MockRender,
   ngMocks,
 } from 'ng-mocks';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgIconComponent } from '../../icon';
 import { LgHintComponent } from '../hint';
@@ -29,9 +28,13 @@ describe('LgSelectFieldComponent', () => {
   const errorId = 'test-error-id';
   const hintId = 'test-hint-id';
 
-  const errorStateMatcherMock = mock(LgErrorStateMatcher);
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn().mockReturnValue(false),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
+
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -48,7 +51,7 @@ describe('LgSelectFieldComponent', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -112,7 +115,7 @@ describe('LgSelectFieldComponent', () => {
   });
 
   it('adds the error class to the select field when the input field is invalid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     renderComponent();
 
     expect(selectFieldDebugElement.nativeElement.className).toContain(
@@ -121,10 +124,7 @@ describe('LgSelectFieldComponent', () => {
   });
 
   it('does not add the error class to the select field when the input field is valid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-      false,
-    );
-
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(false);
     renderComponent();
 
     expect(selectFieldDebugElement.nativeElement.className).not.toContain(

--- a/projects/canopy/src/lib/forms/select/select.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/select/select.directive.spec.ts
@@ -8,7 +8,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgErrorStateMatcher } from '../validation';
 
@@ -36,15 +35,19 @@ describe('LgSelectDirective', () => {
   let fixture: ComponentFixture<TestSelectComponent>;
   let component: TestSelectComponent;
   let selectDebugElement: DebugElement;
-  const errorStateMatcherMock = mock(LgErrorStateMatcher);
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn(),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
+
     TestBed.configureTestingModule({
       imports: [ FormsModule, ReactiveFormsModule, LgSelectDirective, TestSelectComponent ],
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -68,7 +71,7 @@ describe('LgSelectDirective', () => {
   });
 
   it('adds an error class when the field has a validation error', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
 
     expect(selectDebugElement.nativeElement.className).toContain('lg-select--error');

--- a/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/sort-code/sort-code.directive.spec.ts
@@ -9,7 +9,6 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { instance, mock } from '@typestrong/ts-mockito';
 
 import { LgInputDirective } from '../input';
 
@@ -35,11 +34,8 @@ describe('LgSortCodeDirective', () => {
   let component: TestInputComponent;
   let inputDebugElement: DebugElement;
   let inputInstance: LgSortCodeDirective;
-  let control: NgControl;
 
   beforeEach(waitForAsync(() => {
-    control = mock(NgControl);
-
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -47,7 +43,7 @@ describe('LgSortCodeDirective', () => {
         LgSortCodeDirective,
         TestInputComponent,
       ],
-      providers: [ { provide: NgControl, useValue: instance(control) } ],
+      providers: [ { provide: NgControl, useValue: {} } ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestInputComponent);

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.spec.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockComponents, MockDirective } from 'ng-mocks';
-import { anything, instance, mock, when } from '@typestrong/ts-mockito';
 import { NgIf } from '@angular/common';
 
 import { LgIconComponent } from '../../icon';
@@ -138,11 +137,15 @@ describe('LgToggleComponent', () => {
   let inputDebugElement: DebugElement;
   let inputLabelElement: DebugElement;
 
-  const errorStateMatcherMock = mock(LgErrorStateMatcher);
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   jest.spyOn(console, 'error').mockImplementation();
 
   beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn(),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
+
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -156,7 +159,7 @@ describe('LgToggleComponent', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();
@@ -296,7 +299,7 @@ describe('LgToggleComponent', () => {
   });
 
   it('links the error to the fieldset with the correct aria attributes', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
 
     expect(inputDebugElement.nativeElement.getAttribute('aria-describedBy')).toContain(
@@ -305,9 +308,7 @@ describe('LgToggleComponent', () => {
   });
 
   it('unlinks the error from the fieldset with the correct aria attributes when valid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(
-      false,
-    );
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(false);
 
     fixture.detectChanges();
 
@@ -316,7 +317,7 @@ describe('LgToggleComponent', () => {
   });
 
   it('adds the error class and the aria-invalid attribute if the form field is invalid', () => {
-    when(errorStateMatcherMock.isControlInvalid(anything(), anything())).thenReturn(true);
+    errorStateMatcherMock.isControlInvalid.mockReturnValue(true);
     fixture.detectChanges();
 
     expect(toggleDebugElement.nativeElement.className).toContain('lg-toggle--error');
@@ -330,9 +331,13 @@ describe('LgToggleComponent selector variant', () => {
   let toggleInstance: LgToggleComponent;
   let inputLabelElement: DebugElement;
 
-  const errorStateMatcherMock = mock(LgErrorStateMatcher);
+  let errorStateMatcherMock: jest.Mocked<LgErrorStateMatcher>;
 
   beforeEach(waitForAsync(() => {
+    errorStateMatcherMock = {
+      isControlInvalid: jest.fn(),
+    } as unknown as jest.Mocked<LgErrorStateMatcher>;
+
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -345,7 +350,7 @@ describe('LgToggleComponent selector variant', () => {
       providers: [
         {
           provide: LgErrorStateMatcher,
-          useFactory: () => instance(errorStateMatcherMock),
+          useValue: errorStateMatcherMock,
         },
       ],
     }).compileComponents();

--- a/projects/canopy/src/lib/forms/validation/error-state-matcher.spec.ts
+++ b/projects/canopy/src/lib/forms/validation/error-state-matcher.spec.ts
@@ -1,74 +1,84 @@
 import { FormGroupDirective, NgControl } from '@angular/forms';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgErrorStateMatcher } from './error-state-matcher';
 
 describe('LgErrorStateMatcher', () => {
   let service: LgErrorStateMatcher;
-  let control: NgControl;
-  let controlContainer: FormGroupDirective;
 
   beforeEach(() => {
     service = new LgErrorStateMatcher();
-    control = mock(NgControl);
-    controlContainer = mock(FormGroupDirective);
   });
 
   describe('isControlInvalid', () => {
     describe('invalid states', () => {
       it('control is invalid, touched and dirty', () => {
-        when(control.invalid).thenReturn(true);
-        when(control.touched).thenReturn(true);
-        when(control.dirty).thenReturn(true);
+        const control = {
+          invalid: true,
+          touched: true,
+          dirty: true,
+        } as NgControl;
 
-        expect(service.isControlInvalid(instance(control))).toBe(true);
+        expect(service.isControlInvalid(control)).toBe(true);
       });
 
       it('control is invalid and untouched and form is submitted', () => {
-        when(control.invalid).thenReturn(true);
-        when(control.touched).thenReturn(false);
-        when(controlContainer.submitted).thenReturn(true);
+        const control = {
+          invalid: true,
+          touched: false,
+          dirty: false,
+        } as NgControl;
 
-        expect(
-          service.isControlInvalid(instance(control), instance(controlContainer)),
-        ).toBe(true);
+        const controlContainer = {
+          submitted: true,
+        } as FormGroupDirective;
+
+        expect(service.isControlInvalid(control, controlContainer)).toBe(true);
       });
     });
 
     describe('pending states', () => {
       it('control is invalid and not touched', () => {
-        when(control.invalid).thenReturn(true);
-        when(control.touched).thenReturn(false);
-        when(control.dirty).thenReturn(false);
+        const control = {
+          invalid: true,
+          touched: false,
+          dirty: false,
+        } as NgControl;
 
-        expect(service.isControlInvalid(instance(control))).toBe(false);
+        expect(service.isControlInvalid(control)).toBe(false);
       });
 
       it('control is not invalid and not touched', () => {
-        when(control.invalid).thenReturn(false);
-        when(control.touched).thenReturn(false);
-        when(control.dirty).thenReturn(false);
+        const control = {
+          invalid: false,
+          touched: false,
+          dirty: false,
+        } as NgControl;
 
-        expect(service.isControlInvalid(instance(control))).toBe(false);
+        expect(service.isControlInvalid(control)).toBe(false);
       });
 
       it('control is valid and touched', () => {
-        when(control.invalid).thenReturn(false);
-        when(control.touched).thenReturn(true);
-        when(control.dirty).thenReturn(true);
+        const control = {
+          invalid: false,
+          touched: true,
+          dirty: true,
+        } as NgControl;
 
-        expect(service.isControlInvalid(instance(control))).toBe(false);
+        expect(service.isControlInvalid(control)).toBe(false);
       });
 
       it('control is valid and untouched and form is submitted', () => {
-        when(control.invalid).thenReturn(false);
-        when(control.touched).thenReturn(false);
-        when(control.dirty).thenReturn(false);
-        when(controlContainer.submitted).thenReturn(true);
+        const control = {
+          invalid: false,
+          touched: false,
+          dirty: false,
+        } as NgControl;
 
-        expect(
-          service.isControlInvalid(instance(control), instance(controlContainer)),
-        ).toBe(false);
+        const controlContainer = {
+          submitted: true,
+        } as FormGroupDirective;
+
+        expect(service.isControlInvalid(control, controlContainer)).toBe(false);
       });
     });
   });

--- a/projects/canopy/src/lib/icon/icon.component.spec.ts
+++ b/projects/canopy/src/lib/icon/icon.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgIconComponent } from './icon.component';
 import { LgIconRegistry } from './icon.registry';
@@ -7,17 +6,19 @@ import { LgIconRegistry } from './icon.registry';
 describe('LgIconComponent', () => {
   let component: LgIconComponent;
   let fixture: ComponentFixture<LgIconComponent>;
-  let iconRegistryMock: LgIconRegistry;
+  let iconRegistryMock: jest.Mocked<LgIconRegistry>;
 
   beforeEach(waitForAsync(() => {
-    iconRegistryMock = mock(LgIconRegistry);
+    iconRegistryMock = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<LgIconRegistry>;
 
     TestBed.configureTestingModule({
       imports: [ LgIconComponent ],
       providers: [
         {
           provide: LgIconRegistry,
-          useFactory: () => instance(iconRegistryMock),
+          useValue: iconRegistryMock,
         },
       ],
     }).compileComponents();
@@ -46,7 +47,7 @@ describe('LgIconComponent', () => {
       expect(fixture.nativeElement.querySelector('#test')).toBeNull();
       expect(fixture.nativeElement.querySelector('#lg-icon-0')).toBeNull();
 
-      when(await iconRegistryMock.get('add')).thenReturn('<svg id="test">test-svg</svg>');
+      iconRegistryMock.get.mockResolvedValue('<svg id="test">test-svg</svg>');
 
       component.name = 'add';
       fixture.detectChanges();

--- a/projects/canopy/src/lib/modal/modal-header/modal-header.component.spec.ts
+++ b/projects/canopy/src/lib/modal/modal-header/modal-header.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { instance, mock, spy, verify } from '@typestrong/ts-mockito';
 import { MockComponent } from 'ng-mocks';
 
 import { LgModalService } from '../modal.service';
@@ -10,14 +9,16 @@ import { LgModalHeaderComponent } from './modal-header.component';
 describe('LgModalHeaderComponent', () => {
   let component: LgModalHeaderComponent;
   let fixture: ComponentFixture<LgModalHeaderComponent>;
-  let modalServiceMock: LgModalService;
+  let modalServiceMock: jest.Mocked<LgModalService>;
 
   beforeEach(async () => {
-    modalServiceMock = mock(LgModalService);
+    modalServiceMock = {
+      close: jest.fn(),
+    } as unknown as jest.Mocked<LgModalService>;
 
     await TestBed.configureTestingModule({
       imports: [ LgModalHeaderComponent, MockComponent(LgIconComponent) ],
-      providers: [ { provide: LgModalService, useValue: instance(modalServiceMock) } ],
+      providers: [ { provide: LgModalService, useValue: modalServiceMock } ],
     }).compileComponents();
   });
 
@@ -43,12 +44,12 @@ describe('LgModalHeaderComponent', () => {
   });
 
   it('should close the modal on #close', () => {
-    const closedEmitterSpy = spy(component.closed);
+    const closedEmitterSpy = jest.spyOn(component.closed, 'emit');
 
     component.modalId = 'test';
     component.close();
 
-    verify(closedEmitterSpy.emit()).once();
-    verify(modalServiceMock.close('test')).once();
+    expect(closedEmitterSpy).toHaveBeenCalledTimes(1);
+    expect(modalServiceMock.close).toHaveBeenNthCalledWith(1, 'test');
   });
 });

--- a/projects/canopy/src/lib/modal/modal-trigger/modal-trigger.directive.spec.ts
+++ b/projects/canopy/src/lib/modal/modal-trigger/modal-trigger.directive.spec.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { anything, instance, mock, verify, when } from '@typestrong/ts-mockito';
 import { BehaviorSubject } from 'rxjs';
 
 import { LgModalService } from '../modal.service';
@@ -19,19 +18,22 @@ describe('LgModalTriggerComponent', () => {
   let fixture: ComponentFixture<TestTriggerComponent>;
   let triggerDebugElement: DebugElement;
   let triggerInstance: LgModalTriggerDirective;
-  let modalServiceMock: LgModalService;
+  let modalServiceMock: jest.Mocked<LgModalService>;
   let focusSpy: jest.SpyInstance;
   const isOpen$ = new BehaviorSubject(true);
 
   beforeEach(waitForAsync(() => {
-    modalServiceMock = mock(LgModalService);
+    modalServiceMock = {
+      isOpen$: jest.fn(),
+      open: jest.fn(),
+    } as unknown as jest.Mocked<LgModalService>;
+
+    modalServiceMock.isOpen$.mockReturnValue(isOpen$);
 
     TestBed.configureTestingModule({
       imports: [ LgModalTriggerDirective, TestTriggerComponent ],
-      providers: [ { provide: LgModalService, useValue: instance(modalServiceMock) } ],
+      providers: [ { provide: LgModalService, useValue: modalServiceMock } ],
     }).compileComponents();
-
-    when(modalServiceMock.isOpen$(anything())).thenReturn(isOpen$);
 
     fixture = TestBed.createComponent(TestTriggerComponent);
 
@@ -54,8 +56,7 @@ describe('LgModalTriggerComponent', () => {
     triggerDebugElement.nativeElement.click();
 
     expect(triggerInstance['allowFocusOnModalTrigger']).toBe(true);
-    verify(modalServiceMock.open('test')).once();
-
+    expect(modalServiceMock.open).toHaveBeenNthCalledWith(1, 'test');
     expect(clickedSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/projects/canopy/src/lib/modal/modal.service.spec.ts
+++ b/projects/canopy/src/lib/modal/modal.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { spy, verify } from '@typestrong/ts-mockito';
 import { Subscription } from 'rxjs';
 
 import { LgModalService } from './';
@@ -7,7 +6,6 @@ import { LgModalService } from './';
 describe('LgModalService', () => {
   const id = 'test-1';
   let service: LgModalService;
-  let serviceSpy: LgModalService;
   let subscription: Subscription;
 
   beforeEach(waitForAsync(() => {
@@ -15,12 +13,12 @@ describe('LgModalService', () => {
   }));
 
   beforeEach(() => {
-    serviceSpy = spy(service);
     service.add(id);
   });
 
   afterEach(() => {
     subscription?.unsubscribe();
+    jest.restoreAllMocks();
   });
 
   it('should be created', () => {
@@ -56,9 +54,10 @@ describe('LgModalService', () => {
     });
 
     it('should call #add when the modal doesn\'t exist', done => {
-      subscription = service.isOpen$('test-2').subscribe(data => {
-        verify(serviceSpy.add('test-2')).once();
+      const addSpy = jest.spyOn(service, 'add');
 
+      subscription = service.isOpen$('test-2').subscribe(data => {
+        expect(addSpy).toHaveBeenCalledWith('test-2');
         expect(data).toBeUndefined();
         done();
       });
@@ -78,10 +77,11 @@ describe('LgModalService', () => {
   it('should call #close and remove an item from the map when calling #remove', () => {
     expect(service['states'].has(id)).toBe(true);
 
+    const closeSpy = jest.spyOn(service, 'close');
+
     service.remove(id);
 
-    verify(serviceSpy.close(id)).once();
-
+    expect(closeSpy).toHaveBeenCalledWith(id);
     expect(service['states'].has(id)).toBe(false);
   });
 });

--- a/projects/canopy/src/lib/sr-alert-message/sr-alert-message.directive.spec.ts
+++ b/projects/canopy/src/lib/sr-alert-message/sr-alert-message.directive.spec.ts
@@ -7,7 +7,6 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { instance, mock } from '@typestrong/ts-mockito';
 
 import { LgSrAlertMessageDirective } from './sr-alert-message.directive';
 
@@ -24,14 +23,17 @@ describe('lgSrAlertMessage', () => {
   let directive: LgSrAlertMessageDirective;
   let testElement: DebugElement;
   let component: TestComponent;
-  let cdrMock: ChangeDetectorRef;
+  let cdrMock: jest.Mocked<ChangeDetectorRef>;
 
   beforeEach(waitForAsync(() => {
-    cdrMock = mock(ChangeDetectorRef);
+    cdrMock = {
+      detectChanges: jest.fn(),
+      markForCheck: jest.fn(),
+    } as unknown as jest.Mocked<ChangeDetectorRef>;
 
     TestBed.configureTestingModule({
       imports: [ TestComponent, LgSrAlertMessageDirective ],
-      providers: [ { provide: ChangeDetectorRef, useValue: instance(cdrMock) } ],
+      providers: [ { provide: ChangeDetectorRef, useValue: cdrMock } ],
     }).compileComponents();
   }));
 

--- a/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { MockComponents } from 'ng-mocks';
-import { spy, when } from '@typestrong/ts-mockito';
 
 import { LgTableCellComponent } from '../table-cell/table-cell.component';
 import { LgTableRowToggleComponent } from '../table-row-toggle/table-row-toggle.component';
@@ -10,7 +9,6 @@ import { LgTableRowComponent } from './table-row.component';
 
 describe('LgTableRowComponent', () => {
   let component: LgTableRowComponent;
-  let componentSpy: LgTableRowComponent;
   let fixture: ComponentFixture<LgTableRowComponent>;
   let debugElement: DebugElement;
 
@@ -26,7 +24,6 @@ describe('LgTableRowComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LgTableRowComponent);
     component = fixture.componentInstance;
-    componentSpy = spy(component);
     debugElement = fixture.debugElement;
     fixture.detectChanges();
   });
@@ -40,14 +37,14 @@ describe('LgTableRowComponent', () => {
   });
 
   it('should have the table row toggle class if the row is expandable', () => {
-    when(componentSpy.hasToggle).thenReturn(true);
+    jest.spyOn(component, 'hasToggle', 'get').mockReturnValue(true);
     fixture.detectChanges();
 
     expect(fixture.nativeElement.getAttribute('class')).toContain('lg-table-row__toggle');
   });
 
   it('shouldn\'t have the table row toggle class if the row is not expandable', () => {
-    when(componentSpy.hasToggle).thenReturn(false);
+    jest.spyOn(component, 'hasToggle', 'get').mockReturnValue(false);
     fixture.detectChanges();
 
     expect(fixture.nativeElement.getAttribute('class')).not.toContain(
@@ -56,7 +53,7 @@ describe('LgTableRowComponent', () => {
   });
 
   it('should have the active class if the row is toggled active', () => {
-    when(componentSpy.isToggledActive).thenReturn(true);
+    jest.spyOn(component, 'isToggledActive', 'get').mockReturnValue(true);
     fixture.detectChanges();
 
     expect(fixture.nativeElement.getAttribute('class')).toContain(
@@ -65,7 +62,7 @@ describe('LgTableRowComponent', () => {
   });
 
   it('shouldn\'t have the active class if the row is not toggled active', () => {
-    when(componentSpy.isToggledActive).thenReturn(false);
+    jest.spyOn(component, 'isToggledActive', 'get').mockReturnValue(false);
     fixture.detectChanges();
 
     expect(fixture.nativeElement.getAttribute('class')).not.toContain(

--- a/projects/canopy/src/lib/tabs/tab-nav-bar/tab-nav-bar.component.spec.ts
+++ b/projects/canopy/src/lib/tabs/tab-nav-bar/tab-nav-bar.component.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 import { MockedComponentFixture, MockRender, ngMocks } from 'ng-mocks';
 
 import { keyName } from '../../utils/keyboard-keys';
@@ -117,44 +116,43 @@ describe('LgTabNavBarComponent', () => {
 
     beforeEach(() => {
       component.selectedIndex = 0;
-      mockKeyEvent = mock(KeyboardEvent);
     });
 
     it('should select the next tab when using right key', () => {
-      when(mockKeyEvent.key).thenReturn(keyName.KEY_RIGHT);
+      mockKeyEvent = new KeyboardEvent('keyup', { key: keyName.KEY_RIGHT });
       const selectSpy = jest.spyOn(component.tabs[1], 'selectByKeyboard');
 
-      component.onKeyUp(instance(mockKeyEvent));
+      component.onKeyUp(mockKeyEvent);
 
       expect(component.selectedIndex).toEqual(1);
       expect(selectSpy).toHaveBeenCalled();
     });
 
     it('should select the next tab when using down key', () => {
-      when(mockKeyEvent.key).thenReturn(keyName.KEY_DOWN);
+      mockKeyEvent = new KeyboardEvent('keyup', { key: keyName.KEY_DOWN });
       const selectSpy = jest.spyOn(component.tabs[1], 'selectByKeyboard');
 
-      component.onKeyUp(instance(mockKeyEvent));
+      component.onKeyUp(mockKeyEvent);
 
       expect(component.selectedIndex).toEqual(1);
       expect(selectSpy).toHaveBeenCalled();
     });
 
     it('should select the previous tab when using left key', () => {
-      when(mockKeyEvent.key).thenReturn(keyName.KEY_LEFT);
+      mockKeyEvent = new KeyboardEvent('keyup', { key: keyName.KEY_LEFT });
       const selectSpy = jest.spyOn(component.tabs[3], 'selectByKeyboard');
 
-      component.onKeyUp(instance(mockKeyEvent));
+      component.onKeyUp(mockKeyEvent);
 
       expect(component.selectedIndex).toEqual(3);
       expect(selectSpy).toHaveBeenCalled();
     });
 
     it('should select the previous tab when using up key', () => {
-      when(mockKeyEvent.key).thenReturn(keyName.KEY_UP);
+      mockKeyEvent = new KeyboardEvent('keyup', { key: keyName.KEY_UP });
       const selectSpy = jest.spyOn(component.tabs[3], 'selectByKeyboard');
 
-      component.onKeyUp(instance(mockKeyEvent));
+      component.onKeyUp(mockKeyEvent);
 
       expect(component.selectedIndex).toEqual(3);
       expect(selectSpy).toHaveBeenCalled();

--- a/projects/canopy/src/lib/tabs/tabs.component.spec.ts
+++ b/projects/canopy/src/lib/tabs/tabs.component.spec.ts
@@ -8,7 +8,6 @@ import {
   MockedComponentFixture,
   ngMocks,
 } from 'ng-mocks';
-import { instance, mock, when } from '@typestrong/ts-mockito';
 
 import { LgFocusDirective } from '../focus';
 import { LgHeadingComponent } from '../heading';
@@ -203,10 +202,9 @@ describe('LgTabsComponent', () => {
 
     it('the selected index should be 2 when the key press is left', () => {
       component.selectedIndex = 0;
-      const mockClickLeftEvent = mock(KeyboardEvent);
+      const keyboardEvent = new KeyboardEvent('keydown', { key: keyName.KEY_LEFT });
 
-      when(mockClickLeftEvent.key).thenReturn(keyName.KEY_LEFT);
-      component.keyboardNavigation(instance(mockClickLeftEvent));
+      component.keyboardNavigation(keyboardEvent);
 
       expect(component.isKeyboardEvent).toEqual(true);
       expect(component.selectedIndex).toEqual(2);
@@ -214,10 +212,9 @@ describe('LgTabsComponent', () => {
 
     it('the selected index should be 2 when the key press is up', () => {
       component.selectedIndex = 0;
-      const mockClickLeftEvent = mock(KeyboardEvent);
+      const keyboardEvent = new KeyboardEvent('keydown', { key: keyName.KEY_UP });
 
-      when(mockClickLeftEvent.key).thenReturn(keyName.KEY_UP);
-      component.keyboardNavigation(instance(mockClickLeftEvent));
+      component.keyboardNavigation(keyboardEvent);
 
       expect(component.isKeyboardEvent).toEqual(true);
       expect(component.selectedIndex).toEqual(2);
@@ -225,10 +222,9 @@ describe('LgTabsComponent', () => {
 
     it('the selected index should be 1 when the key press is right', () => {
       component.selectedIndex = 0;
-      const mockClickLeftEvent = mock(KeyboardEvent);
+      const keyboardEvent = new KeyboardEvent('keydown', { key: keyName.KEY_RIGHT });
 
-      when(mockClickLeftEvent.key).thenReturn(keyName.KEY_RIGHT);
-      component.keyboardNavigation(instance(mockClickLeftEvent));
+      component.keyboardNavigation(keyboardEvent);
 
       expect(component.isKeyboardEvent).toEqual(true);
       expect(component.selectedIndex).toEqual(1);
@@ -236,10 +232,9 @@ describe('LgTabsComponent', () => {
 
     it('the selected index should be 1 when the key press is down', () => {
       component.selectedIndex = 0;
-      const mockClickLeftEvent = mock(KeyboardEvent);
+      const keyboardEvent = new KeyboardEvent('keydown', { key: keyName.KEY_DOWN });
 
-      when(mockClickLeftEvent.key).thenReturn(keyName.KEY_DOWN);
-      component.keyboardNavigation(instance(mockClickLeftEvent));
+      component.keyboardNavigation(keyboardEvent);
 
       expect(component.isKeyboardEvent).toEqual(true);
       expect(component.selectedIndex).toEqual(1);
@@ -247,10 +242,9 @@ describe('LgTabsComponent', () => {
 
     it('the selected index should change from 2 to 0 when the key press is right', () => {
       component.selectedIndex = 2;
-      const mockClickLeftEvent = mock(KeyboardEvent);
+      const keyboardEvent = new KeyboardEvent('keydown', { key: keyName.KEY_RIGHT });
 
-      when(mockClickLeftEvent.key).thenReturn(keyName.KEY_RIGHT);
-      component.keyboardNavigation(instance(mockClickLeftEvent));
+      component.keyboardNavigation(keyboardEvent);
 
       expect(component.isKeyboardEvent).toEqual(true);
       expect(component.selectedIndex).toEqual(0);


### PR DESCRIPTION
# Description

This PR removes `ts-mockito` as it's no longer maintained and poses a risk to the repository.
It updates all tests to use either Jest or `ng-mocks`.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
