### PR TITLE
feat(content-area): include button as link in content area header

### DIFF
--- a/projects/canopy/src/lib/content-area/content-area-header/content-area-header.component.html
+++ b/projects/canopy/src/lib/content-area/content-area-header/content-area-header.component.html
@@ -1,1 +1,1 @@
-<ng-content select="lg-content-area-title, a" />
+<ng-content select="lg-content-area-title, a, button[lg-button][priority='link']" />

--- a/projects/canopy/src/lib/content-area/content-area-header/content-area-header.component.spec.ts
+++ b/projects/canopy/src/lib/content-area/content-area-header/content-area-header.component.spec.ts
@@ -87,7 +87,7 @@ describe('LgContentAreaHeaderComponent', () => {
     })
     class TestSelectiveProjectionComponent {}
 
-    it('should only project lg-content-area-title and anchor elements', () => {
+    it('should only project lg-content-area-title, anchor elements, and link-priority buttons', () => {
       const testFixture = TestBed.createComponent(TestSelectiveProjectionComponent);
 
       testFixture.detectChanges();
@@ -128,6 +128,61 @@ describe('LgContentAreaHeaderComponent', () => {
       expect(anchorElement).toBeTruthy();
       expect(anchorElement.textContent).toContain('Link');
       expect(titleElement).toBeTruthy();
+    });
+
+    @Component({
+      template: `
+        <lg-content-area-header>
+          <lg-content-area-title [headingLevel]="2">Title</lg-content-area-title>
+          <button lg-button type="button" priority="link">Link Priority</button>
+        </lg-content-area-header>
+      `,
+      standalone: true,
+      imports: [ LgContentAreaHeaderComponent, LgContentAreaTitleComponent ],
+    })
+    class TestLinkPriorityButtonProjectionComponent {}
+
+    it('should project link-priority buttons', () => {
+      const testFixture = TestBed.createComponent(
+        TestLinkPriorityButtonProjectionComponent,
+      );
+
+      testFixture.detectChanges();
+
+      const headerElement = testFixture.nativeElement.querySelector(
+        'lg-content-area-header',
+      );
+      const buttonElement = headerElement.querySelector('button[priority="link"]');
+
+      expect(buttonElement).toBeTruthy();
+      expect(buttonElement.textContent).toContain('Link Priority');
+    });
+
+    @Component({
+      template: `
+        <lg-content-area-header>
+          <lg-content-area-title [headingLevel]="2">Title</lg-content-area-title>
+          <button lg-button type="button" priority="primary">Primary Priority</button>
+        </lg-content-area-header>
+      `,
+      standalone: true,
+      imports: [ LgContentAreaHeaderComponent, LgContentAreaTitleComponent ],
+    })
+    class TestNonLinkPriorityButtonProjectionComponent {}
+
+    it('should not project non-link-priority buttons', () => {
+      const testFixture = TestBed.createComponent(
+        TestNonLinkPriorityButtonProjectionComponent,
+      );
+
+      testFixture.detectChanges();
+
+      const headerElement = testFixture.nativeElement.querySelector(
+        'lg-content-area-header',
+      );
+      const buttonElement = headerElement.querySelector('button[priority="primary"]');
+
+      expect(buttonElement).toBeNull();
     });
   });
 });


### PR DESCRIPTION
# Description

Include buttons as links, `priority="link"` in the Content Area Header

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
