### PR TITLE
ci(deploy): update script to handle untracked icons

### DIFF
--- a/.github/workflow-scripts/gh-pages/deploy.js
+++ b/.github/workflow-scripts/gh-pages/deploy.js
@@ -77,6 +77,15 @@ async function deploy({ branch, sha, repo, owner, docsPath, github, exec }) {
       console.info(`ℹ️ Unable to restore the documentation.json: \n${e}`);
     }
 
+    // Removing the icons as they are only needed when building Storybook,
+    // and they create unnecessary conflicts
+    console.info('ℹ️ Removing any leftover UI and Brand icon file');
+    try {
+      await exec.exec('git', ['restore', 'projects/canopy/src/assets/*icons']);
+    } catch (e) {
+      console.info(`ℹ️ No icons found: \n${e}`);
+    }
+
     console.info('ℹ️ Starting to track the storybook changes before stashing');
     await exec.exec('git', ['add', '.']);
 


### PR DESCRIPTION
# Description

This PR fixes an issue where deployments on `master` and `master-bm` fail whenever new UI or Brand icons are built.
The icons must be built before Storybook, but the environment needs to be cleaned afterward to prevent conflicts when switching to the `gh-pages` branch.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
