### PR TITLE
fix(button-link): button link priority with customisable left icon

### DIFF
--- a/projects/canopy/src/lib/button/button.component.html
+++ b/projects/canopy/src/lib/button/button.component.html
@@ -1,7 +1,7 @@
 <ng-template #standard>
   @if (backIcon) {
     <lg-icon
-      name="arrow-left"
+      [name]="priority === 'link' ? backIconName : 'arrow-left'"
       class="lg-margin__left--none" />
   }
 

--- a/projects/canopy/src/lib/button/button.component.ts
+++ b/projects/canopy/src/lib/button/button.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 
-import { LgIconComponent } from '../icon';
+import { IconName, LgIconComponent } from '../icon';
 import { LgMarginDirective } from '../spacing';
 import { LgSpinnerComponent } from '../spinner';
 
@@ -30,6 +30,7 @@ export class LgButtonComponent implements AfterContentInit, AfterViewInit {
   private renderer = inject(Renderer2);
   private readonly hostElement = inject(ElementRef);
   private _backIcon = false;
+  private _backIconName: IconName = 'arrow-left';
 
   @ContentChildren(LgIconComponent) projectedIcons: QueryList<LgIconComponent>;
 
@@ -77,6 +78,14 @@ export class LgButtonComponent implements AfterContentInit, AfterViewInit {
   }
   get backIcon(): boolean {
     return this._backIcon;
+  }
+
+  @Input()
+  set backIconName(value: IconName) {
+    this._backIconName = value;
+  }
+  get backIconName(): IconName {
+    return this._backIconName;
   }
 
   @HostBinding('class.lg-btn--icon-left') get leftIconClass(): boolean {

--- a/projects/canopy/src/lib/button/docs/button.stories.ts
+++ b/projects/canopy/src/lib/button/docs/button.stories.ts
@@ -18,6 +18,7 @@ const buttonVariants = [ 'primary', 'secondary', 'link' ];
       [fullWidth]="fullWidth"
       [iconButton]="iconButton"
       [backIcon]="backIcon"
+      [backIconName]="backIconName"
       [loading]="loading"
       [priority]="priority"
     >
@@ -51,6 +52,7 @@ class ButtonComponentExampleComponent {
   @Input() disabled: boolean;
   @Input() fullWidth: boolean;
   @Input() backIcon: boolean;
+  @Input() backIconName: IconName = 'arrow-left';
   @Input() icon: IconName;
   @Input() iconButton: boolean;
   @Input() loading: boolean;
@@ -95,10 +97,23 @@ export default {
       },
     },
     backIcon: {
-      description: 'Display arrow-left icon on the left side of the button',
+      description: 'Display icon on the left side of the button',
       control: {
         type: 'boolean',
       },
+    },
+    backIconName: {
+      description: 'Icon name for the left icon (only for link priority)',
+      options: lgIconsArray.map(i => i.name),
+      table: {
+        type: {
+          summary: 'IconName',
+        },
+      },
+      control: {
+        type: 'select',
+      },
+      if: { arg: 'priority', eq: 'link' },
     },
     icon: {
       description:
@@ -163,6 +178,7 @@ const defaultArgValues = {
   iconButton: false,
   loading: false,
   backIcon: false,
+  backIconName: 'arrow-left' as IconName,
   icon: null,
 };
 
@@ -172,6 +188,7 @@ const buttonTemplate = `
     [fullWidth]="fullWidth"
     [iconButton]="iconButton"
     [backIcon]="backIcon"
+    [backIconName]="backIconName"
     [icon]="icon"
     [loading]="loading"
     [priority]="priority"
@@ -272,6 +289,8 @@ export const Link = {
   args: {
     ...defaultArgValues,
     priority: 'link',
+    backIcon: true,
+    backIconName: 'chevron-left',
   },
   globals: {
     backgrounds: { value: setBackground('link') },


### PR DESCRIPTION
Fixes # (issue)

This fixes issue with left icon not being customisable for button priority link.

New Input: `backIconName`
* Type: `IconName`
* Default: 'arrow-left'
* Purpose: Allows customisation of the left icon for `priority="link"`

How It Works

For `priority="link"` buttons:
* The `backIconName` input controls which icon appears on the left when `backIcon` is enabled
* Any icon from the icon library can be used
For other priorities (primary/secondary):
* The left icon remains hardcoded as 'arrow-left' for backwards compatibility
* `backIconName` is ignored

Usage examples:

Link with custom left icon:
```
<button lg-button priority="link" [backIcon]="true" backIconName="chevron-left">
  Go Back
</button>
```

Link button with different icon:
```
<button lg-button priority="link" [backIcon]="true" backIconName="arrow-up">
  Scroll to Top
</button>
```

Link button with right icon (content projection):
```
<button lg-button priority="link">
  Next Step
  <lg-icon name="chevron-right"></lg-icon>
</button>
```


Link button with both icons:
```
<button lg-button priority="link" [backIcon]="true" backIconName="chevron-left">
  Continue
  <lg-icon name="chevron-right"></lg-icon>
</button>

```

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
