### PR TITLE
ci(peerdependencies): remove angular core and common

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -32,6 +32,10 @@ You should now be able to install the module.
 
 `npm install @legal-and-general/canopy`
 
+### Requirements
+
+ Your project should already have `@angular/common` and `@angular/core` installed with a compatible Angular version (Canopy currently supports Angular 20.x; using other major versions may lead to incompatibilities).
+
 ## Import the Library
 
 In your angular `app.module.ts' file you can choose to import all of the component modules or just the specific ones that you are using in your application.

--- a/projects/canopy/package.json
+++ b/projects/canopy/package.json
@@ -5,8 +5,6 @@
   "repository": "https://github.com/Legal-and-General/canopy",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@angular/common": "^19.2.14",
-    "@angular/core": "^19.2.14",
     "date-fns": "^2.29.2"
   },
   "publishConfig": {


### PR DESCRIPTION
# Description

Remove `@angular/common` and `@angular/core` from the package.json `peerDependencies` and update usage.md

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
