### PR TITLE
feat(link-menu): update the link menu

### DIFF
--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -989,7 +989,8 @@
                             <lg-link-menu>
                               <a href="#">
                                 <lg-link-menu-item>
-                                  <lg-link-menu-item-text isBold="true">An internal link (default)</lg-link-menu-item-text>
+                                  <lg-icon name="information"></lg-icon>
+                                  <lg-link-menu-item-text [isBold]="true">An internal link (default)</lg-link-menu-item-text>
                                   <lg-link-menu-item-text>
                                     This links to an internal page
                                   </lg-link-menu-item-text>
@@ -997,10 +998,34 @@
                               </a>
                               <a href="#" target="_blank">
                                 <lg-link-menu-item>
-                                  <lg-link-menu-item-text isBold="true">An external link</lg-link-menu-item-text>
+                                  <lg-icon name="profile"></lg-icon>
+                                  <lg-link-menu-item-text [isBold]="true">An external link</lg-link-menu-item-text>
                                   <lg-link-menu-item-text>
                                     This links to an external page opening in a <em>new</em> tab
                                   </lg-link-menu-item-text>
+                                </lg-link-menu-item>
+                              </a>
+                              <a href="#">
+                                <lg-link-menu-item [rightIcon]="'chevron-right'">
+                                  <lg-icon name="home"></lg-icon>
+                                  <lg-link-menu-item-text [isBold]="true">Custom right icon</lg-link-menu-item-text>
+                                  <lg-link-menu-item-text>
+                                    This item has a custom chevron-right icon
+                                  </lg-link-menu-item-text>
+                                </lg-link-menu-item>
+                              </a>
+                              <a href="#">
+                                <lg-link-menu-item [rightIcon]="null">
+                                  <lg-icon name="download"></lg-icon>
+                                  <lg-link-menu-item-text [isBold]="true">No right icon</lg-link-menu-item-text>
+                                  <lg-link-menu-item-text>
+                                    This item has no right icon
+                                  </lg-link-menu-item-text>
+                                </lg-link-menu-item>
+                              </a>
+                              <a href="#">
+                                <lg-link-menu-item>
+                                  <lg-link-menu-item-text [isBold]="false">Regular font weight</lg-link-menu-item-text>
                                 </lg-link-menu-item>
                               </a>
                             </lg-link-menu>

--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.scss
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.scss
@@ -2,5 +2,6 @@
 
 .lg-card-footer {
   display: block;
+  border-top: solid var(--border-width) var(--card-title-border-color);
   padding-top: var(--space-6);
 }

--- a/projects/canopy/src/lib/card/card-footer/card-footer.component.scss
+++ b/projects/canopy/src/lib/card/card-footer/card-footer.component.scss
@@ -2,6 +2,5 @@
 
 .lg-card-footer {
   display: block;
-  border-top: solid var(--border-width) var(--card-title-border-color);
   padding-top: var(--space-6);
 }

--- a/projects/canopy/src/lib/docs/welcome/bottom-links-section.component.ts
+++ b/projects/canopy/src/lib/docs/welcome/bottom-links-section.component.ts
@@ -5,24 +5,13 @@ import {
   LgLinkMenuItemComponent,
   LgLinkMenuItemTextComponent,
 } from '../../link-menu';
-import { LgSeparatorComponent } from '../../separator';
-import { LgMarginDirective } from '../../spacing';
-
 @Component({
   selector: 'lg-docs-welcome-bottom-links-section',
-  imports: [
-    LgLinkMenuComponent,
-    LgLinkMenuItemTextComponent,
-    LgSeparatorComponent,
-    LgMarginDirective,
-    LgLinkMenuItemComponent,
-  ],
+  imports: [ LgLinkMenuComponent, LgLinkMenuItemTextComponent, LgLinkMenuItemComponent ],
   template: `
     <h2 class="lg-font--expressive lg-font-size-4--700">{{ heading }}</h2>
 
     <p>{{ text }}</p>
-
-    <lg-separator lgMarginBottom="none" />
 
     <lg-link-menu>
       @for (link of links; track link) {

--- a/projects/canopy/src/lib/link-menu/docs/guide.mdx
+++ b/projects/canopy/src/lib/link-menu/docs/guide.mdx
@@ -1,13 +1,10 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as LinkMenuStories from './link-menu.stories';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Link menu/Guide" tags={['pending']}/>
+<Meta title="Components/Link menu/Guide"/>
 
 # Link menu
-
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
 
 <p class="standfirst">Link menu is used to list an array of links.</p>
 
@@ -16,10 +13,7 @@ import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 Import the link menu components in your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgLinkMenuComponent, etc. ],
-});
+import { LgLinkMenuComponent } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -34,17 +28,36 @@ This is where the links are projected.
 
 ### LgLinkMenuItemComponent
 
-This is where the `LgLinkMenuItemTextComponent`s of the link are projected and positioned.
+This is where the `LgLinkMenuItemTextComponent`s and optional left icon are projected and positioned.
 
-This accepts either 1 or 2 `LgLinkMenuItemTextComponent`s, of which either 1 or both can be made bold, by using `isBold`.
+This accepts either 1 or 2 `LgLinkMenuItemTextComponent`s. The first text component represents the primary label, and an optional second text component represents the secondary descriptive text. The secondary text automatically uses regular font weight (400) and muted colour tokens.
 
-Depending on whether the parent, `<a>` element has `target="_blank"`, i.e. attempts to open in a new tab, the icon displayed will
-differ.
+#### Icon behaviour
+
+**Right icon (automatic):**
+- By default, the component automatically displays an icon on the right side
+- If the parent `<a>` element has `target="_blank"`, it shows the `link-external` icon with accessible text "opens in a new tab"
+- Otherwise, it shows the `arrow-right` icon
+- On hover, the icon translates 0.25rem to the right
+
+**Custom icons:**
+- **Left icon**: Project an `<lg-icon>` component as content to display a custom icon on the left
+- **Right icon**: Use the `rightIcon` input to override the default right icon with a custom icon name, or set it to `null` to hide the right icon completely
+
+#### Inputs
+
+| Name        | Description                                                          |    Type                    |   Default     | Required |
+|-------------|----------------------------------------------------------------------|:--------------------------:|:-------------:|:--------:|
+| `rightIcon` | Custom icon name for the right icon, or `null` to hide it completely | `string \| null \| undefined` | `undefined` |    No    |
 
 ### LgLinkMenuItemTextComponent
 
 The text sub-component for the menu item.
 Accepts a `isBold` attribute input that changes its style to make the text of the menu item bold.
+
+When two `LgLinkMenuItemTextComponent`s are used, the second one automatically:
+- Uses font weight 400 (regular) instead of 500
+- Uses muted colour tokens (`--link-menu-item-rest-colour-muted`, etc.)
 
 #### Inputs
 

--- a/projects/canopy/src/lib/link-menu/docs/link-menu.stories.ts
+++ b/projects/canopy/src/lib/link-menu/docs/link-menu.stories.ts
@@ -10,11 +10,11 @@ const template = `
 <lg-link-menu>
   @for (item of menuItems; track item.title) {
     <a href="#" [attr.target]="item.target">
-      <lg-link-menu-item>
-        @if (item.icon) {
-          <lg-icon [name]="item.icon"></lg-icon>
+      <lg-link-menu-item [rightIcon]="item.rightIcon">
+        @if (item.leftIcon) {
+          <lg-icon [name]="item.leftIcon"></lg-icon>
         }
-        <lg-link-menu-item-text isBold="true">{{ item.title }}</lg-link-menu-item-text>
+        <lg-link-menu-item-text [isBold]="item.isBold">{{ item.title }}</lg-link-menu-item-text>
         @if (item.description) {
           <lg-link-menu-item-text>
             {{ item.description }}
@@ -43,17 +43,31 @@ class LinkMenuStoryComponent {
 // This default export determines where your story goes in the story list
 export default {
   title: 'Components/Link menu/Examples',
-  tags: [ 'pending' ],
   decorators: [
     moduleMetadata({
       imports: [ LinkMenuStoryComponent ],
     }),
   ],
+  parameters: {
+    backgrounds: { disable: true },
+  },
   argTypes: {
     class: {
       table: {
         disable: true,
       },
+    },
+    showLeftIcons: {
+      control: 'boolean',
+      description: 'Show left icons on menu items',
+    },
+    showRightIcons: {
+      control: 'boolean',
+      description: 'Show right icons on menu items',
+    },
+    isBold: {
+      control: 'boolean',
+      description: 'Make primary label text bold',
     },
   },
 } as Meta;
@@ -62,62 +76,100 @@ interface MenuItems {
   title: string;
   description: string;
   target: '_blank' | null;
-  icon: string;
+  leftIcon: string;
+  rightIcon: string | null | undefined;
+  isBold: boolean;
 }
 
-function getDefaultMenuItems(withIcons = true): Array<MenuItems> {
+function getDefaultMenuItems(
+  showLeftIcons = true,
+  showRightIcons = false,
+  isBold = true,
+): Array<MenuItems> {
   return [
     {
       title: 'Overview',
       description: '',
       target: null,
-      icon: withIcons
+      leftIcon: showLeftIcons
         ? 'information'
         : '',
+      rightIcon: showRightIcons
+        ? undefined
+        : null,
+      isBold,
     },
     {
       title: 'Personal Details',
       description: 'Name, date of birth, marital status',
       target: '_blank',
-      icon: withIcons
+      leftIcon: showLeftIcons
         ? 'profile'
         : '',
+      rightIcon: showRightIcons
+        ? undefined
+        : null,
+      isBold,
     },
     {
       title: 'Contact',
       description: 'Email, address and phone numbers',
       target: null,
-      icon: withIcons
+      leftIcon: showLeftIcons
         ? 'mail'
         : '',
+      rightIcon: showRightIcons
+        ? undefined
+        : null,
+      isBold,
     },
     {
       title: 'Login and security',
       description: 'Reset your password and get a User ID reminder',
       target: null,
-      icon: withIcons
+      leftIcon: showLeftIcons
         ? 'security'
         : '',
+      rightIcon: showRightIcons
+        ? undefined
+        : null,
+      isBold,
     },
     {
       title: 'Preferences',
       description: 'How we send you documents and marketing',
       target: null,
-      icon: withIcons
+      leftIcon: showLeftIcons
         ? 'console'
         : '',
+      rightIcon: showRightIcons
+        ? undefined
+        : null,
+      isBold,
     },
   ];
 }
 
 export const StandardLinkMenu = {
   name: 'Link menu',
-  render: (args: LinkMenuStoryComponent) => ({
-    props: args,
+  render: (args: {
+    showLeftIcons: boolean;
+    showRightIcons: boolean;
+    isBold: boolean;
+  }) => ({
+    props: {
+      menuItems: getDefaultMenuItems(
+        args.showLeftIcons,
+        args.showRightIcons,
+        args.isBold,
+      ),
+    },
     template: '<lg-link-menu-story [menuItems]="menuItems"></lg-link-menu-story>',
   }),
   args: {
-    menuItems: getDefaultMenuItems(),
+    showLeftIcons: true,
+    showRightIcons: true,
+    isBold: true,
   },
   parameters: {
     docs: {
@@ -126,7 +178,10 @@ export const StandardLinkMenu = {
       },
     },
     additionalSnapshots: [
-      { suffix: ' [without icons]', args: { menuItems: getDefaultMenuItems(false) } },
+      {
+        suffix: ' [without icons]',
+        args: { showLeftIcons: false, showRightIcons: false, isBold: true },
+      },
     ],
   },
 };

--- a/projects/canopy/src/lib/link-menu/link-menu-item-text/link-menu-item-text.component.scss
+++ b/projects/canopy/src/lib/link-menu/link-menu-item-text/link-menu-item-text.component.scss
@@ -1,13 +1,38 @@
 .lg-link-menu-item-text {
-  padding-top: var(--space-2);
-  font-size: var(--font-size-0-8);
-  line-height: var(--text-base-line-height);
+  font-size: var(--font-size-1);
+  line-height: var(--line-height-1);
+  color: var(--link-menu-item-rest-colour);
+  font-weight: var(--font-weight-500);
+  font-feature-settings: 'case' on;
+
+  a:hover & {
+    color: var(--link-menu-item-hover-colour);
+  }
+
+  a:focus-visible & {
+    color: var(--link-menu-item-focus-colour);
+  }
+
+  a:active & {
+    color: var(--link-menu-item-active-colour);
+  }
 
   &--bold {
-    padding-top: 0;
     line-height: initial;
     font-size: var(--font-size-1);
     font-weight: var(--font-weight-700);
-    padding-right: var(--space-1);
+    color: var(--link-menu-item-rest-colour);
+
+    a:hover & {
+      color: var(--link-menu-item-hover-colour);
+    }
+
+    a:focus-visible & {
+      color: var(--link-menu-item-focus-colour);
+    }
+
+    a:active & {
+      color: var(--link-menu-item-active-colour);
+    }
   }
 }

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.html
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.html
@@ -7,9 +7,11 @@
   <ng-content select="lg-link-menu-item-text" />
   <ng-content select="lg-link-menu-item-text" />
 </div>
-<div class="lg-link-menu-item__icon-container">
-  <lg-icon [name]="!openInANewTab ? 'chevron-right' : 'link-external'" class="lg-font-size-0-8" />
-  @if (openInANewTab) {
-    <span class="lg-visually-hidden"> opens in a new tab</span>
-  }
-</div>
+@if (rightIconName) {
+  <div class="lg-link-menu-item__icon-container">
+    <lg-icon [name]="rightIconName" class="lg-font-size-0-8" />
+    @if (openInANewTab) {
+      <span class="lg-visually-hidden"> opens in a new tab</span>
+    }
+  </div>
+}

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.scss
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.scss
@@ -3,43 +3,64 @@
 .lg-link-menu-item {
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 
 .lg-link-menu-item__container {
   display: flex;
   flex-direction: column;
+  gap: var(--space-1);
   margin-right: auto;
-  margin-left: var(--space-3);
 
-  @include mixins.lg-breakpoint('md') {
-    padding-right: var(--space-4);
+  lg-link-menu-item-text:nth-child(2) {
+    font-weight: var(--font-weight-400);
+    color: var(--link-menu-item-rest-colour-muted);
+
+    a:hover & {
+      color: var(--link-menu-item-hover-colour-muted);
+    }
+
+    a:focus-visible & {
+      color: var(--link-menu-item-focus-colour-muted);
+    }
+
+    a:active & {
+      color: var(--link-menu-item-active-colour-muted);
+    }
   }
 }
 
-// To do: remove once updated
 .lg-link-menu-item__icon-left-container,
 .lg-link-menu-item__icon-container {
   .lg-icon {
-    height: var(--icon-height) !important;
-    width: var(--icon-width) !important;
+    height: var(--button-icon-width) !important;
+    width: var(--button-icon-width) !important;
+    margin-right: var(--link-menu-item-gap);
+    color: var(--link-menu-item-rest-colour);
+  }
+
+  a:hover & .lg-icon {
+    color: var(--link-menu-item-hover-colour);
+  }
+
+  a:focus-visible & .lg-icon {
+    color: var(--link-menu-item-focus-colour);
+  }
+
+  a:active & .lg-icon {
+    color: var(--link-menu-item-active-colour);
   }
 }
 
 .lg-link-menu-item__icon-container {
   position: relative;
-  padding-right: var(--space-4);
-
-  @include mixins.lg-breakpoint('md') {
-    padding-right: var(--space-4);
-  }
-
-  @include mixins.lg-breakpoint('lg') {
-    padding-right: var(--space-3);
-  }
 
   .lg-icon {
-    position: absolute;
-    right: 0;
     margin-right: 0;
+    transition: transform var(--animation-duration) var(--animation-fn);
   }
+}
+
+a:hover .lg-link-menu-item__icon-container .lg-icon {
+  transform: translateX(0.25rem);
 }

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.spec.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.spec.ts
@@ -18,6 +18,7 @@ import { LgLinkMenuItemComponent } from './link-menu-item.component';
 })
 class TestComponent {
   @Input() target: string = undefined;
+  @Input() rightIcon: string | null | undefined;
 }
 
 describe('LgLinkMenuItemComponent', () => {
@@ -69,8 +70,8 @@ describe('LgLinkMenuItemComponent', () => {
       ).toBeTruthy();
     });
 
-    it('should render the "chevron-right" icon if the parent is not an anchor element', () => {
-      expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeDefined();
+    it('should render the "arrow-right" icon if the parent is not an anchor element', () => {
+      expect(fixture.debugElement.query(By.css('[name="arrow-right"]'))).toBeDefined();
       expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
     });
 
@@ -111,9 +112,9 @@ describe('LgLinkMenuItemComponent', () => {
     };
 
     describe('opens in a new tab text', () => {
-      const getTextOfElementUnderTest = () =>
+      const getTextOfElementUnderTest = (): string =>
         fixture.debugElement.query(By.css('.lg-link-menu-item__icon-container'))
-          .nativeElement.textContent;
+          ?.nativeElement.textContent || '';
 
       it('should not render the text when the parent anchor target attribute is not "_blank"', () => {
         createComponentWithTarget('_parent');
@@ -129,12 +130,10 @@ describe('LgLinkMenuItemComponent', () => {
     });
 
     describe('icon displayed', () => {
-      it('should render the "chevron-right" icon when the parent anchor target attribute is not "_blank"', () => {
+      it('should render the "arrow-right" icon when the parent anchor target attribute is not "_blank"', () => {
         createComponentWithTarget('_parent');
 
-        expect(
-          fixture.debugElement.query(By.css('[name="chevron-right"]')),
-        ).toBeDefined();
+        expect(fixture.debugElement.query(By.css('[name="arrow-right"]'))).toBeDefined();
 
         expect(fixture.debugElement.query(By.css('[name="link-external"]'))).toBeNull();
       });
@@ -146,7 +145,45 @@ describe('LgLinkMenuItemComponent', () => {
           fixture.debugElement.query(By.css('[name="link-external"]')),
         ).toBeDefined();
 
-        expect(fixture.debugElement.query(By.css('[name="chevron-right"]'))).toBeNull();
+        expect(fixture.debugElement.query(By.css('[name="arrow-right"]'))).toBeNull();
+      });
+    });
+
+    describe('custom rightIcon', () => {
+      const createComponentWithRightIcon = (rightIcon: string | null) => {
+        const template = `
+          <a href="#">
+            <lg-link-menu-item [rightIcon]="rightIcon">
+              <lg-icon [name]="'account'"></lg-icon>
+              <lg-link-menu-item-text [isBold]="true">Menu item</lg-link-menu-item-text>
+            </lg-link-menu-item>
+          </a>
+        `;
+
+        fixture = TestBed.overrideTemplate(TestComponent, template).createComponent(
+          TestComponent,
+        );
+
+        component = fixture.componentInstance;
+        component.rightIcon = rightIcon;
+
+        fixture.detectChanges();
+      };
+
+      it('should render a custom icon when rightIcon is set', () => {
+        createComponentWithRightIcon('information');
+
+        expect(fixture.debugElement.query(By.css('[name="information"]'))).toBeDefined();
+
+        expect(fixture.debugElement.query(By.css('[name="arrow-right"]'))).toBeNull();
+      });
+
+      it('should not render any icon when rightIcon is null', () => {
+        createComponentWithRightIcon(null);
+
+        expect(
+          fixture.debugElement.query(By.css('.lg-link-menu-item__icon-container')),
+        ).toBeNull();
       });
     });
   });

--- a/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
+++ b/projects/canopy/src/lib/link-menu/link-menu-item/link-menu-item.component.ts
@@ -4,6 +4,7 @@ import {
   ContentChild,
   ElementRef,
   HostBinding,
+  Input,
   OnInit,
   ViewEncapsulation,
   inject,
@@ -26,16 +27,29 @@ export class LgLinkMenuItemComponent implements OnInit {
 
   @ContentChild(LgIconComponent) iconComponent: LgIconComponent;
 
+  @Input() rightIcon: string | null | undefined = undefined;
+
   openInANewTab = false;
+
+  get rightIconName(): string | null {
+    if (this.rightIcon !== undefined) {
+      return this.rightIcon;
+    }
+
+    return this.openInANewTab
+      ? 'link-external'
+      : 'arrow-right';
+  }
 
   ngOnInit(): void {
     if (this.elementRef) {
-      const parent = this.elementRef.nativeElement.parentElement;
+      const parent = (this.elementRef.nativeElement as HTMLElement).parentElement;
 
       const tag = parent?.tagName;
 
       if (tag === 'A') {
-        this.openInANewTab = parent.getAttribute('target') === '_blank';
+        this.openInANewTab =
+          (parent as HTMLAnchorElement).getAttribute('target') === '_blank';
       } else {
         console.warn(
           `expected 'lg-link-menu-item' parent to be an HTML Anchor but got ${tag}`,

--- a/projects/canopy/src/lib/link-menu/link-menu.component.scss
+++ b/projects/canopy/src/lib/link-menu/link-menu.component.scss
@@ -3,51 +3,87 @@
 .lg-link-menu {
   display: flex;
   flex-direction: column;
+  border: var(--link-menu-border-width) solid var(--link-menu-border-colour);
+  border-radius: var(--link-menu-border-radius);
+  overflow: hidden;
+  background: transparent;
 
   a {
     flex: 1;
-    @include mixins.lg-unstyled-link();
-
-    text-decoration: none;
-    color: var(--link-menu-link-color);
-    border-bottom: var(--border-width) solid var(--link-menu-link-border-color);
+    border-radius: 0;
+    text-decoration: none !important;
+    color: var(--link-menu-item-rest-colour);
+    border-bottom: var(--link-menu-item-rest-border-width-bottom) solid
+      var(--link-menu-item-rest-border-colour);
     display: block;
-    padding: var(--space-4) var(--space-4) var(--space-3);
+    padding: var(--link-menu-item-padding-top) var(--link-menu-item-padding-right)
+      var(--link-menu-item-padding-bottom) var(--link-menu-item-padding-left) !important;
     width: 100%;
 
-    @include mixins.lg-breakpoint('md') {
-      padding: var(--space-4);
+    &:first-child {
+      border-top-left-radius: var(--link-menu-border-radius);
+      border-top-right-radius: var(--link-menu-border-radius);
     }
 
-    @include mixins.lg-breakpoint('lg') {
-      padding: var(--space-4) var(--space-3);
+    &:last-child {
+      border-bottom-left-radius: var(--link-menu-border-radius);
+      border-bottom-right-radius: var(--link-menu-border-radius);
+      border-bottom-color: transparent;
+
+      &:hover,
+      &:active {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      &:hover {
+        box-shadow: inset 0 calc(-1 * var(--link-menu-item-hover-border-width-bottom)) 0 0
+          var(--link-menu-item-hover-border-colour);
+      }
+
+      &:active {
+        box-shadow: inset 0 calc(-1 * var(--link-menu-item-active-border-width-bottom)) 0
+          0 var(--link-menu-item-active-border-colour);
+      }
     }
 
     &:visited {
-      color: var(--link-menu-link-color);
-      border-bottom: var(--border-width) solid var(--link-menu-link-border-color);
+      color: var(--link-menu-item-rest-colour);
+      border-bottom: var(--link-menu-item-rest-border-width-bottom) solid
+        var(--link-menu-item-rest-border-colour);
       text-decoration: none;
     }
 
-    &:active,
-    &:hover,
-    &:focus-visible {
+    &:hover {
+      color: var(--link-menu-item-hover-colour);
+      background-color: var(--link-menu-item-hover-background-colour);
+      border-bottom: var(--link-menu-item-hover-border-width-bottom) solid
+        var(--link-menu-item-hover-border-colour);
+      padding-right: var(--link-menu-item-hover-padding-right) !important;
       margin-bottom: calc(
-        var(--border-width) - var(--link-menu-link-border-width-lg)
+        var(--link-menu-item-rest-border-width-bottom) - var(
+            --link-menu-item-hover-border-width-bottom
+          )
       ); // prevent bouncing effect caused by border
     }
 
-    &:active,
     &:focus-visible {
-      color: var(--link-menu-link-active-color);
-      border-bottom: var(--link-menu-link-border-width-lg) solid
-        var(--link-menu-link-active-color);
+      color: var(--link-menu-item-focus-colour);
+      box-shadow: inset 0 0 0 var(--link-menu-item-focus-border-width)
+        var(--link-menu-item-focus-border-colour);
+      outline: none !important;
     }
 
-    &:hover {
-      color: var(--link-menu-link-hover-color);
-      border-bottom: var(--link-menu-link-border-width-lg) solid
-        var(--link-menu-link-hover-color);
+    &:active {
+      color: var(--link-menu-item-active-colour);
+      background-color: var(--link-menu-item-active-background-colour);
+      border-bottom: var(--link-menu-item-active-border-width-bottom) solid
+        var(--link-menu-item-active-border-colour);
+      margin-bottom: calc(
+        var(--link-menu-item-rest-border-width-bottom) - var(
+            --link-menu-item-active-border-width-bottom
+          )
+      ); // prevent bouncing effect caused by border
     }
   }
 }

--- a/projects/canopy/src/styles/docs/link/link.stories.ts
+++ b/projects/canopy/src/styles/docs/link/link.stories.ts
@@ -11,6 +11,9 @@ export default {
       imports: [ LgAlertComponent, LgIconComponent, LgMarginDirective ],
     }),
   ],
+  parameters: {
+    backgrounds: { disable: true },
+  },
 } as Meta;
 
 const standardTemplate = `

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -13,7 +13,6 @@
 @use 'variables/components/hero';
 @use 'variables/components/hero-img';
 @use 'variables/components/input';
-@use 'variables/components/link-menu';
 @use 'variables/components/modal-body-timer';
 @use 'variables/components/page';
 @use 'variables/components/pagination';

--- a/projects/canopy/src/styles/variables/components/_link-menu.scss
+++ b/projects/canopy/src/styles/variables/components/_link-menu.scss
@@ -1,8 +1,0 @@
-:root {
-  --link-menu-link-border-width-md: 0.1875rem; // 3px
-  --link-menu-link-border-width-lg: 0.3125rem; // 5px
-  --link-menu-link-color: var(--colour-greyscale-900);
-  --link-menu-link-active-color: var(--colour-blue-800);
-  --link-menu-link-hover-color: var(--link-primary-rest-colour);
-  --link-menu-link-border-color: var(--colour-greyscale-200);
-}


### PR DESCRIPTION
BREAKING CHANGE: CSS custom link menu properies have been removed. Default right icon in link menu component has changed from cherron-right to arrow-right

# Description

Update the Link menu to the new brand

## Requirements

- Left icon as is and customisable
- Right icon changed to be customisable and right-animated on hover
- Label option to be bold or regular font weight. 
- Secondary label is always regular font weight. 
- Link menu has a transparent background and the mode and theme will be set by the above container. 
- Regardless of where the link item is in the link list then the border bottom will be straight, flat line and not curved on hover state

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
