### PR TITLE
ci(brand-modernisation): add legacy branch logic and remove master-bm

### DIFF
--- a/.github/workflow-scripts/gh-pages/deploy.js
+++ b/.github/workflow-scripts/gh-pages/deploy.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 
 const DEFAULT_BRANCH = 'master';
-const BM_BRANCH = 'master-bm';
+const LEGACY_BRANCH = 'legacy';
 const ROOT_DOCS_PATH = './docs';
 const STORYBOOK_BUILD_PREFIX = 'lg-sb-';
 const STORYBOOK_BUILD_PATH = `./${STORYBOOK_BUILD_PREFIX}build`;
@@ -29,7 +29,7 @@ module.exports = async ({
 
   docsPath = `${ROOT_DOCS_PATH}/${STORYBOOK_BUILD_PREFIX}${branch}`;
 
-  if (branch === BM_BRANCH) {
+  if (branch === LEGACY_BRANCH) {
     await deploy({ branch, sha, repo, owner, docsPath, github, exec });
 
     return;
@@ -174,7 +174,7 @@ async function undeploy({ branch, repo, owner, github, exec }) {
       .filter(item => item.isDirectory() &&
         item.name.startsWith(STORYBOOK_BUILD_PREFIX) &&
         item.name !== `${STORYBOOK_BUILD_PREFIX}${branch}` &&
-        item.name !== `${STORYBOOK_BUILD_PREFIX}${BM_BRANCH}`
+        item.name !== `${STORYBOOK_BUILD_PREFIX}${LEGACY_BRANCH}`
       )
       .map(({ name }) => name.replace(prefixRegex, ''));
 

--- a/.github/workflows/branch_pages_deploy.yml
+++ b/.github/workflows/branch_pages_deploy.yml
@@ -49,14 +49,10 @@ jobs:
           unzip lg-sb-build.zip -d ./docs/lg-sb-'${{ fromJSON(steps.prData.outputs.result).branch }}'
           rm lg-sb-build.zip
 
-      - name: 'Set PERCY_TOKEN env var'
-        run: echo "PERCY_TOKEN_NAME=${{ startsWith(fromJSON(steps.prData.outputs.result).branch, 'bm-') && 'PERCY_TOKEN_BM' || 'PERCY_TOKEN' }}" >> $GITHUB_ENV
-
-
       - name: 'Visual comparison'
         run: npx percy storybook ./docs/lg-sb-${{ fromJSON(steps.prData.outputs.result).branch }} --config=.percy.yml
         env:
-          PERCY_TOKEN: ${{ secrets[env.PERCY_TOKEN_NAME] }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_BRANCH: '${{ fromJSON(steps.prData.outputs.result).branch }}'
           NETWORK_IDLE_WAIT_TIMEOUT: 5000
 

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -2,7 +2,7 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [ "master", "next", "master-bm" ]
+    branches: [ "master", "next", "legacy" ]
   pull_request:
     types: [ opened, synchronize ]
 

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - next
-      - master-bm
+      - legacy
     tags-ignore:
       - '*'
 
@@ -66,7 +66,7 @@ jobs:
 
   deploy:
     needs: [ build ]
-    if: github.ref_name == 'master' || github.ref_name == 'master-bm'
+    if: github.ref_name == 'master' || github.ref_name == 'legacy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -90,18 +90,15 @@ jobs:
         run: npm run build:icons
 
       - name: 'Set Storybook output directory'
-        run: echo "SB_OUTPUT_DIR=${{ endsWith(github.ref_name, '-bm') && './docs/lg-sb-master-bm' || './lg-sb-build' }}" >> $GITHUB_ENV
+        run: echo "SB_OUTPUT_DIR=${{ github.ref_name == 'legacy' && './docs/lg-sb-legacy' || './lg-sb-build' }}" >> $GITHUB_ENV
 
       - name: 'Build storybook'
         run: npm run build:storybook -- --output-dir $SB_OUTPUT_DIR
 
-      - name: 'Set PERCY_TOKEN env var'
-        run: echo "PERCY_TOKEN_NAME=${{ endsWith(github.ref_name, '-bm') && 'PERCY_TOKEN_BM' || 'PERCY_TOKEN' }}" >> $GITHUB_ENV
-
       - name: 'Update visual baselines'
         run: npx percy storybook $SB_OUTPUT_DIR --config=.percy.yml
         env:
-          PERCY_TOKEN: ${{ secrets[env.PERCY_TOKEN_NAME] }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_BRANCH: '${{ github.ref_name }}'
           NETWORK_IDLE_WAIT_TIMEOUT: 5000
 

--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,7 @@
   "branches": [
     "master",
     {"name": "next", "prerelease": true},
-    {"name": "master-bm", "prerelease": true}
+    {"name": "legacy", "prerelease": true}
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
# Description

This PR updates the workflows to handle the new `legacy` branch. It also removes any logic to do with `master-bm` as the new Brand Modernisation work will be merged into master itself from now on.
The Percy token is now only a single one as we won't be doing visual testing on the `legacy` branch as it will be deprecated in the near future and will be very rarely be updated until then.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
