### PR TITLE
ci(actions): pin actions to sha references

### DIFF
--- a/.github/workflows/branch_pages_deploy.yml
+++ b/.github/workflows/branch_pages_deploy.yml
@@ -19,9 +19,9 @@ jobs:
   deploy-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
 
@@ -31,7 +31,7 @@ jobs:
           npm ci
 
       - name: 'Save PR data'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: prData
         with:
           script: |
@@ -48,7 +48,7 @@ jobs:
           echo "kebab_branch=$(echo '${{ fromJSON(steps.prData.outputs.result).branch }}' | tr '/' '-')" >> $GITHUB_OUTPUT
 
       - name: 'Download artifacts from PR'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const downloadArtifact = require('./.github/workflow-scripts/gh-pages/download-branch-deploy-artifact.cjs');
@@ -73,7 +73,7 @@ jobs:
           NETWORK_IDLE_WAIT_TIMEOUT: 5000
 
       - name: 'Notify GitHub of branch deployment'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: deploymentId
         with:
           script: |
@@ -85,7 +85,7 @@ jobs:
             });
 
       - name: 'Notify GitHub of deployment in progress'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const createDeploymentStatus = require('./.github/workflow-scripts/gh-pages/create-gh-deployment-status.cjs');
@@ -98,7 +98,7 @@ jobs:
             });
 
       - name: 'Branch deployment to GitHub Pages'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const deployBranch = require('./.github/workflow-scripts/gh-pages/deploy.cjs');
@@ -117,7 +117,7 @@ jobs:
 
       - name: 'Notify GitHub of deployment status'
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const createDeploymentStatus = require('./.github/workflow-scripts/gh-pages/create-gh-deployment-status.cjs');
@@ -131,7 +131,7 @@ jobs:
 
       - name: 'Add label to PR'
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const addLabels = require('./.github/workflow-scripts/add-labels.cjs');

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
@@ -34,7 +34,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           languages: ${{ matrix.language }}
           config: |
@@ -48,9 +48,9 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,7 +8,7 @@ jobs:
     environment: copilot
     steps:
       - name: 'Checkout Repo'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.COPILOT_PAT }}

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -20,10 +20,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 'Setup node'
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -37,7 +37,7 @@ jobs:
         run: npm run build
 
       - name: 'Upload dist folder'
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ github.event.repository.name }}
           path: dist/canopy/
@@ -47,10 +47,10 @@ jobs:
     needs: [ build ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 'Setup node'
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -61,7 +61,7 @@ jobs:
           npm ci
 
       - name: 'Download dist folder'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ github.event.repository.name }}
           path: dist/canopy/
@@ -80,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'master' || github.ref_name == 'next' || github.ref_name == 'legacy'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 'Setup node'
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -94,7 +94,7 @@ jobs:
           npm ci
 
       - name: 'Download dist folder'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ github.event.repository.name }}
           path: dist/canopy/
@@ -118,7 +118,7 @@ jobs:
           NETWORK_IDLE_WAIT_TIMEOUT: 5000
 
       - name: 'Deployment to GitHub Pages'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const deployBranch = require('./.github/workflow-scripts/gh-pages/deploy.cjs');

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,12 +16,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: 'Setup node'
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -60,7 +60,7 @@ jobs:
         run: npm run build:storybook -- --output-dir ./lg-sb-build
 
       - name: 'Upload storybook build'
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: lg-sb-build
           path: ./lg-sb-build
@@ -70,10 +70,10 @@ jobs:
     name: 'Check best-practice skills'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 'Check that .mdx changes are accompanied by skill updates'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const checkDocsSkills = require('./.github/workflow-scripts/check-docs-skills.cjs')


### PR DESCRIPTION
# Description

This pins all non-SHA-pinned GitHub Actions to their commit SHA.
The original version tag is preserved as a trailing comment so that
Dependabot can still detect and propose version updates.

Every tag has been replaced with it's full 40-character commit SHA.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
