### PR TITLE
feat(form-elements): update form elements to new brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "20.3.18",
         "@angular/platform-browser-dynamic": "20.3.18",
         "@angular/router": "20.3.18",
-        "@legal-and-general/canopy-design-tokens": "^1.14.0",
+        "@legal-and-general/canopy-design-tokens": "^1.17.0",
         "date-fns": "4.1.0",
         "rxjs": "7.8.2",
         "tslib": "2.8.1",
@@ -8966,9 +8966,9 @@
       "license": "MIT"
     },
     "node_modules/@legal-and-general/canopy-design-tokens": {
-      "version": "1.14.0",
-      "resolved": "https://npm.pkg.github.com/download/@legal-and-general/canopy-design-tokens/1.14.0/e4767b5045b50664f329f6d1296be0a896a823bf",
-      "integrity": "sha512-X7CORgl116J2r9Cgu1tahWIa/smgNct0ZBdGy4Wok/UEEnUWcqOG9caS4BqaBGPSQbIeaWbpQA92SPVs/9nG1w=="
+      "version": "1.17.0",
+      "resolved": "https://npm.pkg.github.com/download/@legal-and-general/canopy-design-tokens/1.17.0/db31f32f63e4a17f46a7dddc2f4a74b61d616c82",
+      "integrity": "sha512-MzrjHr38KLbFYLPOd2YUxNH1cXndfVHGoTznDMr6sSfXo8ORqraZPyeCLJ+9P3jxPTSrUlsKHwxkuqqyixm3aQ=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/platform-browser": "20.3.18",
     "@angular/platform-browser-dynamic": "20.3.18",
     "@angular/router": "20.3.18",
-    "@legal-and-general/canopy-design-tokens": "^1.14.0",
+    "@legal-and-general/canopy-design-tokens": "^1.17.0",
     "date-fns": "4.1.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",

--- a/projects/canopy-test-app/src/app/app.component.html
+++ b/projects/canopy-test-app/src/app/app.component.html
@@ -474,22 +474,24 @@
 
 
                   <lg-input-field>
-                    Text input with icon
+                    Text input with icon button
                     <input lgInput formControlName="textSearch" />
-                    <button
-                      lg-button
-                      lgSuffix
-                      [iconButton]="true"
-                      >
-                      Search
-                      <lg-icon name="search" />
-                    </button>
                   </lg-input-field>
+                  <button
+                    type="button"
+                    lg-button
+                    [iconButton]="true"
+                    lgMarginTop="2"
+                    >
+                    Search
+                    <lg-icon name="search" />
+                  </button>
 
                   <lg-input-field>
-                    Text input with add-on icon
+                    Text input with add-on and icon buttons
                     <input lgInput formControlName="textSearch" />
                     <button
+                      type="button"
                       lg-button
                       lgSuffix
                       [iconButton]="true"
@@ -498,15 +500,16 @@
                       Cancel
                       <lg-icon name="close" />
                     </button>
-                    <button
-                      lg-button
-                      lgSuffix
-                      [iconButton]="true"
-                      >
-                      Search
-                      <lg-icon name="search" />
-                    </button>
                   </lg-input-field>
+                  <button
+                    type="button"
+                    lg-button
+                    [iconButton]="true"
+                    lgMarginTop="2"
+                    >
+                    Search
+                    <lg-icon name="search" />
+                  </button>
 
                   <lg-input-field>
                     Text input with prefix

--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -83,6 +83,7 @@
     min-width: auto;
     width: auto;
     display: inline-flex;
+    height: var(--button-common-labelled-min-height);
     padding: var(--button-common-icon-only-padding-y)
       var(--button-common-icon-only-padding-x);
 
@@ -227,16 +228,5 @@ $priorities: 'primary', 'secondary' !default;
     &:hover {
       box-shadow: none;
     }
-  }
-}
-
-.lg-input-field__suffix .lg-btn {
-  border-radius: 0;
-  padding: calc(var(--space-1) - var(--border-width));
-  min-height: 0;
-  min-width: 0;
-
-  &:hover {
-    border-radius: 0 !important;
   }
 }

--- a/projects/canopy/src/lib/colour/docs/colour.stories.ts
+++ b/projects/canopy/src/lib/colour/docs/colour.stories.ts
@@ -36,6 +36,7 @@ const themes = [ 'neutral', 'neutral-inverse', 'subtle', 'bold' ];
         <br />
         <button lg-button priority="link">Button link</button>
         <br />
+        <br />
         <a href="#" lg-button priority="secondary" lgMarginBottom="none">
           Secondary link styled as button
         </a>

--- a/projects/canopy/src/lib/external-button/external-button.directive.spec.ts
+++ b/projects/canopy/src/lib/external-button/external-button.directive.spec.ts
@@ -1,0 +1,64 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { LgExternalButtonDirective } from './external-button.directive';
+
+@Component({
+  template: ` <button lgExternalButton>Button 1</button>
+    <button lgExternalButton>Button 2</button>
+    <button lgExternalButton [id]="customId">Button 3</button>`,
+  standalone: true,
+  imports: [ LgExternalButtonDirective ],
+})
+class TestComponent {
+  customId = 'custom-id';
+}
+
+describe('LgExternalButtonDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let buttonElements: Array<DebugElement>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ TestComponent ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    buttonElements = fixture.debugElement.queryAll(
+      By.directive(LgExternalButtonDirective),
+    );
+  });
+
+  it('should create', () => {
+    expect(buttonElements.length).toBe(3);
+  });
+
+  it('should have auto-generated IDs', () => {
+    const button1 = buttonElements[0].nativeElement;
+    const button2 = buttonElements[1].nativeElement;
+
+    expect(button1.id).toMatch(/^lg-external-button-\d+$/);
+    expect(button2.id).toMatch(/^lg-external-button-\d+$/);
+    expect(button1.id).not.toBe(button2.id);
+  });
+
+  it('should accept a custom ID', () => {
+    const button3 = buttonElements[2].nativeElement;
+
+    expect(button3.id).toBe('custom-id');
+  });
+
+  it('should update ID when input changes', () => {
+    const button3 = buttonElements[2].nativeElement;
+
+    expect(button3.id).toBe('custom-id');
+
+    fixture.componentInstance.customId = 'new-custom-id';
+    fixture.detectChanges();
+
+    expect(button3.id).toBe('new-custom-id');
+  });
+});

--- a/projects/canopy/src/lib/external-button/external-button.directive.ts
+++ b/projects/canopy/src/lib/external-button/external-button.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, HostBinding, Input } from '@angular/core';
+
+let nextUniqueId = 0;
+
+@Directive({
+  selector: '[lgExternalButton]',
+  standalone: true,
+})
+export class LgExternalButtonDirective {
+  @Input()
+  @HostBinding('attr.id')
+  id = `lg-external-button-${nextUniqueId++}`;
+}

--- a/projects/canopy/src/lib/external-button/index.ts
+++ b/projects/canopy/src/lib/external-button/index.ts
@@ -1,0 +1,1 @@
+export * from './external-button.directive';

--- a/projects/canopy/src/lib/external-button/index.ts
+++ b/projects/canopy/src/lib/external-button/index.ts
@@ -1,1 +1,0 @@
-export * from './external-button.directive';

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.html
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.html
@@ -3,11 +3,12 @@
   [attr.tabindex]="focus ? '-1' : null"
   [lgFocus]="focus"
 >
-  <legend lg-label [attr.for]="id" lgMarginBottom="3">
+  <legend lg-label [attr.for]="id">
     <ng-content />
   </legend>
+  <ng-content select=".lg-label--optional" />
   <ng-content select="lg-hint" />
-  <ng-content select="lg-toggle, lg-checkbox, lg-filter-checkbox" />
   <ng-content select="lg-validation" />
+  <ng-content select="lg-toggle, lg-checkbox, lg-filter-checkbox" />
 </fieldset>
 <ng-content select="lg-hint" />

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.scss
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.scss
@@ -5,14 +5,27 @@
   margin-bottom: var(--component-margin);
 
   .lg-toggle {
-    margin-bottom: var(--space-3);
+    margin-bottom: var(--checkbox-group-lg-gap);
+  }
+
+  .lg-toggle--sm {
+    margin-bottom: var(--checkbox-group-sm-gap);
+  }
+
+  .lg-toggle:last-of-type {
+    margin-bottom: 0;
   }
 }
 
 .lg-checkbox-group--inline {
   .lg-toggle {
     display: inline-block;
-    margin-right: var(--space-5);
+    margin-right: var(--checkbox-group-lg-gap);
+    margin-bottom: 0;
+  }
+
+  .lg-toggle--sm {
+    margin-right: var(--checkbox-group-sm-gap);
   }
 
   .lg-toggle:last-of-type {

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.spec.ts
@@ -27,14 +27,14 @@ const hintTestId = 'test-hint-id';
   template: `
     <form (ngSubmit)="login()" [formGroup]="form" #testForm="ngForm">
       <lg-filter-multiple-group formControlName="color">
-        Color
+        Colour
         <lg-hint id="${hintTestId}">Choose your favourite</lg-hint>
-        <lg-toggle value="red">Red</lg-toggle>
-        <lg-toggle value="yellow">Yellow</lg-toggle>
-        <lg-toggle value="blue">Blue</lg-toggle>
         @if (isControlInvalid(color, testForm)) {
           <lg-validation id="${validationTestId}"> Error </lg-validation>
         }
+        <lg-toggle value="red">Red</lg-toggle>
+        <lg-toggle value="yellow">Yellow</lg-toggle>
+        <lg-toggle value="blue">Blue</lg-toggle>
       </lg-filter-multiple-group>
     </form>
   `,

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.notes.ts
@@ -5,10 +5,10 @@ Provides a set of components to implement ${name} groups in a form. The ${name} 
 Import the CheckboxGroup and Toggle components into your application:
 
 ~~~js
-@NgModule({
-  ...
-  imports: [ ..., LgCheckboxGroupComponent, LgToggleComponent ],
-})
+import {
+  LgCheckboxGroupComponent,
+  LgToggleComponent,
+} from '@legal-and-general/canopy';
 ~~~
 
 ## Inputs
@@ -27,7 +27,6 @@ ${
     ? '| ``inline`` | If true, displays the buttons inline rather than stacked | boolean | false | No |'
     : ''
 }
-
 ### LgToggleComponent
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|

--- a/projects/canopy/src/lib/forms/date/date-field.component.html
+++ b/projects/canopy/src/lib/forms/date/date-field.component.html
@@ -7,6 +7,7 @@
     <ng-content />
   </legend>
   <lg-hint>For example, 27 12 1977</lg-hint>
+  <ng-content select="lg-validation" />
   <div
     class="lg-date-field__fields"
     [formGroup]="dateFormGroup"
@@ -60,6 +61,4 @@
       </lg-input-field>
     </div>
   </div>
-
-  <ng-content select="lg-validation" />
 </fieldset>

--- a/projects/canopy/src/lib/forms/hint/hint.component.scss
+++ b/projects/canopy/src/lib/forms/hint/hint.component.scss
@@ -1,7 +1,6 @@
 .lg-hint {
   display: block;
-  color: var(--colour-greyscale-700);
-  margin-top: calc(var(--space-2) * -1);
-  margin-bottom: var(--space-2);
+  color: var(--label-and-hint-hint-colour);
+  margin-bottom: var(--form-field-gap);
   font-weight: var(--font-weight-400);
 }

--- a/projects/canopy/src/lib/forms/index.ts
+++ b/projects/canopy/src/lib/forms/index.ts
@@ -1,3 +1,4 @@
+export * from './checkbox-group/index';
 export * from './date/index';
 export * from './hint/index';
 export * from './input/index';
@@ -7,4 +8,3 @@ export * from './select/index';
 export * from './sort-code/index';
 export * from './toggle/index';
 export * from './validation/index';
-export * from './checkbox-group/index';

--- a/projects/canopy/src/lib/forms/input-field-external-button/index.ts
+++ b/projects/canopy/src/lib/forms/input-field-external-button/index.ts
@@ -1,0 +1,1 @@
+export * from './input-field-external-button.directive';

--- a/projects/canopy/src/lib/forms/input-field-external-button/input-field-external-button.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/input-field-external-button/input-field-external-button.directive.spec.ts
@@ -2,20 +2,20 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { LgExternalButtonDirective } from './external-button.directive';
+import { LgInputFieldExternalButtonDirective } from './input-field-external-button.directive';
 
 @Component({
-  template: ` <button lgExternalButton>Button 1</button>
-    <button lgExternalButton>Button 2</button>
-    <button lgExternalButton [id]="customId">Button 3</button>`,
+  template: ` <button lgInputFieldExternalButton>Button 1</button>
+    <button lgInputFieldExternalButton>Button 2</button>
+    <button lgInputFieldExternalButton [id]="customId">Button 3</button>`,
   standalone: true,
-  imports: [ LgExternalButtonDirective ],
+  imports: [ LgInputFieldExternalButtonDirective ],
 })
 class TestComponent {
   customId = 'custom-id';
 }
 
-describe('LgExternalButtonDirective', () => {
+describe('LgInputFieldExternalButtonDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
   let buttonElements: Array<DebugElement>;
 
@@ -28,7 +28,7 @@ describe('LgExternalButtonDirective', () => {
     fixture.detectChanges();
 
     buttonElements = fixture.debugElement.queryAll(
-      By.directive(LgExternalButtonDirective),
+      By.directive(LgInputFieldExternalButtonDirective),
     );
   });
 
@@ -40,8 +40,8 @@ describe('LgExternalButtonDirective', () => {
     const button1 = buttonElements[0].nativeElement;
     const button2 = buttonElements[1].nativeElement;
 
-    expect(button1.id).toMatch(/^lg-external-button-\d+$/);
-    expect(button2.id).toMatch(/^lg-external-button-\d+$/);
+    expect(button1.id).toMatch(/^lg-input-field-external-button-\d+$/);
+    expect(button2.id).toMatch(/^lg-input-field-external-button-\d+$/);
     expect(button1.id).not.toBe(button2.id);
   });
 

--- a/projects/canopy/src/lib/forms/input-field-external-button/input-field-external-button.directive.ts
+++ b/projects/canopy/src/lib/forms/input-field-external-button/input-field-external-button.directive.ts
@@ -3,11 +3,11 @@ import { Directive, HostBinding, Input } from '@angular/core';
 let nextUniqueId = 0;
 
 @Directive({
-  selector: '[lgExternalButton]',
+  selector: '[lgInputFieldExternalButton]',
   standalone: true,
 })
-export class LgExternalButtonDirective {
+export class LgInputFieldExternalButtonDirective {
   @Input()
   @HostBinding('attr.id')
-  id = `lg-external-button-${nextUniqueId++}`;
+  id = `lg-input-field-external-button-${nextUniqueId++}`;
 }

--- a/projects/canopy/src/lib/forms/input/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/input/docs/guide.mdx
@@ -1,16 +1,11 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../docs/common/feedback.md';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Forms/Text input/Guide" tags={['pending']}/>
+<Meta title="Components/Forms/Text input/Guide"/>
 
 # Text input
 
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
-
 <p class="standfirst">Text input allows the user to enter a single line of text into a form.</p>
-
-![example](docs/text-input/example.png)
 
 ## Usage
 
@@ -27,10 +22,7 @@ The component contains a `<label>` and an `<input>` element. The `lgInput` direc
 Import the text input component in your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgInputComponent ],
-});
+import { LgInputComponent } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -40,6 +32,19 @@ and in your HTML:
   Name
   <lg-hint>Please enter your name</lg-hint>
   <input lgInput size="12" formControlName="name" />
+</lg-input-field>
+```
+
+### Optional fields
+
+For optional fields, use a `<span>` element with the `lg-label--optional` class to indicate that the field is not required:
+
+```html
+<lg-input-field>
+  Name
+  <span class="lg-label--optional">(optional)</span>
+  <lg-hint>Please enter your name</lg-hint>
+  <input lgInput formControlName="name" />
 </lg-input-field>
 ```
 
@@ -54,8 +59,6 @@ The user can navigate between inputs using the tab key on desktop, and forward /
 ### Prefixes and suffixes
 
 You can add prefixes (i.e. currency symbols), suffixes (i.e. percentage) using the `lgSuffix` and `lgPrefix` directives.
-
-![prefix-suffix](docs/text-input/prefix-suffix.png)
 
 #### Text prefix
 
@@ -77,24 +80,6 @@ You can add prefixes (i.e. currency symbols), suffixes (i.e. percentage) using t
 </lg-input-field>
 ```
 
-### Input buttons
-
-Buttons can be added within input fields to provide functionality linked to the input. The `lgSuffix` directive needs to be added to the button to place it in the correct place. Only small size buttons should be placed in the input field.
-
-![button](docs/text-input/button.png)
-
-#### Button suffix
-
-```html
-<lg-input-field>
-  Name
-  <input lgInput formControlName="name" />
-  <button lg-button lgSuffix>
-    Search
-  </button>
-</lg-input-field>
-```
-
 #### Icon Button suffix with add-on class
 
 There is an additional add-on button variant for adding a button to the input field which inherits the button spacing but no background or border colours.
@@ -104,7 +89,39 @@ There is an additional add-on button variant for adding a button to the input fi
   Name
   <input lgInput formControlName="name" />
   <button lg-button lgSuffix [iconButton]="true" priority="add-on">
-    <lg-icon name="search" />
+    Close
+    <lg-icon name="close-spot-outline" />
+  </button>
+</lg-input-field>
+```
+
+#### External button
+
+You can add a button that sits outside the input border using the `lgExternalButton` directive. This is useful for actions like search or submit buttons.
+
+```html
+<lg-input-field>
+  Name
+  <input lgInput formControlName="name" />
+  <button lg-button lgExternalButton priority="primary">
+    Search
+  </button>
+</lg-input-field>
+```
+
+You can combine multiple suffixes with an external button:
+
+```html
+<lg-input-field>
+  Name
+  <input lgInput formControlName="name" />
+  <span lgSuffix>%</span>
+  <button lg-button lgSuffix [iconButton]="true" priority="add-on">
+    Close
+    <lg-icon name="close-spot-outline" />
+  </button>
+  <button lg-button lgExternalButton priority="primary">
+    Submit
   </button>
 </lg-input-field>
 ```
@@ -113,8 +130,6 @@ There is an additional add-on button variant for adding a button to the input fi
 
 ### Do
 
-![do](docs/text-input/do.png)
-
 1. **Do** use labels and supporting text to help provide context.
 2. **Do** keep labels clear, concise and relevant.
 3. **Do** use a textarea for multi-line content (Angular component to be built).
@@ -122,8 +137,6 @@ There is an additional add-on button variant for adding a button to the input fi
 5. **Do** keep input widths relative to the information requested.
 
 ### Don't
-
-![dont](docs/text-input/dont.png)
 
 1. **Don't** truncate label text.
 2. **Don't** use text inputs when a pre-defined response is required, use the select component instead.

--- a/projects/canopy/src/lib/forms/input/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/input/docs/guide.mdx
@@ -97,14 +97,13 @@ There is an additional add-on button variant for adding a button to the input fi
 
 #### External button
 
-You can add a button that sits outside the input border using the `lgExternalButton` directive. This is useful for actions like search or submit buttons.
+You can add a button that sits outside the input border using the `lgInputFieldExternalButton` directive. This is useful for actions like search or submit buttons.
 
 ```html
 <lg-input-field>
   Name
   <input lgInput formControlName="name" />
-  <button lg-button lgExternalButton priority="primary">
-    Search
+  <button lg-button lgInputFieldExternalButton priority="primary">
   </button>
 </lg-input-field>
 ```
@@ -120,7 +119,7 @@ You can combine multiple suffixes with an external button:
     Close
     <lg-icon name="close-spot-outline" />
   </button>
-  <button lg-button lgExternalButton priority="primary">
+  <button lg-button lgInputFieldExternalButton priority="primary">
     Submit
   </button>
 </lg-input-field>

--- a/projects/canopy/src/lib/forms/input/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/input/docs/guide.mdx
@@ -22,7 +22,7 @@ The component contains a `<label>` and an `<input>` element. The `lgInput` direc
 Import the text input component in your application:
 
 ```js
-import { LgInputComponent } from '@legal-and-general/canopy';
+import { LgInputFieldComponent, LgInputDirective } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:

--- a/projects/canopy/src/lib/forms/input/docs/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/docs/input.stories.ts
@@ -13,7 +13,7 @@ import { LgInputDirective } from '../input.directive';
 import { LgSuffixDirective } from '../../../suffix';
 import { LgHintComponent } from '../../hint';
 import { LgIconComponent } from '../../../icon';
-import { LgExternalButtonDirective } from '../../../external-button';
+import { LgInputFieldExternalButtonDirective } from '../../input-field-external-button';
 
 interface Config {
   block?: boolean;
@@ -121,7 +121,7 @@ const inputTemplate = `
   @if (showExternalButton) {
     <button
       lg-button
-      lgExternalButton
+      lgInputFieldExternalButton
       [iconButton]="iconButton"
       [priority]="buttonVariant"
     >
@@ -151,7 +151,7 @@ const inputTemplate = `
     LgButtonComponent,
     LgIconComponent,
     LgHintComponent,
-    LgExternalButtonDirective,
+    LgInputFieldExternalButtonDirective,
   ],
 })
 class ReactiveFormComponent {

--- a/projects/canopy/src/lib/forms/input/docs/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/docs/input.stories.ts
@@ -13,18 +13,20 @@ import { LgInputDirective } from '../input.directive';
 import { LgSuffixDirective } from '../../../suffix';
 import { LgHintComponent } from '../../hint';
 import { LgIconComponent } from '../../../icon';
+import { LgExternalButtonDirective } from '../../../external-button';
 
 interface Config {
   block?: boolean;
   buttonText?: boolean;
   disabled?: boolean;
   hint?: string | null;
+  optional?: boolean;
   icon?: string;
   iconButton?: boolean;
   label?: string;
   showLabel?: boolean;
   showButtonFirstSuffix?: boolean;
-  showButtonSecondSuffix?: boolean;
+  showExternalButton?: boolean;
   showTextPrefix?: boolean;
   showTextSuffix?: boolean;
   size?: number;
@@ -43,6 +45,7 @@ function createInputStory(args: LgInputFieldComponent) {
         [buttonVariant]="buttonVariant"
         [disabled]="disabled"
         [hint]="hint"
+        [optional]="optional"
         [icon]="icon"
         [iconButton]="iconButton"
         [label]="label"
@@ -51,7 +54,7 @@ function createInputStory(args: LgInputFieldComponent) {
         [size]="size"
         [suffix]="suffix"
         [showButtonFirstSuffix]="showButtonFirstSuffix"
-        [showButtonSecondSuffix]="showButtonSecondSuffix"
+        [showExternalButton]="showExternalButton"
         [showTextPrefix]="showTextPrefix"
         [showTextSuffix]="showTextSuffix"
       ></lg-reactive-form>
@@ -68,12 +71,13 @@ function setupInputStoryValues(obj, code, config?: Config) {
     hint: config?.hint === null
       ? ''
       : 'Please enter your name',
+    optional: config?.optional || false,
     icon: 'search',
     label: config?.label || 'Name',
     showLabel: true,
     prefix: '£',
     showButtonFirstSuffix: config?.showButtonFirstSuffix,
-    showButtonSecondSuffix: config?.showButtonSecondSuffix,
+    showExternalButton: config?.showExternalButton,
     iconButton: true,
     showTextPrefix: config?.showTextPrefix,
     showTextSuffix: config?.showTextSuffix,
@@ -93,6 +97,9 @@ function setupInputStoryValues(obj, code, config?: Config) {
 const inputTemplate = `
 <lg-input-field [block]="block" [showLabel]="showLabel">
   {{ label }}
+  @if (optional) {
+    <span class="lg-label--optional">(optional)</span>
+  }
   @if (hint) {
     <lg-hint>{{ hint }}</lg-hint>
   }
@@ -108,13 +115,13 @@ const inputTemplate = `
       priority="add-on"
     >
       Close
-      <lg-icon name="close"></lg-icon>
+      <lg-icon name="close-spot-outline"></lg-icon>
     </button>
   }
-  @if (showButtonSecondSuffix) {
+  @if (showExternalButton) {
     <button
       lg-button
-      lgSuffix
+      lgExternalButton
       [iconButton]="iconButton"
       [priority]="buttonVariant"
     >
@@ -144,6 +151,7 @@ const inputTemplate = `
     LgButtonComponent,
     LgIconComponent,
     LgHintComponent,
+    LgExternalButtonDirective,
   ],
 })
 class ReactiveFormComponent {
@@ -165,13 +173,14 @@ class ReactiveFormComponent {
   @Input() buttonText: string;
   @Input() buttonVariant: ButtonPriority;
   @Input() hint: string;
+  @Input() optional: boolean;
   @Input() icon: string;
   @Input() iconButton: boolean;
   @Input() label: string;
   @Input() showLabel: boolean;
   @Input() prefix: string;
   @Input() showButtonFirstSuffix: boolean;
-  @Input() showButtonSecondSuffix: boolean;
+  @Input() showExternalButton: boolean;
   @Input() showTextPrefix: boolean;
   @Input() showTextSuffix: boolean;
   @Input() size: number;
@@ -194,7 +203,6 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Forms/Text input/Examples',
-  tags: [ 'pending' ],
   component: LgInputFieldComponent,
   decorators: [
     moduleMetadata({
@@ -265,7 +273,7 @@ export default {
         disable: true,
       },
     },
-    showButtonSecondSuffix: {
+    showExternalButton: {
       table: {
         disable: true,
       },
@@ -344,7 +352,7 @@ setupInputStoryValues(WithButtonSuffix, inputTemplate, {
 });
 
 export const WithTextSuffix = {
-  name: 'With test suffix',
+  name: 'With text suffix',
   render: (args: LgInputFieldComponent) => createInputStory(args),
 };
 
@@ -361,7 +369,7 @@ export const WithMultipleButtonSuffixes = {
 
 setupInputStoryValues(WithMultipleButtonSuffixes, inputTemplate, {
   showButtonFirstSuffix: true,
-  showButtonSecondSuffix: true,
+  showExternalButton: true,
 });
 
 export const WithTextPrefix = {

--- a/projects/canopy/src/lib/forms/input/input-field.component.html
+++ b/projects/canopy/src/lib/forms/input/input-field.component.html
@@ -27,6 +27,6 @@
 </div>
 @if (externalButtonChildren.length) {
   <div class="lg-input-field__external-btn">
-    <ng-content select="[lgExternalButton]" />
+    <ng-content select="[lgInputFieldExternalButton]" />
   </div>
 }

--- a/projects/canopy/src/lib/forms/input/input-field.component.html
+++ b/projects/canopy/src/lib/forms/input/input-field.component.html
@@ -1,7 +1,9 @@
 <label lg-label [class.lg-visually-hidden]="!showLabel">
   <ng-content />
 </label>
+<ng-content select=".lg-label--optional" />
 <ng-content select="lg-hint" />
+<ng-content select="lg-validation" />
 <div
   class="lg-input-field__inputs"
   (focusin)="onFocusIn($event)"
@@ -23,4 +25,8 @@
     </div>
   }
 </div>
-<ng-content select="lg-validation" />
+@if (externalButtonChildren.length) {
+  <div class="lg-input-field__external-btn">
+    <ng-content select="[lgExternalButton]" />
+  </div>
+}

--- a/projects/canopy/src/lib/forms/input/input-field.component.scss
+++ b/projects/canopy/src/lib/forms/input/input-field.component.scss
@@ -14,13 +14,8 @@
   &__prefix,
   &__suffix {
     display: flex;
-    font-weight: var(--font-weight-500);
+    font-weight: var(--font-weight-700);
     align-items: center;
-
-    .lg-icon {
-      height: var(--space-5);
-      width: var(--space-5);
-    }
   }
 
   &--focus &__prefix {
@@ -30,50 +25,76 @@
   }
 
   &__prefix {
-    margin-left: var(--suffix-margin);
+    margin-left: var(--text-input-common-padding-x);
   }
 
   &__suffix {
-    margin-right: var(--suffix-margin);
+    margin-right: var(--text-input-common-padding-x);
 
     > .lg-btn {
+      margin: 0;
+      padding: 0;
+    }
+  }
+
+  &__external-btn {
+    display: inline-flex;
+    margin-left: var(--button-gap);
+    margin-top: 0;
+    align-self: flex-end;
+
+    .lg-btn {
       margin-bottom: 0;
       margin-top: 0;
-      margin-right: var(--suffix-button-margin);
-    }
-
-    > .lg-btn:last-child {
-      margin-right: calc((-1 * var(--suffix-margin)) + var(--suffix-button-margin));
+      display: inline-block;
     }
   }
 
   &__inputs {
     display: inline-flex;
     align-items: center;
-    background-color: var(--colour-greyscale-0);
-    border: solid var(--border-width) var(--border-color);
-    border-radius: var(--border-radius-sm);
+    border-radius: var(--text-input-common-border-radius);
+    border: var(--text-input-rest-border-width) solid var(--text-input-rest-border-colour);
+    background: var(--text-input-rest-background-colour);
+    min-height: var(--input-common-scale-xxl);
+    max-height: var(--input-common-scale-xxl);
 
     #{$block}--hover & {
-      border-color: var(--border-hover-color);
+      border-color: var(--text-input-hover-border-colour);
+    }
+
+    #{$block}--focus & {
+      color: var(--text-input-focus-colour);
+      border: var(--text-input-rest-border-width) solid
+        var(--text-input-focus-border-colour);
+      background: var(--text-input-focus-background-colour);
+      box-shadow:
+        0 0 0 var(--text-input-rest-border-width) var(--text-input-focus-border-colour),
+        0 0 0 var(--text-input-focus-border-width)
+          var(--text-input-focus-background-colour);
+    }
+
+    #{$block}--disabled & {
+      color: var(--text-input-disabled-colour);
+      border: var(--text-input-disabled-border-width) solid
+        var(--text-input-disabled-border-colour);
+      background: var(--text-input-disabled-background-colour);
+      pointer-events: none;
     }
 
     #{$block}--error & {
-      border-color: var(--form-error-border-color);
+      color: var(--text-input-error-colour);
+      border: var(--text-input-rest-border-width) solid
+        var(--text-input-error-border-colour);
+      background: var(--text-input-error-background-colour);
+      box-shadow:
+        0 0 0 var(--text-input-rest-border-width) var(--text-input-error-border-colour),
+        0 0 0 var(--text-input-error-border-width)
+          var(--text-input-error-background-colour);
     }
 
     #{$block}--error#{$block}--hover#{$block}--focus & {
       color: inherit;
-    }
-
-    #{$block}--disabled & {
-      color: var(--disabled-color);
-      background-color: var(--background-disabled-color);
-      border-color: var(--border-disabled-color);
-    }
-
-    #{$block}--focus & {
-      @include mixins.lg-focus-outline;
     }
 
     #{$block}--block & {
@@ -92,11 +113,13 @@
   flex: 1 0 auto;
   display: block;
   border: none;
-  line-height: var(--input-line-height);
   margin: 0;
-  padding: var(--input-vertical-padding) var(--space-4);
   outline: 0;
   max-width: 100%;
+  background: none;
+  padding: var(--text-input-common-padding-y) var(--text-input-common-padding-x);
+  min-height: var(--input-common-scale-xxl);
+  max-height: var(--input-common-scale-xxl);
 
   &[type='number']::-webkit-inner-spin-button,
   &[type='number']::-webkit-outer-spin-button {
@@ -106,9 +129,5 @@
 
   &:-webkit-autofill {
     -webkit-background-clip: text;
-  }
-
-  &--error {
-    color: var(--form-error-color);
   }
 }

--- a/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.spec.ts
@@ -71,9 +71,9 @@ describe('LgInputFieldComponent', () => {
     fixture = MockRender(`
       <lg-input-field [block]="${block}" [showLabel]="${showLabel}">
         Label
-        <input lgInput />
         <lg-hint id="${hintId}">Hint</lg-hint>
         <lg-validation id="${errorId}">Error</lg-validation>
+        <input lgInput />
         ${hasPrefix && `<span lgPrefix id="${prefixId}">${prefixText}</span>`}
         ${hasSuffix && `<span lgSuffix id="${suffixId}">${suffixText}</span>`}
       </lg-input-field>

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -20,6 +20,7 @@ import { LgValidationComponent } from '../validation';
 import { LgButtonComponent } from '../../button';
 import { LgSuffixDirective } from '../../suffix';
 import { LgPrefixDirective } from '../../prefix';
+import { LgExternalButtonDirective } from '../../external-button';
 
 import { LgInputDirective } from './input.directive';
 
@@ -38,6 +39,7 @@ let nextUniqueId = 0;
     LgSuffixDirective,
     LgPrefixDirective,
     LgInputDirective,
+    LgExternalButtonDirective,
   ],
 })
 export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
@@ -50,6 +52,7 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
   private _validationElement: LgValidationComponent;
   private _suffixChildren: QueryList<LgSuffixDirective>;
   private _prefixChildren: QueryList<LgPrefixDirective>;
+  private _externalButtonChildren: QueryList<LgExternalButtonDirective>;
   /*
   The input field control element mimics the border of the input field.
   This allows us to add buttons and icons inside the input field.
@@ -137,6 +140,9 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
 
   @ContentChild(LgButtonComponent) buttonElement: LgButtonComponent;
 
+  @ContentChildren(LgButtonComponent, { descendants: true })
+  allButtonElements: QueryList<LgButtonComponent>;
+
   @ContentChildren(LgSuffixDirective)
   set suffixChildren(elements: QueryList<LgSuffixDirective>) {
     elements.forEach(element => {
@@ -169,11 +175,25 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
     return this._prefixChildren;
   }
 
+  @ContentChildren(LgExternalButtonDirective)
+  set externalButtonChildren(elements: QueryList<LgExternalButtonDirective>) {
+    this._externalButtonChildren = elements;
+  }
+  get externalButtonChildren() {
+    return this._externalButtonChildren;
+  }
+
   ngAfterContentInit(): void {
-    if (this.inputElement && this.buttonElement) {
-      this.inputElement.control.statusChanges.subscribe(status => {
-        this.buttonElement.disabled = status === 'DISABLED';
-      });
+    if (this.inputElement?.control && this.allButtonElements) {
+      this.disabledStateChanges = this.inputElement.control.statusChanges.subscribe(
+        status => {
+          const isDisabled = status === 'DISABLED';
+
+          this.allButtonElements.forEach(button => {
+            button.disabled = isDisabled;
+          });
+        },
+      );
     }
   }
 

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -138,8 +138,6 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
     this._validationElement = element;
   }
 
-  @ContentChild(LgButtonComponent) buttonElement: LgButtonComponent;
-
   @ContentChildren(LgButtonComponent, { descendants: true })
   allButtonElements: QueryList<LgButtonComponent>;
 
@@ -185,15 +183,18 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
 
   ngAfterContentInit(): void {
     if (this.inputElement?.control && this.allButtonElements) {
-      this.disabledStateChanges = this.inputElement.control.statusChanges.subscribe(
-        status => {
-          const isDisabled = status === 'DISABLED';
+      const updateDisabledState = (status: string) => {
+        const isDisabled = status === 'DISABLED';
 
-          this.allButtonElements.forEach(button => {
-            button.disabled = isDisabled;
-          });
-        },
-      );
+        this.allButtonElements.forEach(button => {
+          button.disabled = isDisabled;
+        });
+      };
+
+      updateDisabledState(this.inputElement.control.status);
+
+      this.disabledStateChanges =
+        this.inputElement.control.statusChanges.subscribe(updateDisabledState);
     }
   }
 

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -20,7 +20,7 @@ import { LgValidationComponent } from '../validation';
 import { LgButtonComponent } from '../../button';
 import { LgSuffixDirective } from '../../suffix';
 import { LgPrefixDirective } from '../../prefix';
-import { LgExternalButtonDirective } from '../../external-button';
+import { LgInputFieldExternalButtonDirective } from '../input-field-external-button';
 
 import { LgInputDirective } from './input.directive';
 
@@ -39,7 +39,7 @@ let nextUniqueId = 0;
     LgSuffixDirective,
     LgPrefixDirective,
     LgInputDirective,
-    LgExternalButtonDirective,
+    LgInputFieldExternalButtonDirective,
   ],
 })
 export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
@@ -52,7 +52,7 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
   private _validationElement: LgValidationComponent;
   private _suffixChildren: QueryList<LgSuffixDirective>;
   private _prefixChildren: QueryList<LgPrefixDirective>;
-  private _externalButtonChildren: QueryList<LgExternalButtonDirective>;
+  private _externalButtonChildren: QueryList<LgInputFieldExternalButtonDirective>;
   /*
   The input field control element mimics the border of the input field.
   This allows us to add buttons and icons inside the input field.
@@ -175,8 +175,8 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
     return this._prefixChildren;
   }
 
-  @ContentChildren(LgExternalButtonDirective)
-  set externalButtonChildren(elements: QueryList<LgExternalButtonDirective>) {
+  @ContentChildren(LgInputFieldExternalButtonDirective)
+  set externalButtonChildren(elements: QueryList<LgInputFieldExternalButtonDirective>) {
     this._externalButtonChildren = elements;
   }
   get externalButtonChildren() {

--- a/projects/canopy/src/lib/forms/input/input.directive.ts
+++ b/projects/canopy/src/lib/forms/input/input.directive.ts
@@ -35,16 +35,21 @@ export class LgInputDirective {
   @Input() block = false;
 
   @Input()
-  @HostBinding('name')
+  @HostBinding('attr.name')
   name = `lg-input-${this.uniqueId}`;
 
   @Input()
   @HostBinding('id')
   id = `lg-input-${this.uniqueId}`;
 
-  @Input()
-  @HostBinding('disabled')
-  disabled = false;
+  @Input() disabled = false;
+
+  @HostBinding('attr.disabled')
+  get disabledAttr() {
+    return this.disabled
+      ? true
+      : null;
+  }
 
   @Input()
   @HostBinding('attr.aria-describedby')

--- a/projects/canopy/src/lib/forms/label/label.component.scss
+++ b/projects/canopy/src/lib/forms/label/label.component.scss
@@ -1,6 +1,26 @@
 .lg-label {
   display: block;
-  margin-bottom: var(--space-2);
+  color: var(--label-and-hint-label-colour);
   font-weight: var(--font-weight-700);
   width: 100%;
+  margin-bottom: var(--form-field-gap);
+}
+
+.lg-label + .lg-label--optional {
+  margin-top: calc(var(--label-and-hint-gap) - var(--form-field-gap));
+}
+
+.lg-label + .lg-hint {
+  margin-top: calc(var(--label-and-hint-gap) - var(--form-field-gap));
+}
+
+.lg-label--optional {
+  display: block;
+  color: var(--label-and-hint-hint-colour);
+  margin-bottom: var(--form-field-gap);
+  font-weight: var(--font-weight-400);
+}
+
+.lg-label--optional + .lg-hint {
+  margin-top: calc(var(--label-and-hint-gap) - var(--form-field-gap));
 }

--- a/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
@@ -19,7 +19,7 @@ Use a radio group when you want the user to make a single selection from 2 or mo
 Import the radio components into your application:
 
 ```js
-import { LgRadioComponent } from '@legal-and-general/canopy';
+import { LgRadioGroupComponent, LgRadioButtonComponent } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -80,7 +80,7 @@ A radio button contains a circular toggle and a label, and will always appear in
 | `id`              | HTML ID attribute, auto generated if not provided                                                                             | `string`    | `lg-radio-button-${++nextUniqueId}` | No       |
 | `name`            | HTML name attribute                                                                                                           | `string`    | `null`                              | Yes      |
 | `value`           | HTML value attribute                                                                                                          | `string`    | `null`                              | Yes      |
-| `ariaDescribedBy` | HTML ID for the corresponding element that describes the radio, if not provided it will use the hint field where appropriate  | `boolean`   | `null`                              | No       |
+| `ariaDescribedBy` | HTML ID for the corresponding element that describes the radio, if not provided it will use the hint field where appropriate  | `string`    | `null`                              | No       |
 | `size`            | The size of the radio button                                                                                                  | `RadioSize` | `lg`                                | No       |
 
 #### Outputs

--- a/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
@@ -1,17 +1,12 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../../docs/common/feedback.md';
 import * as RadioStories from './radio.stories';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Forms/Radio/Guide" tags={['pending']}/>
+<Meta title="Components/Forms/Radio/Guide"/>
 
 # Radio
 
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
-
 <p class="standfirst">Selection control for choosing from a predefined set of options.</p>
-
-![example](docs/forms/radio/example.png)
 
 ## Usage
 
@@ -24,10 +19,7 @@ Use a radio group when you want the user to make a single selection from 2 or mo
 Import the radio components into your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgRadioComponent, etc. ],
-});
+import { LgRadioComponent } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -46,14 +38,10 @@ A radio button contains a circular toggle and a label, and will always appear in
 
 ### Do
 
-![do](docs/forms/radio/do.png)
-
 1. **Do** use when only one item can be selected from a list.
 2. **Do** lay out the options vertically, with one choice per line.
 
 ### Don't
-
-![dont](docs/forms/radio/dont.png)
 
 1. **Don't** use when multiple items from a list can be selected, instead use checkboxes.
 2. **Don't** use radio buttons when the preset options is a long list (more than 5) and space is limited, use the select component instead.
@@ -80,7 +68,7 @@ A radio button contains a circular toggle and a label, and will always appear in
 | `name`            | HTML name attribute                                                                                                           | `string`    | `null`                              | Yes      |
 | `value`           | HTML value attribute                                                                                                          | `string`    | `null`                              | Yes      |
 | `ariaDescribedBy` | HTML ID for the corresponding element that describes the radio, if not provided it will use the hint field where appropriate  | `boolean`   | `null`                              | No       |
-| `size`            | The size of the radio button                                                                                                  | `RadioSize` | `sm`                                | No       |
+| `size`            | The size of the radio button                                                                                                  | `RadioSize` | `lg`                                | No       |
 
 #### Outputs
 

--- a/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
@@ -26,6 +26,19 @@ and in your HTML:
 
 <Source of={RadioStories.Radio} />
 
+### Optional fields
+
+For optional fields, use a `<span>` element with the `lg-label--optional` class to indicate that the field is not required:
+
+```html
+<lg-radio-group formControlName="colour">
+  Favourite colour
+  <span class="lg-label--optional">(optional)</span>
+  <lg-radio-button value="red">Red</lg-radio-button>
+  <lg-radio-button value="blue">Blue</lg-radio-button>
+</lg-radio-group>
+```
+
 ## How it works
 
 A radio button contains a circular toggle and a label, and will always appear in a radio group with a minimum of 2 buttons.

--- a/projects/canopy/src/lib/forms/radio/docs/radio/radio.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/docs/radio/radio.stories.ts
@@ -14,6 +14,9 @@ const formTemplate = `
 <form [formGroup]="form">
   <lg-radio-group [inline]="inline" [focus]="focus" formControlName="color">
     {{ label }}
+    @if (optional) {
+      <span class="lg-label--optional">(optional)</span>
+    }
     @if (hint) {
       <lg-hint>{{ hint }}</lg-hint>
     }
@@ -44,6 +47,7 @@ class ReactiveFormRadioComponent {
   @Input() focus = false;
   @Input() label: string;
   @Input() hint: string;
+  @Input() optional: boolean;
   @Input()
   set disabled(isDisabled: boolean) {
     if (isDisabled === true) {
@@ -248,6 +252,7 @@ export const Radio = {
       <lg-reactive-form-radio
         [disabled]="disabled"
         [hint]="hint"
+        [optional]="optional"
         [inline]="inline"
         [size]="size"
         [label]="label"
@@ -260,10 +265,11 @@ export const Radio = {
   args: {
     disabled: false,
     inline: false,
-    size: 'sm',
+    size: 'lg',
     focus: false,
-    label: 'Color',
-    hint: 'Please select a color',
+    label: 'Colour',
+    hint: 'Please select a colour',
+    optional: false,
   },
   parameters: {
     docs: {

--- a/projects/canopy/src/lib/forms/radio/docs/segment/guide.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/segment/guide.mdx
@@ -1,16 +1,11 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../../docs/common/feedback.md';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Forms/Segment/Guide" tags={['pending']}/>
+<Meta title="Components/Forms/Segment/Guide" />
 
 # Segment
 
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
-
 <p class="standfirst">The segment control can be used on forms where the user is required to make a conscious decision between several choices (min 2, max 5) and vertical space on desktop is limited.</p>
-
-![example](docs/segment/example.png)
 
 ## Usage
 
@@ -23,10 +18,10 @@ The segment component is a variant of the radio component.
 Import the radio components into your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgRadioComponent, etc. ],
-});
+import {
+   LgRadioGroupComponent,
+   LgRadioButtonComponent,
+ } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -53,14 +48,10 @@ The segment control is made up of a segment group and segment buttons. A segment
 
 ### Do
 
-![do](docs/segment/do.png)
-
 1. **Do** use when only one option can be selected from multiple options and where vertical space is limited.
 2. **Do** use the vertical variant on mobile, when space may not permit use of the horizontal variant.
 
 ### Don't
-
-![dont](docs/segment/dont.png)
 
 1. **Don't** use when multiple items from a list can be selected, instead use checkboxes.
 2. **Don't** use when the preset options is a long list (more than five), use the select component instead.

--- a/projects/canopy/src/lib/forms/radio/docs/segment/segment.stories.ts
+++ b/projects/canopy/src/lib/forms/radio/docs/segment/segment.stories.ts
@@ -14,6 +14,9 @@ import { LgHintComponent } from '../../../hint';
 const segmentTemplate = `
 <lg-segment-group [inline]="inline" [focus]="focus" [stack]="stack" formControlName="color">
   {{ label }}
+  @if (optional) {
+    <span class="lg-label--optional">(optional)</span>
+  }
   @if (hint) {
     <lg-hint>{{ hint }}</lg-hint>
   }
@@ -39,6 +42,7 @@ class ReactiveFormSegmentComponent {
 
   @Input() label: string;
   @Input() hint: string;
+  @Input() optional: boolean;
   @Input() secondButtonLabel: string;
   @Input() stack: RadioStackBreakpoint;
   @Input() focus: boolean;
@@ -67,7 +71,6 @@ class ReactiveFormSegmentComponent {
 
 export default {
   title: 'Components/Forms/Segment/Examples',
-  tags: [ 'pending' ],
   component: LgRadioGroupComponent,
   decorators: [
     moduleMetadata({
@@ -235,6 +238,7 @@ export const SegmentButtons = {
         [focus]="focus"
         [label]="label"
         [hint]="hint"
+        [optional]="optional"
         [secondButtonLabel]="secondButtonLabel"
         (segmentChange)="segmentChange($event)"
         (segmentBlur)="segmentBlur($event)">
@@ -245,8 +249,9 @@ export const SegmentButtons = {
     disabled: false,
     stack: false,
     focus: false,
-    label: 'Color',
-    hint: 'Please select a color',
+    label: 'Colour',
+    hint: 'Please select a colour',
+    optional: false,
   },
   parameters: {
     docs: {

--- a/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
@@ -2,22 +2,23 @@
 
 .lg-radio-button--segment {
   display: flex;
-  flex-grow: 1;
-  flex-basis: auto;
-  align-items: stretch;
-  padding: 0 var(--space-1);
-  margin: var(--space-1) 0;
+  min-height: var(--segment-button-common-min-height);
+  padding: var(--segment-button-common-padding-y) var(--segment-button-common-padding-x);
+  justify-content: center;
+  align-items: center;
+  border-radius: var(--segment-button-common-border-radius);
+  background: var(--segment-button-rest-background-colour);
+  transition: all var(--animation-duration) var(--animation-fn);
 
-  + .lg-radio-button--segment {
-    border-left: var(--radio-segment-separator-border-width) solid
-      var(--radio-segment-separator-border-color);
+  @include mixins.lg-breakpoint('md', 'max-width') {
+    margin-bottom: var(--segment-control-common-gap);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .lg-radio-button__label {
-    display: flex;
-    padding: var(--space-1) var(--space-4);
-    border-radius: var(--border-radius-sm);
-    min-width: var(--radio-segment-label-min-width);
     flex-grow: 1;
     text-align: center;
     align-items: center;
@@ -30,42 +31,42 @@
     }
   }
 
-  &.lg-radio-button--error .lg-radio-button__input:checked + .lg-radio-button__label {
-    background-color: var(--form-error-color);
-    color: var(--radio-color);
+  &:has(.lg-radio-button__input:checked) {
+    background: var(--segment-button-active-background-colour);
+    color: var(--segment-button-active-colour);
+    transition: all var(--animation-duration) var(--animation-fn);
   }
 
-  .lg-radio-button__input {
-    &:checked + .lg-radio-button__label {
-      background-color: var(--radio-bg-color);
-      color: var(--radio-color);
-      transition: all var(--animation-duration) var(--animation-fn);
-    }
+  &:has(.lg-radio-button__input:disabled:checked) {
+    background: var(--segment-button-active-background-colour);
+    color: var(--segment-button-active-colour);
+  }
 
-    &:disabled:checked + .lg-radio-button__label {
-      background-color: var(--radio-disabled-color);
-      color: var(--radio-color);
-    }
+  &:has(.lg-radio-button__input:disabled) {
+    background: var(--segment-button-disabled-background-colour);
+    color: var(--segment-button-disabled-colour);
+    cursor: not-allowed;
+  }
 
-    &:disabled + .lg-radio-button__label {
-      color: var(--disabled-color);
-      cursor: not-allowed;
-    }
+  &:has(.lg-radio-button__input:hover:not(:checked)) {
+    color: var(--segment-button-hover-colour);
+    border-radius: var(--segment-button-common-border-radius);
+    background: var(--segment-button-hover-background-colour);
+    transition: all var(--animation-duration) var(--animation-fn);
+  }
 
-    &:hover + .lg-radio-button__label {
-      background-color: var(--radio-segment-hover-bg-color);
-      color: var(--radio-color);
-      transition: all var(--animation-duration) var(--animation-fn);
-    }
+  &:has(.lg-radio-button__input:focus-visible) {
+    color: var(--segment-button-focus-colour);
+    border-radius: var(--segment-button-common-border-radius);
+    box-shadow: inset 0 0 0 var(--segment-button-focus-border-width)
+      var(--segment-control-focus-border-colour);
+    background: var(--segment-button-focus-background-colour);
+  }
 
-    &:focus-visible + .lg-radio-button__label {
-      @include mixins.lg-focus-outline;
-    }
-
-    &:focus-visible:hover + .lg-radio-button__label {
-      background-color: var(--radio-bg-color);
-      @include mixins.lg-focus-outline;
-    }
+  &:has(.lg-radio-button__input:focus-visible:hover) {
+    color: var(--segment-button-hover-colour);
+    border-radius: var(--segment-button-common-border-radius);
+    background: var(--segment-button-hover-background-colour);
   }
 
   $stack-breakpoints: 'md', 'lg' !default;
@@ -88,16 +89,6 @@
       + .lg-radio-button--segment {
         @include mixins.lg-breakpoint($stack-breakpoint, 'max-width') {
           border-left: 0;
-        }
-
-        &::before {
-          @include mixins.lg-breakpoint($stack-breakpoint, 'max-width') {
-            content: '';
-            display: inline-block;
-            width: 100%;
-            height: var(--radio-segment-separator-border-width);
-            background-color: var(--radio-segment-separator-border-color);
-          }
         }
       }
     }

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -1,17 +1,24 @@
 @use '../../../styles/mixins';
 
 .lg-radio-button__hint {
-  margin-top: var(--space-3);
-  padding-left: var(--space-6);
+  padding-left: var(--radio-scale-lg-gap);
+}
+
+.lg-radio-button__label--sm ~ .lg-radio-button__hint {
+  padding-left: var(--radio-scale-sm-gap);
 }
 
 .lg-radio-button--radio {
   display: block;
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--radio-group-lg-gap);
+}
 
-  &:last-of-type {
-    margin-bottom: var(--space-3);
-  }
+.lg-radio-button--radio.lg-radio-button--sm {
+  margin-bottom: var(--radio-group-sm-gap);
+}
+
+.lg-radio-button--radio:last-of-type {
+  margin-bottom: 0;
 }
 
 .lg-radio-button__input {
@@ -22,14 +29,18 @@
   display: flex;
   position: relative;
   font-weight: var(--font-weight-400);
-  padding-left: calc(var(--radio-outer-lg-width) + var(--space-2));
 
-  .lg-radio-button__input:disabled + & {
-    color: var(--disabled-color);
+  &--sm {
+    padding-left: var(--radio-scale-sm-gap);
   }
 
-  .lg-radio-button--error & {
-    color: var(--form-error-color);
+  &--lg {
+    padding-left: var(--radio-scale-lg-gap);
+  }
+
+  .lg-radio-button__input:disabled + & {
+    color: var(--radio-disabled-label-colour);
+    pointer-events: none;
   }
 }
 
@@ -38,38 +49,51 @@
   left: 0;
   top: 0;
   bottom: 0;
-  display: inline-block;
+  display: flex;
   height: var(--_radio-outer-height);
   width: var(--_radio-outer-width);
-  background-color: var(--colour-greyscale-0);
-  border-radius: 50%;
-  border: var(--border-width) solid var(--radio-border-color);
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: var(--radio-common-border-radius);
+  border: var(--radio-rest-control-border-width) solid
+    var(--radio-rest-control-border-colour);
+  background: var(--radio-rest-control-background-colour);
   margin: auto var(--space-4) auto 0;
   position: absolute;
 
   .lg-radio-button__input:focus-visible + & {
-    border-color: var(--border-focus-color);
-    @include mixins.lg-focus-outline;
+    border: var(--radio-focus-control-border-width) solid
+      var(--radio-focus-control-border-colour);
+    background: var(--radio-focus-control-background-colour);
+    box-shadow: 0 0 0 var(--radio-focus-control-border-width)
+      var(--radio-focus-control-background-colour);
   }
 
-  .lg-radio-button:disabled & {
-    border-color: var(--border-disabled-color);
+  .lg-radio-button__input:disabled + & {
+    border: var(--text-input-disabled-border-width) solid
+      var(--radio-disabled-control-border-colour);
+    background: var(--radio-disabled-control-background-colour);
   }
 
   .lg-radio-button--error:hover &,
   .lg-radio-button--error & {
-    border-color: var(--form-error-border-color);
+    border: var(--radio-error-control-border-width) solid
+      var(--radio-error-control-border-colour);
+    background: var(--radio-error-control-background-colour);
+    box-shadow: 0 0 0 var(--radio-error-control-border-width)
+      var(--radio-error-control-background-colour);
   }
 }
 
 .lg-radio-button__label--sm::before {
-  --_radio-outer-height: var(--radio-outer-height);
-  --_radio-outer-width: var(--radio-outer-width);
+  --_radio-outer-height: var(--radio-scale-sm-control-size);
+  --_radio-outer-width: var(--radio-scale-sm-control-size);
 }
 
 .lg-radio-button__label--lg::before {
-  --_radio-outer-height: var(--radio-outer-lg-height);
-  --_radio-outer-width: var(--radio-outer-lg-width);
+  --_radio-outer-height: var(--radio-scale-lg-control-size);
+  --_radio-outer-width: var(--radio-scale-lg-control-size);
 }
 
 .lg-radio-button__label::after {
@@ -82,28 +106,32 @@
   width: var(--_radio-inner-width);
   margin: auto var(--_radio-inner-margin-horizontal);
   border-radius: 50%;
+}
 
-  .lg-radio-button__input:checked + & {
-    background-color: var(--radio-bg-color);
-  }
+.lg-radio-button__input:checked + .lg-radio-button__label::after {
+  background-color: var(--radio-rest-indicator-colour);
+}
 
-  .lg-radio-button__input:disabled:checked + & {
-    background-color: var(--radio-disabled-color);
-  }
+.lg-radio-button__input:checked + .lg-radio-button__label:hover::after {
+  background-color: var(--radio-hover-indicator-colour);
+}
 
-  .lg-radio-button--error .lg-radio-button__input:checked + & {
-    background-color: var(--form-error-border-color);
-  }
+.lg-radio-button__input:disabled:checked + .lg-radio-button__label::after {
+  background-color: var(--radio-disabled-indicator-colour);
+}
+
+.lg-radio-button--error .lg-radio-button__input:checked + .lg-radio-button__label::after {
+  background-color: var(--radio-error-indicator-colour);
 }
 
 .lg-radio-button__label--sm::after {
-  --_radio-inner-margin-horizontal: calc(var(--radio-inner-height) / 2);
-  --_radio-inner-height: var(--radio-inner-height);
-  --_radio-inner-width: var(--radio-inner-width);
+  --_radio-inner-margin-horizontal: calc(var(--radio-scale-sm-control-size) / 4);
+  --_radio-inner-height: calc(var(--radio-scale-sm-control-size) / 2);
+  --_radio-inner-width: calc(var(--radio-scale-sm-control-size) / 2);
 }
 
 .lg-radio-button__label--lg::after {
-  --_radio-inner-margin-horizontal: calc(var(--radio-inner-lg-height) / 2);
-  --_radio-inner-height: var(--radio-inner-lg-height);
-  --_radio-inner-width: var(--radio-inner-lg-width);
+  --_radio-inner-margin-horizontal: calc(var(--radio-scale-lg-control-size) / 4);
+  --_radio-inner-height: calc(var(--radio-scale-lg-control-size) / 2);
+  --_radio-inner-width: calc(var(--radio-scale-lg-control-size) / 2);
 }

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.scss
@@ -29,6 +29,7 @@
   display: flex;
   position: relative;
   font-weight: var(--font-weight-400);
+  cursor: pointer;
 
   &--sm {
     padding-left: var(--radio-scale-sm-gap);
@@ -40,6 +41,7 @@
 
   .lg-radio-button__input:disabled + & {
     color: var(--radio-disabled-label-colour);
+    cursor: not-allowed;
     pointer-events: none;
   }
 }

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.spec.ts
@@ -46,7 +46,7 @@ const hintTestId = 'test-hint-id';
 class TestRadioButtonComponent {
   private fb = inject(UntypedFormBuilder);
   form: UntypedFormGroup;
-  @Input() size: RadioSize = 'sm';
+  @Input() size: RadioSize = 'lg';
 
   constructor() {
     this.form = this.fb.group({

--- a/projects/canopy/src/lib/forms/radio/radio-button.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-button.component.ts
@@ -68,7 +68,7 @@ export class LgRadioButtonComponent implements OnInit {
   @Input() id = `lg-radio-button-${++nextUniqueId}`;
   @Input() name: string;
   @Input() value: boolean | string;
-  @Input() size: RadioSize = 'sm';
+  @Input() size: RadioSize = 'lg';
   @Input() ariaDescribedBy: string;
 
   _stacked: RadioStackBreakpoint;
@@ -103,6 +103,12 @@ export class LgRadioButtonComponent implements OnInit {
   @HostBinding('class.lg-radio-button--error')
   public get errorClass() {
     return this.errorState.isControlInvalid(this.control, this.controlContainer);
+  }
+  @HostBinding('class.lg-radio-button--sm') get sizeSmClass() {
+    return this.size === 'sm';
+  }
+  @HostBinding('class.lg-radio-button--lg') get sizeLgClass() {
+    return this.size === 'lg';
   }
 
   _hintElement: LgHintComponent;

--- a/projects/canopy/src/lib/forms/radio/radio-group--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-group--segment.component.scss
@@ -1,21 +1,57 @@
 @use '../../../styles/mixins';
 
 .lg-radio-group__segment {
-  display: inline-flex;
-  border: var(--border-width) solid var(--radio-border-color);
-  border-radius: var(--border-radius-sm);
+  display: block;
+  padding: var(--segment-control-common-padding-y) var(--segment-control-common-padding-x);
+  align-items: center;
+  gap: var(--segment-control-common-gap);
+  border-radius: var(--segment-control-common-border-radius);
+  border: var(--segment-control-common-border-width) solid
+    var(--segment-control-common-border-colour);
+  background: var(--segment-control-common-background-colour);
+  grid-auto-flow: row;
+  grid-auto-columns: 1fr;
+
+  @include mixins.lg-breakpoint('md') {
+    display: inline-grid;
+    grid-auto-flow: column;
+  }
 
   .lg-radio-group--error & {
-    border-color: var(--form-error-color);
+    box-shadow:
+      inset 0 0 0 var(--segment-control-error-border-width)
+        var(--segment-control-error-border-colour),
+      0 0 0 var(--text-input-rest-border-width)
+        var(--segment-control-common-background-colour);
+    border: var(--text-input-rest-border-width) solid
+      var(--segment-control-common-background-colour);
+    outline: 0;
+  }
+
+  &:has(.lg-radio-button__input:disabled) {
+    border: none;
   }
 }
 
-$stack-breakpoints: 'md', 'lg' !default;
+$stack-breakpoints: (
+  'md': 'lg',
+  'lg': 'xl',
+) !default;
 
-@each $stack-breakpoint in $stack-breakpoints {
+@each $stack-breakpoint, $max-breakpoint in $stack-breakpoints {
   .lg-radio-group--stack-#{$stack-breakpoint} .lg-radio-group__segment {
-    @include mixins.lg-breakpoint($stack-breakpoint, 'max-width') {
+    @include mixins.lg-breakpoint($stack-breakpoint, 'range', $max-breakpoint) {
       display: block;
+    }
+
+    .lg-radio-button--segment {
+      @include mixins.lg-breakpoint($stack-breakpoint, 'range', $max-breakpoint) {
+        margin-bottom: var(--segment-control-common-gap);
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
     }
   }
 }

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.html
@@ -3,10 +3,13 @@
   [attr.tabindex]="focus ? '-1' : null"
   [lgFocus]="focus"
   >
-  <legend lg-label [attr.for]="id" lgMarginBottom="3">
+  <legend lg-label [attr.for]="id">
     <ng-content />
   </legend>
+  <ng-content select=".lg-label--optional" />
   <ng-content select="lg-hint" />
+
+  <ng-content select="lg-validation" />
 
   @if (variant === 'segment') {
     <div class="lg-radio-group__segment">
@@ -15,8 +18,5 @@
   } @else {
     <ng-content select="lg-radio-button, lg-filter-button" />
   }
-
-
-  <ng-content select="lg-validation" />
 </fieldset>
 <ng-content select="lg-hint" />

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.scss
@@ -6,8 +6,13 @@
 .lg-radio-group--inline {
   .lg-radio-button {
     display: inline-block;
-    margin-right: var(--space-5);
+    margin-right: var(--radio-group-lg-gap);
+    margin-bottom: 0;
     vertical-align: top;
+  }
+
+  .lg-radio-button--sm {
+    margin-right: var(--radio-group-sm-gap);
   }
 
   .lg-radio-button:last-of-type {

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
@@ -29,12 +29,12 @@ const hintTestId = 'test-hint-id';
       <lg-radio-group formControlName="color">
         Color
         <lg-hint id="${hintTestId}">Choose your favourite</lg-hint>
-        <lg-radio-button value="red">Red</lg-radio-button>
-        <lg-radio-button value="yellow">Yellow</lg-radio-button>
-        <lg-radio-button value="blue">Blue</lg-radio-button>
         @if (isControlInvalid(color, testForm)) {
           <lg-validation id="${validationTestId}"> Error </lg-validation>
         }
+        <lg-radio-button value="red">Red</lg-radio-button>
+        <lg-radio-button value="yellow">Yellow</lg-radio-button>
+        <lg-radio-button value="blue">Blue</lg-radio-button>
       </lg-radio-group>
     </form>
   `,

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.spec.ts
@@ -27,7 +27,7 @@ const hintTestId = 'test-hint-id';
   template: `
     <form (ngSubmit)="login()" [formGroup]="form" #testForm="ngForm">
       <lg-radio-group formControlName="color">
-        Color
+        Colour
         <lg-hint id="${hintTestId}">Choose your favourite</lg-hint>
         @if (isControlInvalid(color, testForm)) {
           <lg-validation id="${validationTestId}"> Error </lg-validation>

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.ts
@@ -18,7 +18,6 @@ import { LgDomService } from '../../utils';
 import { LgHintComponent } from '../hint';
 import { LgErrorStateMatcher } from '../validation';
 import { LgValidationComponent } from '../validation';
-import { LgMarginDirective } from '../../spacing';
 import { LgLabelComponent } from '../label';
 import { LgFocusDirective } from '../../focus';
 
@@ -32,7 +31,7 @@ let uniqueId = 0;
   templateUrl: './radio-group.component.html',
   styleUrls: [ './radio-group.component.scss', './radio-group--segment.component.scss' ],
   encapsulation: ViewEncapsulation.None,
-  imports: [ LgFocusDirective, LgLabelComponent, LgMarginDirective ],
+  imports: [ LgFocusDirective, LgLabelComponent ],
 })
 export class LgRadioGroupComponent implements ControlValueAccessor, AfterContentInit {
   private control = inject(NgControl, { self: true, optional: true });
@@ -163,10 +162,21 @@ export class LgRadioGroupComponent implements ControlValueAccessor, AfterContent
   }
 
   ngAfterContentInit(): void {
-    if (this.radios && this.stack) {
+    if (this.radios) {
       this.radios.toArray().forEach(radio => {
         radio.stacked = this.stack;
       });
+
+      // Validate segment button count
+      if (this.variant === 'segment') {
+        const count = this.radios.length;
+
+        if (count < 2 || count > 5) {
+          console.warn(
+            `LgRadioGroupComponent: Segment controls must have between 2 and 5 options. Current count: ${count}`,
+          );
+        }
+      }
     }
   }
 
@@ -174,7 +184,7 @@ export class LgRadioGroupComponent implements ControlValueAccessor, AfterContent
     this._value = value;
   }
 
-  public onTouched(_?: any) {}
+  public onTouched(): void {}
 
   public writeValue(obj: string): void {
     this.value = obj;

--- a/projects/canopy/src/lib/forms/select/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/select/docs/guide.mdx
@@ -1,17 +1,12 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../docs/common/feedback.md';
 import * as SelectStories from './select.stories';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Forms/Select/Guide" tags={['pending']}/>
+<Meta title="Components/Forms/Select/Guide" />
 
 # Select
 
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
-
 <p class="standfirst">A drop down list that enables the user to choose between several options.</p>
-
-![example](docs/select/example.png)
 
 ## Usage
 
@@ -20,10 +15,7 @@ Use this component when users need to make a single selection from a list of opt
 Import the select component and directive in your application:
 
 ```js
-@NgModule({
-  ...,
-  imports: [ ..., LgSelectFieldComponent, LgSelectDirective ],
-});
+import { LgSelectFieldComponent, LgSelectDirective } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -48,14 +40,10 @@ While the select box is styled by Canopy, the select menu styling is handled by 
 
 ### Do
 
-![do](docs/select/do.png)
-
 1. **Do** use a select component when the preset options is a long list (more than five) and space is limited.
 2. **Do** list options in a predictable format, such as alphabetical, chronological, or most frequently used.
 
 ### Don't
-
-![dont](docs/select/dont.png)
 
 1. **Don't** use a select component when typing may be faster, such as date of birth or postcode; use text input instead.
 2. **Don't** use a select component as a way of presenting a single selection; use a checkbox instead.

--- a/projects/canopy/src/lib/forms/select/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/select/docs/guide.mdx
@@ -22,6 +22,21 @@ and in your HTML:
 
 <Source of={SelectStories.Select} />
 
+### Optional fields
+
+For optional fields, use a `<span>` element with the `lg-label--optional` class to indicate that the field is not required:
+
+```html
+<lg-select-field>
+  Country
+  <span class="lg-label--optional">(optional)</span>
+  <select lgSelect formControlName="country">
+    <option value="">Select</option>
+    <option value="uk">United Kingdom</option>
+  </select>
+</lg-select-field>
+```
+
 ## How it works
 
 The select component controls custom select box styling and linking the label and field.

--- a/projects/canopy/src/lib/forms/select/docs/select.stories.ts
+++ b/projects/canopy/src/lib/forms/select/docs/select.stories.ts
@@ -13,6 +13,9 @@ import { LgSelectDirective } from '../select.directive';
 const template = `
 <lg-select-field [block]="block">
   {{ label }}
+  @if (optional) {
+    <span class="lg-label--optional">(optional)</span>
+  }
   @if (hint) {
     <lg-hint>{{ hint }}</lg-hint>
   }
@@ -39,6 +42,7 @@ class ReactiveFormComponent {
 
   @Input() block: boolean;
   @Input() hint: string;
+  @Input() optional: boolean;
   @Input() label: string;
   @Input() options: Array<string>;
 
@@ -69,7 +73,6 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Forms/Select/Examples',
-  tags: [ 'pending' ],
   component: LgSelectFieldComponent,
   decorators: [
     moduleMetadata({
@@ -98,6 +101,11 @@ export default {
       },
     },
     _hintElement: {
+      table: {
+        disable: true,
+      },
+    },
+    _optionalElement: {
       table: {
         disable: true,
       },
@@ -134,6 +142,7 @@ export const Select = {
         (selectChange)="selectChange($event)"
         [block]="block"
         [disabled]="disabled"
+        [optional]="optional"
         [hint]="hint"
         [label]="label"
         [options]="options"
@@ -141,8 +150,9 @@ export const Select = {
     `,
   }),
   args: {
-    label: 'Color',
-    hint: 'Please select a color',
+    label: 'Colour',
+    hint: 'Please select a colour',
+    optional: false,
     block: false,
     options: [ 'Red', 'Blue', 'Green', 'Yellow' ],
     disabled: false,

--- a/projects/canopy/src/lib/forms/select/select-field.component.html
+++ b/projects/canopy/src/lib/forms/select/select-field.component.html
@@ -1,11 +1,12 @@
 <label lg-label>
   <ng-content />
 </label>
+<ng-content select=".lg-label--optional" />
 <ng-content select="lg-hint" />
+<ng-content select="lg-validation" />
 <div class="lg-select-field__outer">
   <div class="lg-select-field__inner" [class.lg-select-field__inner--block]="block">
     <ng-content select="[lgSelect]" />
     <lg-icon class="lg-select-field__icon" name="chevron-down" />
   </div>
 </div>
-<ng-content select="lg-validation" />

--- a/projects/canopy/src/lib/forms/select/select-field.component.scss
+++ b/projects/canopy/src/lib/forms/select/select-field.component.scss
@@ -12,7 +12,6 @@
 
 .lg-select-field__inner {
   display: inline-block;
-  background-color: var(--colour-greyscale-0);
   max-width: 100%;
   position: relative;
 
@@ -29,8 +28,8 @@
   position: absolute;
   right: 0;
   top: calc(50% - var(--icon-width) / 2);
-  margin-left: var(--space-4);
-  margin-right: var(--space-4);
+  margin-left: var(--text-input-common-addon-button-gap);
+  margin-right: var(--text-input-common-addon-button-gap);
   pointer-events: none;
 
   .lg-select-field--error & {

--- a/projects/canopy/src/lib/forms/select/select-field.component.spec.ts
+++ b/projects/canopy/src/lib/forms/select/select-field.component.spec.ts
@@ -63,11 +63,11 @@ describe('LgSelectFieldComponent', () => {
     fixture = MockRender(`
       <lg-select-field [block]="${block}">
         Label
+        <lg-hint id="${hintId}">Hint</lg-hint>
+        <lg-validation id="${errorId}">Error</lg-validation>
         <select lgSelect>
           <option value="red">Red</option>
         </select>
-        <lg-hint id="${hintId}">Hint</lg-hint>
-        <lg-validation id="${errorId}">Error</lg-validation>
       </lg-select-field>
     `);
 

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -3,6 +3,7 @@
 .lg-select {
   @include mixins.lg-typography-default;
 
+  cursor: pointer;
   border-radius: var(--text-input-common-border-radius);
   border: var(--text-input-rest-border-width) solid var(--select-rest-border-colour);
   background: var(--select-rest-background-colour);

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -3,39 +3,52 @@
 .lg-select {
   @include mixins.lg-typography-default;
 
-  border: solid var(--border-width) var(--border-color);
-  border-radius: var(--border-radius-sm);
-  padding: var(--select-vertical-padding)
-    calc(var(--select-icon-width) + (2 * var(--space-4))) var(--select-vertical-padding)
-    var(--space-4);
-  background-color: var(--colour-greyscale-0);
+  border-radius: var(--text-input-common-border-radius);
+  border: var(--text-input-rest-border-width) solid var(--select-rest-border-colour);
+  background: var(--select-rest-background-colour);
+  min-height: var(--input-common-scale-xxl);
+  max-height: var(--input-common-scale-xxl);
+  padding: var(--text-input-common-padding-y)
+    calc(var(--icon-width) + 2 * var(--text-input-common-padding-x))
+    var(--text-input-common-padding-y) var(--text-input-common-padding-x);
+  color: var(--select-rest-colour);
   outline: 0;
   appearance: none;
   max-width: 100%;
 
   &:hover {
+    color: var(--select-hover-colour);
     border-color: var(--border-hover-color);
   }
 
   &:focus-visible {
-    @include mixins.lg-focus-outline();
+    color: var(--select-focus-colour);
+    background: var(--select-focus-background-colour);
+    box-shadow:
+      inset 0 0 0 var(--select-focus-border-width) var(--select-focus-border-colour),
+      0 0 0 var(--text-input-rest-border-width) var(--select-focus-background-colour);
+    border: var(--text-input-rest-border-width) solid
+      var(--select-focus-background-colour);
+    outline: 0;
   }
 
   &:disabled {
-    color: var(--disabled-color);
-    background-color: var(--background-disabled-color);
-    border-color: var(--border-disabled-color);
+    color: var(--select-disabled-colour);
+    border: var(--text-input-disabled-border-width) solid
+      var(--select-disabled-border-colour);
+    background: var(--select-disabled-background-colour);
+    pointer-events: none;
   }
 
   &--error,
   &--error:hover {
-    color: var(--form-error-color);
-    border-color: var(--form-error-border-color);
-
-    &:focus-visible {
-      color: inherit;
-      border-color: inherit;
-    }
+    color: var(--select-error-colour);
+    background: var(--select-error-background-colour);
+    box-shadow:
+      inset 0 0 0 var(--select-error-border-width) var(--select-error-border-colour),
+      0 0 0 var(--text-input-rest-border-width) var(--select-error-background-colour);
+    border: var(--text-input-rest-border-width) solid
+      var(--select-error-background-colour);
   }
 
   &--block {

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/checkbox-group.stories.ts
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/checkbox-group.stories.ts
@@ -14,11 +14,14 @@ const formTemplate = `
 <form [formGroup]="form">
   <lg-checkbox-group [inline]="inline" [focus]="focus" formControlName="colors">
     {{ label }}
+    @if (optional) {
+      <span class="lg-label--optional">(optional)</span>
+    }
     @if (hint) {
       <lg-hint>{{ hint }}</lg-hint>
     }
-    <lg-toggle value="red" (blur)="checkboxBlur.emit($event)">Red</lg-toggle>
-    <lg-toggle value="yellow" (blur)="checkboxBlur.emit($event)">Yellow</lg-toggle>
+    <lg-toggle value="red" [size]="size" (blur)="checkboxBlur.emit($event)">Red</lg-toggle>
+    <lg-toggle value="yellow" [size]="size" (blur)="checkboxBlur.emit($event)">Yellow</lg-toggle>
   </lg-checkbox-group>
 </form>
 `;
@@ -40,6 +43,8 @@ class ReactiveFormComponent {
   @Input() focus = false;
   @Input() label: string;
   @Input() hint: string;
+  @Input() optional: boolean;
+  @Input() size = 'lg';
   @Input()
   set disabled(isDisabled: boolean) {
     if (isDisabled === true) {
@@ -108,6 +113,21 @@ export default {
         defaultValue: {
           summary: false,
         },
+      },
+    },
+    size: {
+      options: [ 'sm', 'lg' ],
+      description: 'The size of the checkbox.',
+      table: {
+        type: {
+          summary: [ 'sm', 'lg' ],
+        },
+        defaultValue: {
+          summary: 'lg',
+        },
+      },
+      control: {
+        type: 'select',
       },
     },
     disabled: {
@@ -204,9 +224,11 @@ export const CheckboxGroup = {
       <lg-reactive-form
         [disabled]="disabled"
         [hint]="hint"
+        [optional]="optional"
         [inline]="inline"
         [focus]="focus"
         [label]="label"
+        [size]="size"
         (checkboxChange)="checkboxChange($event)"
         (checkboxBlur)="checkboxBlur($event)">
       </lg-reactive-form>
@@ -216,8 +238,10 @@ export const CheckboxGroup = {
     inline: false,
     disabled: false,
     focus: false,
-    label: 'Color',
-    hint: 'Please select all colors that apply',
+    label: 'Colour',
+    hint: 'Please select all colours that apply',
+    optional: false,
+    size: 'lg',
   },
   parameters: {
     docs: {

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/checkbox.stories.ts
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/checkbox.stories.ts
@@ -6,7 +6,6 @@ import { createToggleStory, ReactiveToggleFormComponent } from '../toggle.storie
 
 export default {
   title: 'Components/Forms/Checkbox/Examples',
-  tags: [ 'pending' ],
   component: LgToggleComponent,
   decorators: [
     moduleMetadata({
@@ -177,7 +176,7 @@ const code = `
 <lg-checkbox
   formControlName="umbrella"
   [value]="true"
-  [size]="sm"
+  [size]="'lg'"
   [checked]="umbrella.value"
   [focus]="focus"
   (blur)="toggleBlur.emit($event)"
@@ -193,7 +192,7 @@ export const Checkbox = {
     disabled: false,
     inline: false,
     focus: false,
-    size: 'sm',
+    size: 'lg',
     label: 'I will bring my Umbrella if it is raining',
     variant: 'checkbox',
   },

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
@@ -99,7 +99,7 @@ On click, the checkbox is filled with a 'tick' to indicate a state of confirmati
 | `name`            | HTML name attribute                                                                                                             | `string`                      | `null`                        | Yes      |
 | `value`           | HTML value attribute                                                                                                            | `string`                      | `null`                        | Yes      |
 | `focus`           | Set the focus on the checkbox                                                                                                   | `boolean`                     | `null`                        | No       |
-| `ariaDescribedBy` | HTML ID for the corresponding element that describes the checkbox, if not provided it will use the hint field where appropriate | `boolean`                     | `null`                        | No       |
+| `ariaDescribedBy` | HTML ID for the corresponding element that describes the checkbox, if not provided it will use the hint field where appropriate | `string`                      | `null`                        | No       |
 | `size`            | The size of the checkbox                                                                                                        | `'sm'` \| `'lg'`              | `'lg'`                        | No       |
 
 #### Outputs
@@ -119,7 +119,7 @@ On click, the checkbox is filled with a 'tick' to indicate a state of confirmati
 | `value`           | HTML value attribute. Sets the default checked checkbox buttons, must match the values of the checkbox buttons                    | `Array<string>` | `null`                                      | No       |
 | `focus`           | Set the focus on the fieldset                                                                                                     | `boolean`       | `null`                                      | No       |
 | `disabled`        | Set the inner checkboxes to disabled                                                                                              | `boolean`       | `false`                                     | No       |
-| `ariaDescribedBy` | HTML ID for the corresponding element that describes the checkboxes, if not provided it will use the hint field where appropriate | `boolean`       | `null`                                      | No       |
+| `ariaDescribedBy` | HTML ID for the corresponding element that describes the checkboxes, if not provided it will use the hint field where appropriate | `string`        | `null`                                      | No       |
 | `inline`          | If true, displays the checkboxes inline rather than stacked                                                                       | `boolean`       | `false`                                     | No       |
 
 ## Research on this component

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
@@ -54,6 +54,19 @@ and in your HTML:
 </lg-checkbox-group>
 ```
 
+### Optional fields
+
+For optional fields, use a `<span>` element with the `lg-label--optional` class to indicate that the field is not required:
+
+```html
+<lg-checkbox-group formControlName="colors">
+  Select your colours
+  <span class="lg-label--optional">(optional)</span>
+  <lg-toggle value="red">Red</lg-toggle>
+  <lg-toggle value="yellow">Yellow</lg-toggle>
+</lg-checkbox-group>
+```
+
 ## How it works
 
 On click, the checkbox is filled with a 'tick' to indicate a state of confirmation. The checkbox can also be un-checked by clicking again to remove the 'tick'.

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
@@ -1,16 +1,11 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../../docs/common/feedback.md';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Forms/Checkbox/Guide" tags={['pending']}/>
+<Meta title="Components/Forms/Checkbox/Guide" />
 
 # Checkbox
 
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
-
 <p class="standfirst">A checkbox lets the user select or deselect an option.</p>
-
-![example](docs/forms/checkbox/example.png)
 
 ## Usage
 
@@ -27,10 +22,7 @@ The checkbox component is a variant of the toggle component.
 Import the toggle component in your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgToggleComponent ],
-});
+import { LgToggleComponent } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -46,10 +38,7 @@ The checkbox group component is a container which displays the label with an opt
 Import the toggle and checkbox group components in your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgCheckboxGroupComponent, LgToggleComponent ],
-});
+import { LgCheckboxGroupComponent, LgToggleComponent } from '@legal-and-general/canopy';
 ```
 
 and in your HTML:
@@ -73,15 +62,11 @@ On click, the checkbox is filled with a 'tick' to indicate a state of confirmati
 
 ### Do
 
-![do](docs/forms/checkbox/do.png)
-
 1. **Do** use to confirm a response.
 2. **Do** use to help highlight that an action or task is required.
 3. **Do** use to allow the user to choose from multiple options.
 
 ### Don't
-
-![dont](docs/forms/checkbox/dont.png)
 
 1. **Don't** use negative labels.
 2. **Don't** use as part of a dark pattern.
@@ -102,7 +87,7 @@ On click, the checkbox is filled with a 'tick' to indicate a state of confirmati
 | `value`           | HTML value attribute                                                                                                            | `string`                      | `null`                        | Yes      |
 | `focus`           | Set the focus on the checkbox                                                                                                   | `boolean`                     | `null`                        | No       |
 | `ariaDescribedBy` | HTML ID for the corresponding element that describes the checkbox, if not provided it will use the hint field where appropriate | `boolean`                     | `null`                        | No       |
-| `size`            | The size of the checkbox                                                                                                        | `CheckboxSize` (`sm` | `lg`) | `sm`                          | No       |
+| `size`            | The size of the checkbox                                                                                                        | `'sm'` \| `'lg'`              | `'lg'`                        | No       |
 
 #### Outputs
 

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.html
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.html
@@ -1,3 +1,4 @@
+<ng-content select="lg-validation" />
 <input
   (click)="onCheck()"
   (blur)="onBlur($event)"
@@ -33,9 +34,8 @@
         'lg-toggle__checkbox--sm': size === 'sm',
         'lg-toggle__checkbox--lg': size === 'lg',
       }"
-      name="checkmark-heavy"
+      [name]="size === 'sm' ? 'checkmark-heavy' : 'checkmark'"
     />
   }
   <ng-content />
 </label>
-<ng-content select="lg-validation" />

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -14,6 +14,7 @@
   align-items: center;
   position: relative;
   font-weight: var(--font-weight-400);
+  cursor: pointer;
 
   &:has(> .lg-toggle__checkbox:hover) {
     color: var(--checkbox-hover-label-colour);
@@ -21,6 +22,7 @@
 
   .lg-toggle__input:disabled + & {
     color: var(--checkbox-disabled-label-colour);
+    cursor: not-allowed;
   }
 }
 

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -15,30 +15,50 @@
   position: relative;
   font-weight: var(--font-weight-400);
 
-  .lg-toggle__input:disabled + & {
-    color: var(--disabled-color);
+  &:has(> .lg-toggle__checkbox:hover) {
+    color: var(--checkbox-hover-label-colour);
   }
 
-  .lg-toggle--error & {
-    color: var(--form-error-color);
+  .lg-toggle__input:disabled + & {
+    color: var(--checkbox-disabled-label-colour);
   }
 }
 
 .lg-toggle__label > .lg-toggle__checkbox {
-  background-color: var(--colour-greyscale-0);
-  border: var(--border-width) solid var(--toggle-border-color);
   color: transparent;
   font-size: var(--_toggle-icon-font-size);
-  margin: var(--_toggle-icon-margin-top) var(--space-4) auto 0;
+  margin: var(--_toggle-icon-margin-top) var(--checkbox-common-gap) auto 0;
+  border-radius: var(--checkbox-common-border-radius);
+  border: var(--checkbox-rest-control-border-width) solid
+    var(--checkbox-rest-control-border-colour);
+  background: var(--checkbox-rest-control-background-colour);
+
+  &:hover {
+    border: var(--checkbox-rest-control-border-width) solid
+      var(--checkbox-hover-control-border-colour);
+  }
+
+  .lg-toggle__input:disabled + & {
+    border-radius: var(--checkbox-common-border-radius);
+    border: var(--checkbox-disabled-control-border-width) solid
+      var(--checkbox-disabled-control-border-colour);
+    background: var(--checkbox-disabled-control-background-colour);
+  }
 
   &--sm {
     --_toggle-icon-font-size: 0.8rem;
     --_toggle-icon-margin-top: var(--space-1);
+
+    width: var(--checkbox-scale-sm-control-size);
+    height: var(--checkbox-scale-sm-control-size);
   }
 
   &--lg {
     --_toggle-icon-font-size: 1.334rem;
     --_toggle-icon-margin-top: -0.063rem;
+
+    width: var(--checkbox-scale-lg-control-size);
+    height: var(--checkbox-scale-lg-control-size);
   }
 
   &.lg-icon > svg {
@@ -48,12 +68,52 @@
   }
 
   .lg-toggle__input:focus-visible + & {
-    @include mixins.lg-focus-outline();
+    border-radius: var(--checkbox-common-border-radius);
+    border: var(--checkbox-focus-control-border-width) solid
+      var(--checkbox-focus-control-border-colour);
+    background: var(--checkbox-focus-control-background-colour);
+    box-shadow: 0 0 0 var(--checkbox-focus-control-border-width)
+      var(--checkbox-focus-control-background-colour);
+  }
+
+  .lg-toggle--error &,
+  .lg-toggle--error &:hover {
+    border: var(--checkbox-error-control-border-width) solid
+      var(--checkbox-error-control-border-colour);
+    background: var(--checkbox-error-control-background-colour);
+    box-shadow: 0 0 0 var(--checkbox-error-control-border-width)
+      var(--checkbox-error-control-background-colour);
   }
 
   .lg-toggle__input:checked + & {
-    background-color: var(--toggle-bg-color);
-    color: var(--toggle-checkbox-color);
-    border-color: var(--toggle-checkbox-active-border-color);
+    background-color: var(--checkbox-rest-indicator-colour);
+    color: var(--checkbox-rest-control-background-colour);
+    border-color: var(--checkbox-rest-control-border-colour);
+
+    &:hover {
+      background-color: var(--checkbox-hover-indicator-colour);
+      color: var(--checkbox-hover-control-background-colour);
+      border-color: var(--checkbox-hover-control-border-colour);
+    }
+  }
+
+  .lg-toggle__input:checked:disabled + & {
+    background-color: var(--checkbox-disabled-indicator-colour);
+    color: var(--checkbox-disabled-control-background-colour);
+    border-color: var(--checkbox-disabled-control-border-colour);
+  }
+
+  .lg-toggle__input:checked:focus-visible + & {
+    background-color: var(--checkbox-focus-indicator-colour);
+    color: var(--checkbox-focus-control-background-colour);
+    border-color: var(--checkbox-focus-control-border-colour);
+    box-shadow: 0 0 0 var(--checkbox-focus-control-border-width)
+      var(--checkbox-focus-control-background-colour);
+  }
+
+  .lg-toggle--error .lg-toggle__input:checked + & {
+    background-color: var(--checkbox-error-indicator-colour);
+    color: var(--checkbox-error-control-background-colour);
+    border-color: var(--checkbox-error-control-border-colour);
   }
 }

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.ts
@@ -64,7 +64,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
   @Input() focus: boolean;
   @Input() ariaDescribedBy: string;
   @Input() variant: ToggleVariant = 'checkbox';
-  @Input() size: CheckboxSize = 'sm';
+  @Input() size: CheckboxSize = 'lg';
   @Input()
   _disabled = false;
   get disabled(): boolean {
@@ -79,6 +79,12 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
   @HostBinding('class.lg-toggle') class = true;
   @HostBinding('class.lg-toggle--error') get errorClass() {
     return this.errorState.isControlInvalid(this.control, this.controlContainer);
+  }
+  @HostBinding('class.lg-toggle--sm') get sizeSmClass() {
+    return this.size === 'sm';
+  }
+  @HostBinding('class.lg-toggle--lg') get sizeLgClass() {
+    return this.size === 'lg';
   }
 
   @ViewChild('input', { static: true }) inputRef: ElementRef;

--- a/projects/canopy/src/lib/forms/validation/docs/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/docs/form.stories.ts
@@ -121,7 +121,6 @@ class FormGroupChildComponent implements OnInit {
 
       <lg-input-field>
         Text
-        <input lgInput formControlName="text" />
         <lg-hint>This is a standard input field</lg-hint>
         @if (isControlInvalid(text, validationForm) && text.hasError('required')) {
           <lg-validation> Text is a required field </lg-validation>
@@ -132,11 +131,18 @@ class FormGroupChildComponent implements OnInit {
         @if (isControlInvalid(text, validationForm) && text.hasError('invalid')) {
           <lg-validation> Please enter a valid value </lg-validation>
         }
+        <input lgInput formControlName="text" />
       </lg-input-field>
 
       <lg-select-field>
         Select field
         <lg-hint>This is a standard single option select field</lg-hint>
+        @if (isControlInvalid(select, validationForm) && select.hasError('invalid')) {
+          <lg-validation> Please select a valid option </lg-validation>
+        }
+        @if (isControlInvalid(select, validationForm) && select.hasError('required')) {
+          <lg-validation> Select is a required field </lg-validation>
+        }
         <select lgSelect formControlName="select">
           <option value="blue">Blue</option>
           <option value="red">Red</option>
@@ -144,53 +150,47 @@ class FormGroupChildComponent implements OnInit {
           <option value="yellow">Yellow</option>
           <option value="invalid">Invalid</option>
         </select>
-        @if (isControlInvalid(select, validationForm) && select.hasError('invalid')) {
-          <lg-validation> Please select a valid option </lg-validation>
-        }
-        @if (isControlInvalid(select, validationForm) && select.hasError('required')) {
-          <lg-validation> Select is a required field </lg-validation>
-        }
       </lg-select-field>
 
       <lg-radio-group formControlName="radio">
         Radio option
         <lg-hint>This is a standard radio group</lg-hint>
-        <lg-radio-button value="yellow">Yellow</lg-radio-button>
-        <lg-radio-button value="red">Red</lg-radio-button>
-        <lg-radio-button value="blue">Blue</lg-radio-button>
-        <lg-radio-button value="invalid">Invalid</lg-radio-button>
         @if (isControlInvalid(radio, validationForm) && radio.hasError('invalid')) {
           <lg-validation> Please select a valid option </lg-validation>
         }
         @if (isControlInvalid(radio, validationForm) && radio.hasError('required')) {
           <lg-validation> Please select an option </lg-validation>
         }
+        <lg-radio-button value="yellow">Yellow</lg-radio-button>
+        <lg-radio-button value="red">Red</lg-radio-button>
+        <lg-radio-button value="blue">Blue</lg-radio-button>
+        <lg-radio-button value="invalid">Invalid</lg-radio-button>
       </lg-radio-group>
       <lg-segment-group formControlName="segment">
         Segment option
         <lg-hint>This is a standard segment group</lg-hint>
-        <lg-segment-button value="yellow">Yellow</lg-segment-button>
-        <lg-segment-button value="red">Red</lg-segment-button>
-        <lg-segment-button value="blue">Blue</lg-segment-button>
-        <lg-segment-button value="invalid">Invalid</lg-segment-button>
         @if (isControlInvalid(segment, validationForm) && segment.hasError('invalid')) {
           <lg-validation> Please select a valid option </lg-validation>
         }
         @if (isControlInvalid(radio, validationForm) && radio.hasError('required')) {
           <lg-validation> Please select an option </lg-validation>
         }
+        <lg-segment-button value="yellow">Yellow</lg-segment-button>
+        <lg-segment-button value="red">Red</lg-segment-button>
+        <lg-segment-button value="blue">Blue</lg-segment-button>
+        <lg-segment-button value="invalid">Invalid</lg-segment-button>
       </lg-segment-group>
 
       <lg-checkbox-group formControlName="colors">
         Checkbox group
         <lg-hint>This is a standard checkbox group</lg-hint>
+        @if (isControlInvalid(colors, validationForm) && colors.hasError('required')) {
+          <lg-validation> Please select an option </lg-validation>
+        }
         <lg-toggle value="red">Red</lg-toggle>
         <lg-toggle value="yellow">Yellow</lg-toggle>
         <lg-toggle value="green">Green</lg-toggle>
         <lg-toggle value="blue">Blue</lg-toggle>
-        @if (isControlInvalid(colors, validationForm) && colors.hasError('required')) {
-          <lg-validation> Please select an option </lg-validation>
-        }
       </lg-checkbox-group>
 
       <lg-toggle formControlName="checkbox" [value]="true" variant="checkbox">
@@ -245,7 +245,6 @@ class FormGroupChildComponent implements OnInit {
       <lg-input-field>
         Sort Code
         <lg-hint>Must be 6 digits long, for example 00-00-00</lg-hint>
-        <input lgInput lgSortCode formControlName="sortCode" />
         @if (isControlInvalid(sortCode, validationForm)) {
           <lg-validation>
             @if (sortCode.hasError('required')) {
@@ -256,6 +255,7 @@ class FormGroupChildComponent implements OnInit {
             }
           </lg-validation>
         }
+        <input lgInput lgSortCode formControlName="sortCode" />
       </lg-input-field>
 
       <button lg-button type="submit" priority="primary">Submit</button>
@@ -360,7 +360,6 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Forms/Form validation/Examples',
-  tags: [ 'pending' ],
   decorators: [
     moduleMetadata({
       imports: [ ReactiveFormsModule, ReactiveFormComponent ],

--- a/projects/canopy/src/lib/forms/validation/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/validation/docs/guide.mdx
@@ -1,23 +1,18 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../docs/common/feedback.md';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
 
-<Meta title="Components/Forms/Form validation/Guide" tags={['pending']}/>
+<Meta title="Components/Forms/Form validation/Guide" />
 
 # Form validation
 
-<CustomBadge text="Pending" style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }} /> <span class="small-text">Due for brand modernisation</span>
-
 <p class="standfirst">Form validation is the process of checking the inputs of a form against expected results, allowing those inputs to be submitted or otherwise returning an error. This page describes our recommended methods of implementing form validation in your application.</p>
-
-![validation](docs/forms/validation/validation.png)
 
 ## How errors should display
 
 When the user submits a form and it is validated as having errors, the following things should happen:
 
 1. All fields with errors are highlighted as having errors.
-2. Inline messages display beneath each field telling the user how to fix the problem. [Read the writing guide](./?path=/docs/principles-writing--docs) to find out how to write good error messages.
+2. Inline messages display above each field telling the user how to fix the problem. [Read the writing guide](./?path=/docs/principles-writing--docs) to find out how to write good error messages.
 3. The first field with an error automatically gets focus so the user knows where to begin.
 
 ## Usage
@@ -61,7 +56,6 @@ In your HTML, add the validation components with the appropriate structural dire
   #userForm="ngForm">
     <lg-input-field>
       Text
-      <input lgInput formControlName="username" />
       <lg-hint>This is a standard input field</lg-hint>
     @if (isControlInvalid(text, userForm) && text.hasError('required')) {
       <lg-validation>
@@ -73,6 +67,7 @@ In your HTML, add the validation components with the appropriate structural dire
         Username needs to be at least 4 characters
       </lg-validation>
     }
+      <input lgInput formControlName="username" />
   </lg-input-field>
 </form>
 ```

--- a/projects/canopy/src/lib/forms/validation/docs/validation.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/docs/validation.stories.ts
@@ -28,7 +28,6 @@ class LgValidationExampleComponent {
 
 export default {
   title: 'Components/Forms/Form validation/Examples',
-  tags: [ 'pending' ],
   component: LgValidationComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/forms/validation/validation.component.scss
+++ b/projects/canopy/src/lib/forms/validation/validation.component.scss
@@ -2,12 +2,16 @@
 
 .lg-validation {
   display: flex;
-  align-items: flex-start;
-  padding: var(--space-3);
-  margin-top: var(--space-2);
-  @include mixins.lg-status-subtle();
+  align-items: center;
+  color: var(--label-and-hint-validation-message-colour);
+  margin-bottom: var(--form-field-gap);
+
+  .lg-icon {
+    width: var(--content-icon-size-sm);
+    height: var(--content-icon-size-sm);
+  }
 }
 
 .lg-validation__icon {
-  margin-right: var(--space-3);
+  margin-right: var(--content-gap-inside-md);
 }

--- a/projects/canopy/src/lib/promo-card/promo-card/promo-card-image/promo-card-image.component.scss
+++ b/projects/canopy/src/lib/promo-card/promo-card/promo-card-image/promo-card-image.component.scss
@@ -7,7 +7,7 @@
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
-  border-radius: var(--container-border-radius-sm);
+  border-radius: var(--container-common-border-radius-sm);
 
   @media (min-width: promo-card.$promo-card-inline-breakpoint) {
     width: var(--promo-card-image-dimension);
@@ -15,13 +15,13 @@
   }
 
   @include mixins.lg-breakpoint('md') {
-    border-radius: var(--container-border-radius-md);
+    border-radius: var(--container-common-border-radius-md);
   }
 
   @include mixins.lg-breakpoint('lg') {
     width: 100%;
     height: 20rem;
-    border-radius: var(--container-border-radius-lg);
+    border-radius: var(--container-common-border-radius-lg);
   }
 
   @include mixins.lg-breakpoint('xl') {

--- a/projects/canopy/src/lib/promo-card/promo-card/promo-card.component.scss
+++ b/projects/canopy/src/lib/promo-card/promo-card/promo-card.component.scss
@@ -57,14 +57,14 @@
   position: relative;
   padding: var(--space-4);
   background: var(--colour-greyscale-0);
-  border-radius: var(--container-border-radius-sm);
+  border-radius: var(--container-common-border-radius-sm);
 
   @include mixins.lg-breakpoint('md') {
     padding: var(--space-5);
-    border-radius: var(--container-border-radius-md);
+    border-radius: var(--container-common-border-radius-md);
   }
 
   @include mixins.lg-breakpoint('lg') {
-    border-radius: var(--container-border-radius-lg);
+    border-radius: var(--container-common-border-radius-lg);
   }
 }

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -43,6 +43,10 @@
 .lg-table-cell__content {
   text-align: end;
   margin-left: auto;
+
+  .lg-label {
+    margin-bottom: var(--space-2);
+  }
 }
 
 .lg-table-cell__content--hidden-label {

--- a/projects/canopy/src/public-api.ts
+++ b/projects/canopy/src/public-api.ts
@@ -13,6 +13,7 @@ export * from './lib/content-area/index';
 export * from './lib/carousel/index';
 export * from './lib/data-point/index';
 export * from './lib/details/index';
+export * from './lib/external-button/index';
 export * from './lib/feature-toggle/index';
 export * from './lib/filter-container/index';
 export * from './lib/focus/index';

--- a/projects/canopy/src/public-api.ts
+++ b/projects/canopy/src/public-api.ts
@@ -13,7 +13,7 @@ export * from './lib/content-area/index';
 export * from './lib/carousel/index';
 export * from './lib/data-point/index';
 export * from './lib/details/index';
-export * from './lib/external-button/index';
+export * from './lib/forms/input-field-external-button/index';
 export * from './lib/feature-toggle/index';
 export * from './lib/filter-container/index';
 export * from './lib/focus/index';

--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -402,27 +402,27 @@ $breakpoints: (
 
 @mixin lg-card {
   background-color: var(--card-bg-color);
-  border-radius: var(--container-border-radius-sm);
+  border-radius: var(--container-common-border-radius-sm);
   margin-bottom: var(--grid-gutter);
   padding: var(--component-padding);
 
   @include lg-breakpoint('md') {
-    border-radius: var(--container-border-radius-md);
+    border-radius: var(--container-common-border-radius-md);
   }
   @include lg-breakpoint('lg') {
-    border-radius: var(--container-border-radius-lg);
+    border-radius: var(--container-common-border-radius-lg);
   }
 }
 
 @mixin lg-content-area {
-  border-radius: var(--container-border-radius-sm);
+  border-radius: var(--container-common-border-radius-sm);
   background: var(--content-area-background-colour);
 
   @include lg-breakpoint('md') {
-    border-radius: var(--container-border-radius-md);
+    border-radius: var(--container-common-border-radius-md);
   }
   @include lg-breakpoint('lg') {
-    border-radius: var(--container-border-radius-lg);
+    border-radius: var(--container-common-border-radius-lg);
   }
 }
 

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -12,7 +12,6 @@
 @use 'variables/components/header';
 @use 'variables/components/hero';
 @use 'variables/components/hero-img';
-@use 'variables/components/input';
 @use 'variables/components/modal-body-timer';
 @use 'variables/components/page';
 @use 'variables/components/pagination';
@@ -20,7 +19,6 @@
 @use 'variables/components/side-nav';
 @use 'variables/components/brand-icon';
 @use 'variables/components/quick-action';
-@use 'variables/components/select';
 @use 'variables/components/separator';
 @use 'variables/components/spinner';
 @use 'variables/components/tabs';

--- a/projects/canopy/src/styles/variables/components/_input.scss
+++ b/projects/canopy/src/styles/variables/components/_input.scss
@@ -1,5 +1,0 @@
-:root {
-  --input-line-height: 1.5;
-  --input-vertical-padding: var(--form-field-vertical-padding);
-  --input-button-right-margin: 0.3125rem;
-}

--- a/projects/canopy/src/styles/variables/components/_select.scss
+++ b/projects/canopy/src/styles/variables/components/_select.scss
@@ -1,4 +1,0 @@
-:root {
-  --select-icon-width: 0.875rem;
-  --select-vertical-padding: var(--form-field-vertical-padding);
-}

--- a/skills/best-practice/forms-checkbox/SKILL.md
+++ b/skills/best-practice/forms-checkbox/SKILL.md
@@ -62,7 +62,7 @@ Use `lg-checkbox-group` when presenting two or more related options.
 | `name` | `string` | `null` | Yes | HTML `name` attribute. |
 | `value` | `string` | `null` | Yes | HTML `value` attribute. |
 | `focus` | `boolean` | `null` | No | Sets focus on the checkbox. |
-| `size` | `'sm' \| 'lg'` | `'sm'` | No | Size of the checkbox. |
+| `size` | `'sm' \| 'lg'` | `'lg'` | No | Size of the checkbox. |
 | `ariaDescribedBy` | `string` | `null` | No | ID of element that describes the checkbox. |
 
 ## LgToggleComponent Outputs
@@ -79,6 +79,16 @@ Use `lg-checkbox-group` when presenting two or more related options.
 | `name` | `string` | auto-generated | Sets `name` on all checkboxes in the group. |
 | `inline` | `boolean` | `false` | Displays checkboxes inline. |
 | `focus` | `boolean` | `null` | Sets focus on the fieldset. |
+
+---
+
+## Accessibility
+
+- Always group related checkboxes using `lg-checkbox-group` with a clear label.
+- Use `lg-hint` to provide extra context where needed.
+- Ensure all checkboxes have clear, descriptive labels.
+- Set `ariaDescribedBy` to link checkboxes to hint or validation messages.
+- Keyboard users must be able to tab through all checkboxes and toggle them with Space.
 
 ---
 

--- a/skills/best-practice/forms-input/SKILL.md
+++ b/skills/best-practice/forms-input/SKILL.md
@@ -64,22 +64,49 @@ Use Angular reactive forms. The `lgInput` directive goes on the `<input>` elemen
 
 ## Button Suffix
 
-Only use `size="sm"` buttons inside an input field.
+Use the `lgSuffix` directive for buttons inside the input border (add-on variant).
 
 ```html
-<!-- Standard button suffix -->
-<lg-input-field>
-  Search
-  <input lgInput formControlName="query" />
-  <button lg-button lgSuffix size="sm">Go</button>
-</lg-input-field>
-
 <!-- Icon-only add-on button -->
 <lg-input-field>
   Search
   <input lgInput formControlName="query" />
   <button lg-button lgSuffix [iconButton]="true" priority="add-on">
-    <lg-icon name="search"></lg-icon>
+    Clear
+    <lg-icon name="close"></lg-icon>
+  </button>
+</lg-input-field>
+```
+
+---
+
+## External Button
+
+Use the `lgExternalButton` directive for buttons outside the input border (e.g., search or submit).
+
+```html
+<lg-input-field>
+  Search
+  <input lgInput formControlName="query" />
+  <button lg-button lgExternalButton priority="primary">
+    Search
+  </button>
+</lg-input-field>
+```
+
+You can combine multiple suffixes with an external button:
+
+```html
+<lg-input-field>
+  Amount
+  <input lgInput formControlName="amount" />
+  <span lgSuffix>%</span>
+  <button lg-button lgSuffix [iconButton]="true" priority="add-on">
+    Clear
+    <lg-icon name="close" />
+  </button>
+  <button lg-button lgExternalButton priority="primary">
+    Submit
   </button>
 </lg-input-field>
 ```

--- a/skills/best-practice/forms-input/SKILL.md
+++ b/skills/best-practice/forms-input/SKILL.md
@@ -82,14 +82,13 @@ Use the `lgSuffix` directive for buttons inside the input border (add-on variant
 
 ## External Button
 
-Use the `lgExternalButton` directive for buttons outside the input border (e.g., search or submit).
+Use the `lgInputFieldExternalButton` directive for buttons outside the input border (e.g., search or submit).
 
 ```html
 <lg-input-field>
   Search
   <input lgInput formControlName="query" />
-  <button lg-button lgExternalButton priority="primary">
-    Search
+  <button lg-button lgInputFieldExternalButton priority="primary">
   </button>
 </lg-input-field>
 ```
@@ -105,7 +104,7 @@ You can combine multiple suffixes with an external button:
     Clear
     <lg-icon name="close" />
   </button>
-  <button lg-button lgExternalButton priority="primary">
+  <button lg-button lgInputFieldExternalButton priority="primary">
     Submit
   </button>
 </lg-input-field>

--- a/skills/best-practice/forms-radio/SKILL.md
+++ b/skills/best-practice/forms-radio/SKILL.md
@@ -67,8 +67,6 @@ import {
 
 ---
 
----
-
 ## Accessibility
 
 - Always use `lg-radio-group` to group related radio buttons with a clear label.

--- a/skills/best-practice/forms-radio/SKILL.md
+++ b/skills/best-practice/forms-radio/SKILL.md
@@ -56,7 +56,7 @@ import {
 | `id` | `string` | auto-generated | No | HTML `id` attribute. |
 | `name` | `string` | `null` | Yes | HTML `name` attribute. |
 | `value` | `string` | `null` | Yes | HTML `value` attribute. |
-| `size` | `RadioSize` | `'sm'` | No | Size of the radio button. |
+| `size` | `RadioSize` | `'lg'` | No | Size of the radio button. |
 | `ariaDescribedBy` | `string` | `null` | No | ID of the element that describes this radio button. |
 
 ## LgRadioButtonComponent Outputs
@@ -64,6 +64,19 @@ import {
 | Output | Type | Description |
 |--------|------|-------------|
 | `blur` | `EventEmitter<Event>` | Emitted on blur. |
+
+---
+
+---
+
+## Accessibility
+
+- Always use `lg-radio-group` to group related radio buttons with a clear label.
+- Use `lg-hint` to provide extra context where needed.
+- Ensure all radio buttons have clear, descriptive labels.
+- Set `ariaDescribedBy` to link radio buttons to hint or validation messages.
+- Keyboard users use Tab to move into/out of the radio group, and arrow keys to navigate between options and select them.
+- Only one radio button can be selected at a time within a group.
 
 ---
 

--- a/skills/best-practice/forms-segment/SKILL.md
+++ b/skills/best-practice/forms-segment/SKILL.md
@@ -74,6 +74,17 @@ import { LgRadioGroupComponent, LgRadioButtonComponent } from '@legal-and-genera
 
 ---
 
+## Accessibility
+
+- Always use `lg-segment-group` to group related segment buttons with a clear label.
+- Use `lg-hint` to provide extra context where needed.
+- Ensure all segment buttons have clear, descriptive labels.
+- There must be clear colour contrast between selected and unselected states.
+- Keyboard users use Tab to move into/out of the segment group, and arrow keys to navigate between options and select them (segment buttons are implemented as radios).
+- Only one segment button can be selected at a time within a group.
+
+---
+
 ## Design Constraints
 
 - In the default state, nothing is pre-selected (unlike radio buttons, where one is always selected).

--- a/skills/best-practice/forms-select/SKILL.md
+++ b/skills/best-practice/forms-select/SKILL.md
@@ -59,7 +59,7 @@ Use Angular reactive forms. The `lgSelect` directive goes on the `<select>` elem
 
 ## Accessibility
 
-- Always include a `<label>` element linked to the select via `lg-select-field`.
+- Always provide label text inside `lg-select-field` as projected content — the component renders the associated `<label>` element automatically.
 - Use `lg-hint` to provide extra context where needed.
 - Provide a meaningful default option or empty value ("Select" or "Choose an option").
 - Ensure option text is clear and descriptive.

--- a/skills/best-practice/forms-select/SKILL.md
+++ b/skills/best-practice/forms-select/SKILL.md
@@ -57,6 +57,17 @@ Use Angular reactive forms. The `lgSelect` directive goes on the `<select>` elem
 
 ---
 
+## Accessibility
+
+- Always include a `<label>` element linked to the select via `lg-select-field`.
+- Use `lg-hint` to provide extra context where needed.
+- Provide a meaningful default option or empty value ("Select" or "Choose an option").
+- Ensure option text is clear and descriptive.
+- Keyboard users must be able to open the select with Space/Enter and navigate options with arrow keys.
+- List options in a predictable order (alphabetical, chronological, most frequently used).
+
+---
+
 ## Dos and Don'ts
 
 ### Do

--- a/skills/best-practice/forms-validation/SKILL.md
+++ b/skills/best-practice/forms-validation/SKILL.md
@@ -54,13 +54,13 @@ Always add `#userForm="ngForm"` to the `<form>` element and ensure the submit bu
 <form [formGroup]="form" (ngSubmit)="onSubmit(form)" #userForm="ngForm">
   <lg-input-field>
     Username
-    <input lgInput formControlName="username" />
     @if (isControlInvalid(form.get('username'), userForm) && form.get('username').hasError('required')) {
       <lg-validation>Username is required</lg-validation>
     }
     @if (isControlInvalid(form.get('username'), userForm) && form.get('username').hasError('minlength')) {
       <lg-validation>Username must be at least 4 characters</lg-validation>
     }
+    <input lgInput formControlName="username" />
   </lg-input-field>
   <button type="submit">Submit</button>
 </form>
@@ -80,7 +80,7 @@ Always add `#userForm="ngForm"` to the `<form>` element and ensure the submit bu
 ## Error Display Rules
 
 1. All fields with errors are highlighted when the form is submitted.
-2. Inline messages appear beneath each field describing how to fix the problem.
+2. Inline messages appear above each field describing how to fix the problem.
 3. The first field with an error automatically receives focus.
 
 ---


### PR DESCRIPTION
BREAKING CHANGE: css properties for input and select have been removed. Card and content area css properties renamed. Default size value on LgRadioButtonComponent and LgToggleComponent changed to lg.

# Description

Update all the Form elements to the new brand

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [x] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
