### PR TITLE
ci(legacy): remove update of visual baselines

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -96,6 +96,7 @@ jobs:
         run: npm run build:storybook -- --output-dir $SB_OUTPUT_DIR
 
       - name: 'Update visual baselines'
+        if: github.ref_name == 'master'
         run: npx percy storybook $SB_OUTPUT_DIR --config=.percy.yml
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
# Description

This PR updates the push workflow to only run the "Update visual baselines" for `master`.


# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
