### PR TITLE
fix(styles): update webpack to include css files in styles

### DIFF
--- a/webpack.global.config.js
+++ b/webpack.global.config.js
@@ -35,7 +35,7 @@ export default {
           context: 'projects/canopy/src/lib/',
         },
         {
-          from: path.resolve(__dirname, 'projects/canopy/src/styles/**/*.scss'),
+          from: path.resolve(__dirname, 'projects/canopy/src/styles/**/*.(scss|css)'),
           to: path.resolve(__dirname, 'dist/canopy/styles'),
           context: 'projects/canopy/src/styles/',
         },


### PR DESCRIPTION
# Description

This fixes an issue where the token folder was missing from dist/styles folder.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
