### PR TITLE
fix(icon): add space left to open-in-new-window icon

### DIFF
--- a/projects/canopy/src/styles/mixins.scss
+++ b/projects/canopy/src/styles/mixins.scss
@@ -84,7 +84,8 @@
     margin-right: var(--link-gap);
   }
 
-  .lg-icon[name='link-external'] {
+  .lg-icon[name='link-external'],
+  .lg-icon[name='open-in-new-window'] {
     margin-right: 0;
     margin-left: var(--link-gap);
   }


### PR DESCRIPTION
# Description

Fixes an issue with the `open-in-new-window` icon not getting the margin left when included in a link.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
