### PR TITLE
fix(tabs): amend line height on item

### DIFF
--- a/projects/canopy/src/styles/variables/components/_tabs.scss
+++ b/projects/canopy/src/styles/variables/components/_tabs.scss
@@ -2,7 +2,7 @@
   --tabs-border-bottom-width: var(--border-width);
   --tabs-border-bottom-color: var(--colour-greyscale-200);
 
-  --tabs-list-item-line-height: var(--space-6);
+  --tabs-list-item-line-height: var(--space-8);
   --tabs-list-item-lg-line-height: 3.25rem; // 52px;
   --tabs-list-item-color: var(--colour-greyscale-900);
   --tabs-list-item-font-weight: var(--font-weight-400);


### PR DESCRIPTION
Fixes # (issue)

Fixes issue where wrong space token was applied to the `--tabs-list-item-line-height`

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
