### PR TITLE
fix(footer): remove padding-x

### DIFF
--- a/projects/canopy/src/lib/footer/footer.component.scss
+++ b/projects/canopy/src/lib/footer/footer.component.scss
@@ -4,7 +4,7 @@
   background-color: var(--footer-background-colour);
 
   &__wrapper {
-    padding: var(--footer-padding-y) var(--footer-padding-x);
+    padding: var(--footer-padding-y) 0;
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
Fixes # (issue)

This removes the `padding-x` from the footer wrapper to keep it consistent with the page content and header

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
