### PR TITLE
fix(button): update link variant to get status and colour vars

### DIFF
--- a/projects/canopy/src/lib/alert/alert.component.scss
+++ b/projects/canopy/src/lib/alert/alert.component.scss
@@ -55,24 +55,29 @@
 }
 // Ensure links use status tokens
 [class*='lg-status-'].lg-alert a:not(.lg-btn),
-[class*='lg-status-'].lg-alert a:not(.lg-btn):link {
+[class*='lg-status-'].lg-alert a:not(.lg-btn):link,
+[class*='lg-status-'].lg-alert .lg-btn--link {
   color: var(--interactive-text-status-subtle-rest) !important;
 }
 
-[class*='lg-status-'].lg-alert a:not(.lg-btn):visited {
+[class*='lg-status-'].lg-alert a:not(.lg-btn):visited,
+[class*='lg-status-'].lg-alert .lg-btn--link:visited {
   color: var(--interactive-text-status-subtle-visited) !important;
 }
 
-[class*='lg-status-'].lg-alert a:not(.lg-btn):hover {
+[class*='lg-status-'].lg-alert a:not(.lg-btn):hover,
+[class*='lg-status-'].lg-alert .lg-btn--link:hover {
   color: var(--interactive-text-status-subtle-hover) !important;
 }
 
-[class*='lg-status-'].lg-alert a:not(.lg-btn):active {
+[class*='lg-status-'].lg-alert a:not(.lg-btn):active,
+[class*='lg-status-'].lg-alert .lg-btn--link:active {
   color: var(--interactive-text-status-subtle-active) !important;
   background-color: var(--container-status-subtle-background-colour) !important;
 }
 
-[class*='lg-status-'].lg-alert a:not(.lg-btn):focus-visible {
+[class*='lg-status-'].lg-alert a:not(.lg-btn):focus-visible,
+[class*='lg-status-'].lg-alert .lg-btn--link:focus-visible {
   color: var(--interactive-text-status-subtle-focus) !important;
   background-color: var(--container-status-subtle-background-colour) !important;
   outline-color: var(--interactive-text-status-subtle-focus) !important;

--- a/projects/canopy/src/lib/alert/docs/alert.stories.ts
+++ b/projects/canopy/src/lib/alert/docs/alert.stories.ts
@@ -1,6 +1,7 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
 
 import { LgAlertComponent } from '../alert.component';
+import { LgButtonComponent } from '../../button';
 
 const statusTypes = [ 'generic', 'info', 'success', 'warning', 'error' ];
 
@@ -11,7 +12,7 @@ export default {
   component: LgAlertComponent,
   decorators: [
     moduleMetadata({
-      imports: [ LgAlertComponent ],
+      imports: [ LgAlertComponent, LgButtonComponent ],
     }),
   ],
   argTypes: {
@@ -68,7 +69,7 @@ const template = `
   [status]="status"
   [role]="role"
 >
-  {{content}} Here is some <a href="#"> link text</a>.
+  {{content}} Here is some <a href="#"> link text</a> or a <button lg-button variant="link">button link</button>.
 </lg-alert>
 `;
 
@@ -83,7 +84,7 @@ export const StandardAlert = {
   [statusTheme]="statusTheme"
   [role]="role"
 >
-  {{content}} Here is some <a href="#"> link text</a>.
+  {{content}} Here is some <a href="#"> link text</a> or a <button lg-button variant="link">button link</button>.
 </lg-alert>
 `,
   }),

--- a/projects/canopy/src/lib/alert/docs/alert.stories.ts
+++ b/projects/canopy/src/lib/alert/docs/alert.stories.ts
@@ -69,7 +69,7 @@ const template = `
   [status]="status"
   [role]="role"
 >
-  {{content}} Here is some <a href="#"> link text</a> or a <button lg-button variant="link">button link</button>.
+  {{content}} Here is some <a href="#"> link text</a> or a <button lg-button priority="link">button link</button>.
 </lg-alert>
 `;
 
@@ -84,7 +84,7 @@ export const StandardAlert = {
   [statusTheme]="statusTheme"
   [role]="role"
 >
-  {{content}} Here is some <a href="#"> link text</a> or a <button lg-button variant="link">button link</button>.
+  {{content}} Here is some <a href="#"> link text</a> or a <button lg-button priority="link">button link</button>.
 </lg-alert>
 `,
   }),

--- a/projects/canopy/src/lib/banner/banner.component.scss
+++ b/projects/canopy/src/lib/banner/banner.component.scss
@@ -61,24 +61,29 @@
 
 // Ensure links use status tokens
 [class*='lg-status-'].lg-banner a:not(.lg-btn),
-[class*='lg-status-'].lg-banner a:not(.lg-btn):link {
+[class*='lg-status-'].lg-banner a:not(.lg-btn):link,
+[class*='lg-status-'].lg-banner .lg-btn--link {
   color: var(--interactive-text-status-bold-rest) !important;
 }
 
-[class*='lg-status-'].lg-banner a:not(.lg-btn):visited {
+[class*='lg-status-'].lg-banner a:not(.lg-btn):visited,
+[class*='lg-status-'].lg-banner .lg-btn--link:visited {
   color: var(--interactive-text-status-bold-visited) !important;
 }
 
-[class*='lg-status-'].lg-banner a:not(.lg-btn):hover {
+[class*='lg-status-'].lg-banner a:not(.lg-btn):hover,
+[class*='lg-status-'].lg-banner .lg-btn--link:hover {
   color: var(--interactive-text-status-bold-hover) !important;
 }
 
-[class*='lg-status-'].lg-banner a:not(.lg-btn):active {
+[class*='lg-status-'].lg-banner a:not(.lg-btn):active,
+[class*='lg-status-'].lg-banner .lg-btn--link:active {
   color: var(--interactive-text-status-bold-active) !important;
   background-color: var(--container-status-bold-background-colour) !important;
 }
 
-[class*='lg-status-'].lg-banner a:not(.lg-btn):focus-visible {
+[class*='lg-status-'].lg-banner a:not(.lg-btn):focus-visible,
+[class*='lg-status-'].lg-banner .lg-btn--link:focus-visible {
   color: var(--interactive-text-status-bold-focus) !important;
   background-color: var(--container-status-bold-background-colour) !important;
   outline-color: var(--interactive-text-status-bold-focus) !important;

--- a/projects/canopy/src/lib/banner/docs/banner.stories.ts
+++ b/projects/canopy/src/lib/banner/docs/banner.stories.ts
@@ -4,6 +4,7 @@ import { Meta, moduleMetadata } from '@storybook/angular';
 import { IconName, LgIconComponent } from '../../icon';
 import { LgBannerComponent } from '../banner.component';
 import type { Status } from '../../status';
+import { LgButtonComponent } from '../../button';
 // Direct import required for Webpack compatibility - do not use barrel file
 import { lgIconsArray } from '../../ui-icons-files/set/lgIconsArray';
 
@@ -14,10 +15,11 @@ const statuses: Array<Status> = [ 'generic', 'info', 'success', 'warning', 'erro
   template: `
     <lg-banner [status]="status" [statusTheme]="statusTheme">
       <lg-icon [name]="icon" />
-      {{ content }} Here is some <a href="#"> link text</a>.
+      {{ content }} Here is some <a href="#"> link text</a> or a
+      <button lg-button variant="link">button link</button>.
     </lg-banner>
   `,
-  imports: [ LgBannerComponent, LgIconComponent ],
+  imports: [ LgBannerComponent, LgIconComponent, LgButtonComponent ],
 })
 class LgBannerIconComponent {
   @Input() content: string;

--- a/projects/canopy/src/lib/banner/docs/banner.stories.ts
+++ b/projects/canopy/src/lib/banner/docs/banner.stories.ts
@@ -16,7 +16,7 @@ const statuses: Array<Status> = [ 'generic', 'info', 'success', 'warning', 'erro
     <lg-banner [status]="status" [statusTheme]="statusTheme">
       <lg-icon [name]="icon" />
       {{ content }} Here is some <a href="#"> link text</a> or a
-      <button lg-button variant="link">button link</button>.
+      <button lg-button priority="link">button link</button>.
     </lg-banner>
   `,
   imports: [ LgBannerComponent, LgIconComponent, LgButtonComponent ],

--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -97,11 +97,15 @@
   }
 
   &--link {
-    border: none;
-    background: none;
-    min-height: 0;
-    min-width: 0;
+    border: 0;
+    background-color: transparent;
+    cursor: pointer;
+    min-width: initial;
+    border-radius: 0;
     width: initial;
+    font-weight: var(--font-weight-400);
+    text-align: start;
+    margin-bottom: 0;
 
     @include mixins.lg-link();
   }

--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -97,14 +97,11 @@
   }
 
   &--link {
-    border: 0;
-    background-color: transparent;
-    cursor: pointer;
-    min-width: initial;
-    border-radius: 0;
+    border: none;
+    background: none;
+    min-height: 0;
+    min-width: 0;
     width: initial;
-    font-weight: var(--font-weight-400);
-    text-align: start;
     margin-bottom: 0;
 
     @include mixins.lg-link();

--- a/projects/canopy/src/lib/colour/docs/colour.stories.ts
+++ b/projects/canopy/src/lib/colour/docs/colour.stories.ts
@@ -34,7 +34,7 @@ const themes = [ 'neutral', 'neutral-inverse', 'subtle', 'bold' ];
         <br />
         <button lg-button priority="secondary">Secondary button</button>
         <br />
-        <button lg-button variant="link">Button link</button>
+        <button lg-button priority="link">Button link</button>
         <br />
         <a href="#" lg-button priority="secondary" lgMarginBottom="none">
           Secondary link styled as button

--- a/projects/canopy/src/lib/colour/docs/colour.stories.ts
+++ b/projects/canopy/src/lib/colour/docs/colour.stories.ts
@@ -34,6 +34,8 @@ const themes = [ 'neutral', 'neutral-inverse', 'subtle', 'bold' ];
         <br />
         <button lg-button priority="secondary">Secondary button</button>
         <br />
+        <button lg-button variant="link">Button link</button>
+        <br />
         <a href="#" lg-button priority="secondary" lgMarginBottom="none">
           Secondary link styled as button
         </a>

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -214,7 +214,8 @@ $breakpoints: (
   background-color: var(--container-status-subtle-background-colour);
   color: var(--text-status-subtle-primary-colour);
 
-  a:not(.lg-btn) {
+  a:not(.lg-btn),
+  .lg-btn--link {
     @include lg-link(
       $default-color: var(--link-status-subtle-rest-colour),
       $hover-color: var(--link-status-subtle-hover-colour),
@@ -266,7 +267,8 @@ $breakpoints: (
   background-color: var(--container-status-bold-background-colour);
   color: var(--text-status-bold-primary-colour);
 
-  a:not(.lg-btn) {
+  a:not(.lg-btn),
+  .lg-btn--link {
     @include lg-link(
       $default-color: var(--link-status-bold-rest-colour),
       $hover-color: var(--link-status-bold-hover-colour),
@@ -317,7 +319,8 @@ $breakpoints: (
   background-color: var(--container-default-background-colour) !important;
   color: var(--text-default-primary-colour) !important;
 
-  a:not(.lg-btn) {
+  a:not(.lg-btn),
+  .lg-btn--link {
     @include lg-link(
       $default-color: var(--interactive-text-default-rest),
       $hover-color: var(--interactive-text-default-hover),


### PR DESCRIPTION
Fixes # (issue)

Update the lg-button variant link to pick up the correct colours from the status components and colour directive

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
