### PR TITLE
feat(button): update icon position for buttons as links

### DIFF
--- a/projects/canopy/src/lib/button/button.component.html
+++ b/projects/canopy/src/lib/button/button.component.html
@@ -1,5 +1,5 @@
 <ng-template #standard>
-  @if (backIcon) {
+  @if (backIcon && priority !== 'link') {
     <lg-icon
       name="arrow-left"
       class="lg-margin__left--none" />
@@ -9,7 +9,7 @@
     <ng-content />
   </span>
 
-  @if (!backIcon) {
+  @if (!backIcon || priority === 'link') {
     <ng-content select="lg-icon" />
   }
 </ng-template>

--- a/projects/canopy/src/lib/button/button.component.scss
+++ b/projects/canopy/src/lib/button/button.component.scss
@@ -64,6 +64,12 @@
     }
   }
 
+  &--link#{&}--icon-left {
+    .lg-icon {
+      order: -1;
+    }
+  }
+
   &:is(a):not(&--icon-left) .lg-icon {
     margin-right: 0;
   }
@@ -103,6 +109,7 @@
     min-width: 0;
     width: initial;
     margin-bottom: 0;
+    text-align: left;
 
     @include mixins.lg-link();
   }
@@ -167,14 +174,12 @@ $priorities: 'primary', 'secondary' !default;
   .lg-btn--#{$priority}:focus-visible:not(.lg-btn-toggle) {
     color: var(--button-#{$priority}-focus-colour);
     background: var(--button-#{$priority}-focus-background-colour);
-    box-shadow:
-      inset
-        0
-        0
-        0
-        var(--button-border-width-focus)
-        var(--button-#{$priority}-focus-colour),
-      0 0 0 var(--button-border-width) var(--button-#{$priority}-focus-background-colour);
+    box-shadow: inset
+      0
+      0
+      0
+      var(--button-border-width-focus)
+      var(--button-#{$priority}-focus-colour);
     border-radius: var(--button-border-radius);
 
     &:not(:disabled) {

--- a/projects/canopy/src/lib/button/button.component.ts
+++ b/projects/canopy/src/lib/button/button.component.ts
@@ -93,8 +93,14 @@ export class LgButtonComponent implements AfterContentInit, AfterViewInit {
   }
 
   ngAfterContentInit(): void {
-    // Check if backIcon is set and there are projected lg-icon components
-    if (this._backIcon && this.projectedIcons && this.projectedIcons.length > 0) {
+    // Check if backIcon is set and there are projected lg-icon components.
+    // When priority is 'link', backIcon + a projected icon is a valid combination.
+    if (
+      this._backIcon &&
+      this.priority !== 'link' &&
+      this.projectedIcons &&
+      this.projectedIcons.length > 0
+    ) {
       console.error(
         'Button component error: Cannot have both backIcon and a right icon set at the same time. Back icon takes precedence.',
       );
@@ -106,7 +112,8 @@ export class LgButtonComponent implements AfterContentInit, AfterViewInit {
       'lg-icon',
     ) as HTMLCollectionOf<HTMLElement>;
 
-    if (this._backIcon && icons.length > 1) {
+    // When priority is 'link', backIcon + a projected icon is valid, so skip cleanup.
+    if (this._backIcon && this.priority !== 'link' && icons.length > 1) {
       // Back icon takes precedence, so remove any other icons
       for (let i = icons.length - 1; i > 0; i--) {
         icons[i].remove();

--- a/projects/canopy/src/lib/button/docs/guide.mdx
+++ b/projects/canopy/src/lib/button/docs/guide.mdx
@@ -122,6 +122,24 @@ Shows a loading spinner and disables the button.
 <button lg-button [loading]="true">Loading…</button>
 ```
 
+**Button as link**
+
+A button styled as a link. Buttons styled as links support a custom icon on either left or right, including when `[backIcon]="true"` is used. The earlier `backIcon` limitation applies to non-link button priorities only.
+
+```html
+<!-- Icon on the right (default) -->
+<button lg-button priority="link">
+  Label
+  <lg-icon name="chevron-right" />
+</button>
+
+<!-- Icon on the left -->
+<button lg-button priority="link" [backIcon]="true">
+  Label
+  <lg-icon name="chevron-left" />
+</button>
+```
+
 ## Dos and Don'ts
 
 ### Do

--- a/skills/canopy-v22-migration/SKILL.md
+++ b/skills/canopy-v22-migration/SKILL.md
@@ -121,6 +121,8 @@ Use the following mapping table to determine the correct replacement:
 
 **What changed:** `@Input() iconPosition` and the `ButtonIconPosition` type have been removed. The icon now appears on the right by default. To position an icon on the left (e.g. a back/previous button), use the new `@Input() backIcon: boolean`. Remove any `iconPosition="right"` bindings entirely — right is now the default and requires no input.
 
+> **Note — `priority="link"` buttons:** When `[backIcon]="true"` is combined with `priority="link"`, the projected `<lg-icon>` is displayed on the left rather than a fixed `arrow-left` icon. This means you can use a custom icon on the left for link-priority buttons. The fixed `arrow-left` limitation and the removal of any projected icon applies to all other priorities (`primary`, `secondary`, `add-on`) only.
+
 **Search for** (in `*.html` files):
 ```
 iconPosition


### PR DESCRIPTION
# Description

Updates `lg-button` so `priority="link"` buttons can use projected icons on either side, avoiding the previously hardcoded back arrow for link-priority buttons.

Changes:

Prevent hardcoded `arrow-left` from rendering when `priority="link"` while still supporting backIcon for left positioning.
Always render projected `<lg-icon>` for `priority="link"`, including when `backIcon` is set.
Add link+icon-left styling to reorder the projected icon to the left.

```
<!-- Icon on the right (default) -->
<button lg-button priority="link">
  Label
  <lg-icon name="chevron-right" />
</button>

<!-- Icon on the left via backIcon -->
<button lg-button priority="link" [backIcon]="true">
  Label
  <lg-icon name="chevron-left" />
</button>
```

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
