### PR TITLE
Cn 644 add version no to guidance

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -5,6 +5,24 @@ import { defaultConfig } from 'storybook-addon-tag-badges/manager-helpers';
 addons.setConfig({
   tagBadges: [
     {
+      tags: 'updated',
+      badge: {
+        text: 'Updated',
+        style: {
+          backgroundColor: '#caeedd',
+          color: '#1d1d1b',
+          fontWeight: 'normal'
+        },
+        tooltip:
+          'See the `Updated` tag in the guidance for the Canopy version in which these updates are available from.',
+      },
+      display: {
+        sidebar: false,
+        toolbar: true,
+        mdx: true,
+      },
+    },
+    {
       tags: 'pending',
       badge: {
         text: 'Pending',

--- a/projects/canopy/src/lib/alert/docs/alert.stories.ts
+++ b/projects/canopy/src/lib/alert/docs/alert.stories.ts
@@ -99,6 +99,7 @@ class LgAlertRichTextStoryComponent {
 // This default export determines where your story goes in the story list
 export default {
   title: 'Components/Inline message (Alert)/Examples',
+  tags: [ 'updated' ],
   component: LgAlertComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/alert/docs/guide.mdx
+++ b/projects/canopy/src/lib/alert/docs/guide.mdx
@@ -1,15 +1,16 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as AlertStories from './alert.stories.ts';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Inline message (Alert)/Guide" />
+<Meta title="Components/Inline message (Alert)/Guide" tags={['updated']} />
 
 # Inline message
 
-
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v28.0.0" target="_blank" rel="noopener noreferrer">v28</a>.</span></span>
 <p class="standfirst">An inline message provides an eye-catching way to notify the user in-page of an important alert or message, such as a success or error message.</p>
 
-### Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.
+*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
 
 ## Usage
 

--- a/projects/canopy/src/lib/banner/docs/banner.stories.ts
+++ b/projects/canopy/src/lib/banner/docs/banner.stories.ts
@@ -64,6 +64,7 @@ class LgBannerStoryComponent implements OnChanges {
 // This default export determines where your story goes in the story list
 export default {
   title: 'Components/Banner message/Examples',
+  tags: [ 'updated' ],
   component: LgBannerComponent,
   argTypes: {
     content: {

--- a/projects/canopy/src/lib/banner/docs/guide.mdx
+++ b/projects/canopy/src/lib/banner/docs/guide.mdx
@@ -1,14 +1,17 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as BannerStories from './banner.stories.ts';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Banner message/Guide" />
+<Meta title="Components/Banner message/Guide" tags={['updated']}/>
 
 # Banner message
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v27.0.0" target="_blank" rel="noopener noreferrer">v27</a>.</span></span>
+
 <p class="standfirst">Full-width banner to display at the top of a page, beneath the header but before the hero or other page content.</p>
 
-### Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.
+*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
 
 ## Usage
 

--- a/projects/canopy/src/lib/breadcrumb/docs/breadcrumb.stories.ts
+++ b/projects/canopy/src/lib/breadcrumb/docs/breadcrumb.stories.ts
@@ -18,6 +18,7 @@ const themes = [ 'neutral', 'neutral-inverse', 'subtle', 'bold' ];
 
 export default {
   title: 'Components/Breadcrumb/Examples',
+  tags: [ 'updated' ],
   component: LgBreadcrumbComponent,
   parameters: {
     backgrounds: { disable: true },

--- a/projects/canopy/src/lib/breadcrumb/docs/guide.mdx
+++ b/projects/canopy/src/lib/breadcrumb/docs/guide.mdx
@@ -1,14 +1,26 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as BreadcrumbStories from './breadcrumb.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Breadcrumb/Guide" />
+<Meta title="Components/Breadcrumb/Guide" tags={['updated']} />
 
 # Breadcrumb
 
-<p class="standfirst">Breadcrumbs help users to understand a site's hierarchical structure and allow them to move between levels.</p>
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy {' '} <a href="https://github.com/Legal-and-General/canopy/releases/tag/v34.0.0" target="_blank" rel="noopener noreferrer">v34</a>.</span>
+</span>
 
-### Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.
+<p class="standfirst">
+  Breadcrumbs help users to understand a site's hierarchical structure and allow them to
+  move between levels.
+</p>
+
+_Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component._
 
 ## Usage
 
@@ -86,8 +98,8 @@ Note: _This is not automatically added and should be implemented in your app as 
 
 ### LgBreadcrumbComponent inputs
 
-| Name      | Description                                    | Type     | Default | Required |
-| --------- | ---------------------------------------------- | -------- | ------- | -------- |
+| Name      | Description                                       | Type     | Default | Required |
+| --------- | ------------------------------------------------- | -------- | ------- | -------- |
 | `variant` | The layout variants available: `page`, `embedded` | `string` | `page`  | No       |
 
 ---

--- a/projects/canopy/src/lib/button/docs/button-group.stories.ts
+++ b/projects/canopy/src/lib/button/docs/button-group.stories.ts
@@ -5,6 +5,7 @@ import { LgButtonComponent } from '../button.component';
 
 export default {
   title: 'Components/Button/Examples',
+  tags: [ 'updated' ],
   component: LgButtonGroupComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/button/docs/button.stories.ts
+++ b/projects/canopy/src/lib/button/docs/button.stories.ts
@@ -60,6 +60,7 @@ class ButtonComponentExampleComponent {
 
 export default {
   title: 'Components/Button/Examples',
+  tags: [ 'updated' ],
   component: LgButtonComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/button/docs/guide.mdx
+++ b/projects/canopy/src/lib/button/docs/guide.mdx
@@ -1,11 +1,12 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as ButtonsGroupStories from './button-group.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Button/Guide"/>
+<Meta title="Components/Button/Guide" tags={['updated']} />
 
 # Button
-
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v22.0.0" target="_blank" rel="noopener noreferrer">v22</a>.</span></span>
 <p class="standfirst">A Button is an interactive component that allows users to initiate actions within an interface.</p>
 
 ![Button component example](docs/button/hero.png)

--- a/projects/canopy/src/lib/colour/docs/colour.stories.ts
+++ b/projects/canopy/src/lib/colour/docs/colour.stories.ts
@@ -57,6 +57,7 @@ class LgColourStoryComponent {
 
 export default {
   title: 'Helpers/Directives/Colour/Examples',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ LgColourStoryComponent ],

--- a/projects/canopy/src/lib/colour/docs/guide.mdx
+++ b/projects/canopy/src/lib/colour/docs/guide.mdx
@@ -1,9 +1,12 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Helpers/Directives/Colour/Guide"/>
+<Meta title="Helpers/Directives/Colour/Guide" tags={['updated']} />
 
 # Colour
+
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v21.0.0" target="_blank" rel="noopener noreferrer">v21</a>.</span></span>
 
 The `lgColour` directive allows you to apply one of four colour modes to any Canopy component. When combined with a theme, it sets design tokens that control the appearance of interactive elements, backgrounds, borders, and text within the component.
 

--- a/projects/canopy/src/lib/content-area/docs/content-area.stories.ts
+++ b/projects/canopy/src/lib/content-area/docs/content-area.stories.ts
@@ -26,6 +26,7 @@ const content =
 
 export default {
   title: 'Components/Content area/Examples',
+  tags: [ 'updated' ],
   component: LgContentAreaComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/content-area/docs/guide.mdx
+++ b/projects/canopy/src/lib/content-area/docs/guide.mdx
@@ -1,11 +1,12 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as ContentAreaStories from './content-area.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Content area/Guide" />
+<Meta title="Components/Content area/Guide" tags={['updated']} />
 
 # Content area
-
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v22.0.0" target="_blank" rel="noopener noreferrer">v22</a>.</span></span>
 <p class="standfirst">A content area is a layout container used to structure and group main content sections within a page.</p>
 
 ![Content area component hero](docs/content-area/hero.png)

--- a/projects/canopy/src/lib/data-point/docs/data-point.stories.ts
+++ b/projects/canopy/src/lib/data-point/docs/data-point.stories.ts
@@ -21,6 +21,7 @@ const orientationOptions = [ 'horizontal', 'vertical' ];
 
 export default {
   title: 'Components/Data point/Examples',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [

--- a/projects/canopy/src/lib/data-point/docs/guide.mdx
+++ b/projects/canopy/src/lib/data-point/docs/guide.mdx
@@ -1,14 +1,26 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as DataPointStories from './data-point.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Data point/Guide"/>
+<Meta title="Components/Data point/Guide" tags={['updated']} />
 
 # Data point
 
-<p class="standfirst">Display data organised by a label and value. A data point can be used on its own, or grouped into a data point group where items are arranged horizontally or vertically.</p>
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v29.0.0" target="_blank" rel="noopener noreferrer">v29</a>.</span>
+</span>
 
-### Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.
+<p class="standfirst">
+  Display data organised by a label and value. A data point can be used on its own, or
+  grouped into a data point group where items are arranged horizontally or vertically.
+</p>
+
+_Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component._
 
 ## Usage
 
@@ -39,23 +51,23 @@ Data point groups support up to four data points and can be arranged horizontall
 
 ### LgDataPointComponent inputs
 
-| Name         | Description                                                                    | Type                        | Default     | Required |
-|--------------|--------------------------------------------------------------------------------|-----------------------------|-------------|----------|
-| `variant`    | Sets the visual variant of the data point                                      | `'form' \| 'card' \| 'card-principle'` | `'form'` | No       |
-| `isListItem` | When `true`, applies `role="listitem"` — used when inside a data point group    | `boolean`                   | `false`     | No       |
+| Name         | Description                                                                  | Type                                   | Default  | Required |
+| ------------ | ---------------------------------------------------------------------------- | -------------------------------------- | -------- | -------- |
+| `variant`    | Sets the visual variant of the data point                                    | `'form' \| 'card' \| 'card-principle'` | `'form'` | No       |
+| `isListItem` | When `true`, applies `role="listitem"` — used when inside a data point group | `boolean`                              | `false`  | No       |
 
 ### LgDataPointLabelComponent inputs
 
-| Name           | Description                                                  | Type      | Default | Required |
-|----------------|--------------------------------------------------------------|-----------|---------|----------|
-| `headingLevel` | The level of the heading element rendered inside the label   | `number`  | n/a     | Yes      |
-| `isBold`       | When `true`, renders the label text at `font-weight: 700`; when `false`, uses `font-weight: 400` | `boolean` | `false` | No |
+| Name           | Description                                                                                      | Type      | Default | Required |
+| -------------- | ------------------------------------------------------------------------------------------------ | --------- | ------- | -------- |
+| `headingLevel` | The level of the heading element rendered inside the label                                       | `number`  | n/a     | Yes      |
+| `isBold`       | When `true`, renders the label text at `font-weight: 700`; when `false`, uses `font-weight: 400` | `boolean` | `false` | No       |
 
 ### LgDataPointValueComponent inputs
 
-| Name     | Description                                                                    | Type                  | Default | Required |
-|----------|--------------------------------------------------------------------------------|-----------------------|---------|----------|
-| `size`   | Controls the font size of the value: `sm` = size 1, `md` = size 3, `lg` = size 5. When used with `variant="card"`, `sm` is bold (`font-weight-700`) and `md`/`lg` are regular (`font-weight-400`). | `'sm' \| 'md' \| 'lg'` | `'sm'`  | No       |
+| Name   | Description                                                                                                                                                                                        | Type                   | Default | Required |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------- | -------- |
+| `size` | Controls the font size of the value: `sm` = size 1, `md` = size 3, `lg` = size 5. When used with `variant="card"`, `sm` is bold (`font-weight-700`) and `md`/`lg` are regular (`font-weight-400`). | `'sm' \| 'md' \| 'lg'` | `'sm'`  | No       |
 
 ### LgDataPointSecondaryLabelComponent
 
@@ -84,12 +96,10 @@ An optional add-on displayed below the secondary label (or below the value if no
 
 ### LgDataPointGroupComponent inputs
 
-| Name          | Description                                                                 | Type                         | Default        | Required |
-|---------------|-----------------------------------------------------------------------------|------------------------------|----------------|----------|
-| `orientation` | Sets how data points are arranged in the group                              | `'horizontal' \| 'vertical'` | `'horizontal'` | No       |
+| Name          | Description                                    | Type                         | Default        | Required |
+| ------------- | ---------------------------------------------- | ---------------------------- | -------------- | -------- |
+| `orientation` | Sets how data points are arranged in the group | `'horizontal' \| 'vertical'` | `'horizontal'` | No       |
 
-***
+---
 
-<Markdown>
-  {Feedback}
-</Markdown>
+<Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/docs/foundation/colours/colours.mdx
+++ b/projects/canopy/src/lib/docs/foundation/colours/colours.mdx
@@ -1,11 +1,13 @@
 import { Meta, Markdown, Story } from '@storybook/addon-docs/blocks';
 import Feedback from '../../common/feedback.md';
 import * as ColoursStories from './colours.stories.ts';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta of={ColoursStories} />
+<Meta of={ColoursStories} tags={['updated']} />
 
 # Colours
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v16.0.0" target="_blank" rel="noopener noreferrer">v16</a>.</span></span>
 <p class="standfirst">The Canopy colour palette is built on L&G’s brand colours and colour architecture, providing a clear, structured foundation for colour across all digital products. This palette ensures that every interface feels consistent, accessible, and unmistakably L&G, regardless of platform or product.</p>
 
 ## Principles

--- a/projects/canopy/src/lib/docs/foundation/design-tokens.mdx
+++ b/projects/canopy/src/lib/docs/foundation/design-tokens.mdx
@@ -1,9 +1,17 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../common/feedback.md';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Foundations/Design tokens" />
+<Meta title="Foundations/Design tokens" tags={['updated']} />
 
 # Design tokens
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v20.0.0" target="_blank" rel="noopener noreferrer">v20</a>.</span>
+</span>
 
 <p class="standfirst">Design tokens are one of the core building blocks of our visual language. All our Angular components, patterns, and templates we create are styled using our design tokens. This ensures a unified look and feel across our products, makes it easier to build and scale components, and provides a way for teams who can’t use the Canopy Angular library to style their components consistently with all of our applications.</p>
 

--- a/projects/canopy/src/lib/docs/foundation/layout-grid-and-spacing.mdx
+++ b/projects/canopy/src/lib/docs/foundation/layout-grid-and-spacing.mdx
@@ -7,11 +7,19 @@ import {
   getSpacingDisplayName,
   getResponsiveSpacingValue
 } from './spacing-utils';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
 
-<Meta title="Foundations/Layout, grid and spacing" />
+<Meta title="Foundations/Layout, grid and spacing" tags={['updated']} />
 
 # Layout, grid and spacing
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v19.0.0" target="_blank" rel="noopener noreferrer">v19</a>.</span>
+</span>
 
 <p class="standfirst">Our responsive layout grid adapts to screen size and orientation, ensuring consistency across layouts. Our common approach across design and development enables us to remain in sync during the development process.</p>
 

--- a/projects/canopy/src/lib/docs/foundation/typography/typography.mdx
+++ b/projects/canopy/src/lib/docs/foundation/typography/typography.mdx
@@ -10,11 +10,13 @@ import {
   getFontSizeBreakpointValuesForTable,
   getLineHeightBreakpointValuesForTable,
 } from './typography-utils.ts';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta of={TypographyStories} />
+<Meta of={TypographyStories} tags={['updated']} />
 
 # Typography
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v17.0.0" target="_blank" rel="noopener noreferrer">v17</a>.</span></span>
 <p class="standfirst">Effective use of typography is one of the most important ways we can convey the hierarchy of a page and help the customer understand the nature of the content within. We have two flavours of our type system; Productive and Expressive.</p>
 
 Productive type is our default system and should be used in the majority of cases. The Expressive system should be used in cases where it's necessary to imbue the design with a greater degree of brand personality, such as on the home page or other marketing pages. Adding more brand personality can make designs feel richer, but should be used judiciously and never at the expense of usability or accessibility.

--- a/projects/canopy/src/lib/docs/welcome/hero.component.ts
+++ b/projects/canopy/src/lib/docs/welcome/hero.component.ts
@@ -30,11 +30,13 @@ import { LgAlertComponent } from '../../alert';
         >
       </p>
       <p>
-        It's easy to see what's been updated already - if the menu item says 'pending'
-        then we haven't got to it yet - but we're working on it.
+        It's easy to see what's been updated already from the green 'updated' tag - if the
+        menu item says 'pending' then we haven't got to it yet - but we're working on it.
+        Each updated component has a link to the Canopy version it's available from.
         <a
           href="https://github.com/Legal-and-General/canopy/releases?q=&expanded=true"
           target="_blank"
+          rel="noopener noreferrer"
           >Find our releases here.</a
         >
       </p>

--- a/projects/canopy/src/lib/flag-icon/docs/flag-icons.stories.ts
+++ b/projects/canopy/src/lib/flag-icon/docs/flag-icons.stories.ts
@@ -40,6 +40,7 @@ class SwatchFlagIconComponent {
 
 export default {
   title: 'Foundations/Flag icon/Catalog',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ SwatchFlagIconComponent, LgFlagIconComponent ],

--- a/projects/canopy/src/lib/flag-icon/docs/guide.mdx
+++ b/projects/canopy/src/lib/flag-icon/docs/guide.mdx
@@ -1,10 +1,12 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as FlagIconStories from './flag-icons.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Foundations/Flag icon/Guide" />
+<Meta title="Foundations/Flag icon/Guide" tags={['updated']} />
 
 # Flag icon
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v24.0.0" target="_blank" rel="noopener noreferrer">v24</a>.</span></span>
 
 <p class="standfirst">Flag icons are coloured country flags typically used to support location toggle.</p>
 

--- a/projects/canopy/src/lib/footer/docs/footer.stories.ts
+++ b/projects/canopy/src/lib/footer/docs/footer.stories.ts
@@ -44,6 +44,7 @@ export const socialLinks = [
 
 export default {
   title: 'Components/Footer/Examples',
+  tags: [ 'updated' ],
   excludeStories: [ 'primaryLinks', 'socialLinks' ],
   component: LgFooterComponent,
   decorators: [

--- a/projects/canopy/src/lib/footer/docs/guide.mdx
+++ b/projects/canopy/src/lib/footer/docs/guide.mdx
@@ -1,14 +1,16 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as FooterStories from './footer.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Footer/Guide"/>
+<Meta title="Components/Footer/Guide" tags={['updated']}/>
 
 # Footer
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v26.0.0" target="_blank" rel="noopener noreferrer">v26</a>.</span></span>
 <p class="standfirst">Provides a generic footer to display at the bottom of the page.</p>
 
-### Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.
+*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
 
 ## Usage
 

--- a/projects/canopy/src/lib/forms/input/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/input/docs/guide.mdx
@@ -1,10 +1,12 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../docs/common/feedback.md';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Forms/Text input/Guide"/>
+<Meta title="Components/Forms/Text input/Guide" tags={['updated']}/>
 
 # Text input
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v25.0.0" target="_blank" rel="noopener noreferrer">v25</a>.</span></span>
 <p class="standfirst">Text input allows the user to enter a single line of text into a form.</p>
 
 ![Text input hero](docs/text-input/hero.png)

--- a/projects/canopy/src/lib/forms/input/docs/input.stories.ts
+++ b/projects/canopy/src/lib/forms/input/docs/input.stories.ts
@@ -203,6 +203,7 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Forms/Text input/Examples',
+  tags: [ 'updated' ],
   component: LgInputFieldComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/radio/guide.mdx
@@ -1,11 +1,13 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../../docs/common/feedback.md';
 import * as RadioStories from './radio.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Forms/Radio/Guide"/>
+<Meta title="Components/Forms/Radio/Guide" tags={['updated']} />
 
 # Radio
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v25.0.0" target="_blank" rel="noopener noreferrer">v25</a>.</span></span>
 <p class="standfirst">A radio button lets a user choose one option from a set of mutually exclusive choices.</p>
 
 ![Radio hero](docs/forms/radio/hero-radio.png)

--- a/projects/canopy/src/lib/forms/radio/docs/segment/guide.mdx
+++ b/projects/canopy/src/lib/forms/radio/docs/segment/guide.mdx
@@ -1,10 +1,12 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../../docs/common/feedback.md';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Forms/Segment/Guide" />
+<Meta title="Components/Forms/Segment/Guide" tags={['updated']}/>
 
 # Segment
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v25.0.0" target="_blank" rel="noopener noreferrer">v25</a>.</span></span>
 <p class="standfirst">A segment allows users to select a single option from a small set of mutually exclusive choices, typically used as a more prominent alternative to radio buttons.</p>
 
 ![Segment hero](docs/segment/hero.png)

--- a/projects/canopy/src/lib/forms/select/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/select/docs/guide.mdx
@@ -1,11 +1,13 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../docs/common/feedback.md';
 import * as SelectStories from './select.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Forms/Select/Guide" />
+<Meta title="Components/Forms/Select/Guide" tags={['updated']} />
 
 # Select
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v25.0.0" target="_blank" rel="noopener noreferrer">v25</a>.</span></span>
 <p class="standfirst">A drop down list that enables the user to choose between several options.</p>
 
 ![Select hero](docs/select/hero.png)

--- a/projects/canopy/src/lib/forms/select/docs/select.stories.ts
+++ b/projects/canopy/src/lib/forms/select/docs/select.stories.ts
@@ -73,6 +73,7 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Forms/Select/Examples',
+  tags: [ 'updated' ],
   component: LgSelectFieldComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
+++ b/projects/canopy/src/lib/forms/toggle/docs/checkbox/guide.mdx
@@ -1,10 +1,12 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../../docs/common/feedback.md';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Forms/Checkbox/Guide" />
+<Meta title="Components/Forms/Checkbox/Guide" tags={['updated']} />
 
 # Checkbox
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v25.0.0" target="_blank" rel="noopener noreferrer">v25</a>.</span></span>
 <p class="standfirst">A checkbox lets the user select one or more options from a set, with a clear visual indicator showing which options are selected.</p>
 
 ![Checkbox hero](docs/forms/checkbox/hero.png)

--- a/projects/canopy/src/lib/forms/validation/docs/form.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/docs/form.stories.ts
@@ -348,6 +348,7 @@ class ReactiveFormComponent {
 
 export default {
   title: 'Components/Forms/Form validation/Examples',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ ReactiveFormsModule, ReactiveFormComponent ],

--- a/projects/canopy/src/lib/forms/validation/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/validation/docs/guide.mdx
@@ -1,10 +1,12 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../docs/common/feedback.md';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Forms/Form validation/Guide" />
+<Meta title="Components/Forms/Form validation/Guide" tags={['updated']} />
 
 # Form validation
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v25.0.0" target="_blank" rel="noopener noreferrer">v25</a>.</span></span>
 <p class="standfirst">Form validation provides real-time or post-submission feedback to help users identify and correct errors in their input.</p>
 
 ![Form Validation Hero](docs/forms/validation/form-validation-hero.png)

--- a/projects/canopy/src/lib/forms/validation/docs/validation.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/docs/validation.stories.ts
@@ -28,6 +28,7 @@ class LgValidationExampleComponent {
 
 export default {
   title: 'Components/Forms/Form validation/Examples',
+  tags: [ 'updated' ],
   component: LgValidationComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/header/docs/guide.mdx
+++ b/projects/canopy/src/lib/header/docs/guide.mdx
@@ -1,10 +1,14 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as HeaderStories from './header.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Header/Guide" />
+<Meta title="Components/Header/Guide" tags={['updated']} />
 
 # Header
+
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v36.0.0" target="_blank" rel="noopener noreferrer">v36</a>.</span></span>
+
 <p class="standfirst">Provides a generic header for display at the top of the page.</p>
 
 *Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*

--- a/projects/canopy/src/lib/header/docs/header.stories.ts
+++ b/projects/canopy/src/lib/header/docs/header.stories.ts
@@ -284,6 +284,7 @@ class CoBrandedNavigationComponent {
 
 export default {
   title: 'Components/Header/Examples',
+  tags: [ 'updated' ],
   component: LgHeaderComponent,
   decorators: [
     moduleMetadata({

--- a/projects/canopy/src/lib/icon/docs/guide.mdx
+++ b/projects/canopy/src/lib/icon/docs/guide.mdx
@@ -2,13 +2,14 @@ import { Meta, Markdown, Unstyled } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Foundations/UI icon/Guide" />
+<Meta title="Foundations/UI icon/Guide" tags={['updated']} />
 
 # UI icon
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v24.0.0" target="_blank" rel="noopener noreferrer">v24</a>.</span></span>
 
 <p class="standfirst">UI icons are visual depictions of an object, action or idea. They're simple and easy to recognise, and can communicate a lot with very little.</p>
 
-### Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.
+*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
 
 ## Usage
 

--- a/projects/canopy/src/lib/icon/docs/icons.stories.ts
+++ b/projects/canopy/src/lib/icon/docs/icons.stories.ts
@@ -62,6 +62,7 @@ const colours = [
 
 export default {
   title: 'Foundations/UI icon/Catalog',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ SwatchIconComponent, LgIconComponent ],

--- a/projects/canopy/src/lib/link-menu/docs/guide.mdx
+++ b/projects/canopy/src/lib/link-menu/docs/guide.mdx
@@ -1,10 +1,12 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as LinkMenuStories from './link-menu.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Link menu/Guide"/>
+<Meta title="Components/Link menu/Guide" tags={['updated']} />
 
 # Link menu
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v23.0.0" target="_blank" rel="noopener noreferrer">v23</a>.</span></span>
 
 <p class="standfirst">A link menu displays a grouped list of navigation links, each with optional icons and descriptive text.</p>
 

--- a/projects/canopy/src/lib/link-menu/docs/link-menu.stories.ts
+++ b/projects/canopy/src/lib/link-menu/docs/link-menu.stories.ts
@@ -43,6 +43,7 @@ class LinkMenuStoryComponent {
 // This default export determines where your story goes in the story list
 export default {
   title: 'Components/Link menu/Examples',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ LinkMenuStoryComponent ],

--- a/projects/canopy/src/lib/list/docs/guide.mdx
+++ b/projects/canopy/src/lib/list/docs/guide.mdx
@@ -1,10 +1,13 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as ListStories from './lists.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/List with icons/Guide" />
+<Meta title="Components/List with icons/Guide" tags={['updated']} />
 
 # List with icons
+
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v37.0.0" target="_blank" rel="noopener noreferrer">v37</a>.</span></span>
 
 <p class="standfirst">
   Lists are used to list an array of items. Canopy provides components for icon-enhanced

--- a/projects/canopy/src/lib/list/docs/lists.stories.ts
+++ b/projects/canopy/src/lib/list/docs/lists.stories.ts
@@ -143,7 +143,7 @@ class OrderedListWithIconsWrapperComponent {
 
 export default {
   title: 'Components/List with icons/Examples',
-  tags: [],
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [

--- a/projects/canopy/src/lib/pagination/docs/guide.mdx
+++ b/projects/canopy/src/lib/pagination/docs/guide.mdx
@@ -1,17 +1,27 @@
 import { Meta, Markdown, Source } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import * as ComponentStories from './pagination.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Pagination/Guide" />
+<Meta title="Components/Pagination/Guide" tags={['updated']} />
 
 # Pagination
 
-<p class="standfirst">Controls a paginated list of items and exposes the current result range.</p>
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy {' '} <a href="https://github.com/Legal-and-General/canopy/releases/tag/v34.2.0" target="_blank" rel="noopener noreferrer">v34</a>.</span>
+</span>
 
-*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
+<p class="standfirst">
+  Controls a paginated list of items and exposes the current result range.
+</p>
+
+_Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component._
 
 ## Usage
-
 
 Import the component in your application:
 
@@ -74,31 +84,30 @@ On medium viewports (`md` breakpoint) the component shows a sliding window of 5 
 
 On small viewports (below `md`) the component shows a sliding window of 3 consecutive page buttons with no ellipses. The results label is displayed below the controls.
 
-
 ## Additional development details
 
 ### LgPaginationComponent inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
-| `id` | HTML `id` attribute, auto generated if not provided. | `string` | auto-generated | No |
-| `totalItems` | Total number of items in the paged collection. | `number` | `0` | No |
-| `itemsPerPage` | Maximum number of items shown per page. Values lower than `1` are clamped to `1`. | `number` | `10` | No |
-| `currentPage` | Current page number. Values are clamped to the valid page range. | `number` | `1` | No |
+| Name           | Description                                                                       | Type     | Default        | Required |
+| -------------- | --------------------------------------------------------------------------------- | -------- | -------------- | -------- |
+| `id`           | HTML `id` attribute, auto generated if not provided.                              | `string` | auto-generated | No       |
+| `totalItems`   | Total number of items in the paged collection.                                    | `number` | `0`            | No       |
+| `itemsPerPage` | Maximum number of items shown per page. Values lower than `1` are clamped to `1`. | `number` | `10`           | No       |
+| `currentPage`  | Current page number. Values are clamped to the valid page range.                  | `number` | `1`            | No       |
 
 ### LgPaginationComponent outputs
 
-| Output | Description | Value |
-|--------|-------------|-------|
+| Output        | Description                                                                                                                                | Value                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `pageChanged` | Emitted when the current page changes, including the requested page number and the zero-based start and end indexes for the visible slice. | `EventEmitter<PageData>` |
 
 ### PageData
 
-| Property | Description |
-|----------|-------------|
-| `pageNumber` | The requested page number. |
+| Property     | Description                                            |
+| ------------ | ------------------------------------------------------ |
+| `pageNumber` | The requested page number.                             |
 | `startIndex` | Zero-based inclusive start index for the current page. |
-| `endIndex` | Zero-based inclusive end index for the current page. |
+| `endIndex`   | Zero-based inclusive end index for the current page.   |
 
 ### Additional notes
 

--- a/projects/canopy/src/lib/pagination/docs/pagination.stories.ts
+++ b/projects/canopy/src/lib/pagination/docs/pagination.stories.ts
@@ -105,6 +105,7 @@ class PaginationStoryComponent implements OnInit, OnChanges {
 
 export default {
   title: 'Components/Pagination/Examples',
+  tags: [ 'updated' ],
   component: LgPaginationComponent,
   globals: {
     backgrounds: { value: 'light' },

--- a/projects/canopy/src/lib/pictogram/docs/guide.mdx
+++ b/projects/canopy/src/lib/pictogram/docs/guide.mdx
@@ -1,18 +1,30 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
+import * as PictogramStories from './pictogram.stories';
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Foundations/Pictogram/Guide"/>
+<Meta title="Foundations/Pictogram/Guide" tags={['updated']} />
 
 # Pictogram
 
-<p class="standfirst">A pictogram allows you to add supporting illustration to messages or journeys.</p>
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy {' '} <a href="https://github.com/Legal-and-General/canopy/releases/tag/v33.0.0" target="_blank" rel="noopener noreferrer">v33</a>.</span>
+</span>
+
+<p class="standfirst">
+  A pictogram allows you to add supporting illustration to messages or journeys.
+</p>
 
 Adding a pictogram can provide extra affordance and help users in making decisions or understanding the outcome of a journey.
 
 More illustrative and colourful than UI icons, pictograms draw attention, create narratives and help to visualise data.
 
+_Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component._
 
-*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
 ## Usage
 
 Consider using the message with illustration pattern for the end of journeys and for empty states.
@@ -50,15 +62,13 @@ Pictograms should be scaled according to the following sizes to ensure outlines 
 
 ### Do
 
-
-* **Do** scale pictograms according to the sizing chart above.
-* **Do** enable `hasFill` when using a pictogram in a self-service application only, to make the fill visible on neutral backgrounds.
+- **Do** scale pictograms according to the sizing chart above.
+- **Do** enable `hasFill` when using a pictogram in a self-service application only, to make the fill visible on neutral backgrounds.
 
 ### Don't
 
-
-* **Don't** use a pictogram in place of a UI icon, or at a size less than 160px.
-* **Don't** set `hasFill` to `true` to fill pictograms when using them in highly-branded scenarios such as in the Dotcom CMS.
+- **Don't** use a pictogram in place of a UI icon, or at a size less than 160px.
+- **Don't** set `hasFill` to `true` to fill pictograms when using them in highly-branded scenarios such as in the Dotcom CMS.
 
 ## Additional development details
 
@@ -73,9 +83,7 @@ Pictograms should be scaled according to the following sizes to ensure outlines 
 
 ## Related
 
-* [UI icon](./?path=/docs/foundations-ui-icon-guide--docs)
-* [Flag icon](./?path=/docs/foundations-flag-icon-guide--docs)
+- [UI icon](./?path=/docs/foundations-ui-icon-guide--docs)
+- [Flag icon](./?path=/docs/foundations-flag-icon-guide--docs)
 
-<Markdown>
-  {Feedback}
-</Markdown>
+<Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/pictogram/docs/pictogram.stories.ts
+++ b/projects/canopy/src/lib/pictogram/docs/pictogram.stories.ts
@@ -64,6 +64,7 @@ const sizes = [ 'md', 'lg', 'xl' ];
 
 export default {
   title: 'Foundations/Pictogram/Catalog',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ SwatchPictogramComponent, LgPictogramComponent ],

--- a/projects/canopy/src/styles/docs/link/guide.mdx
+++ b/projects/canopy/src/styles/docs/link/guide.mdx
@@ -1,11 +1,12 @@
 import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../../lib/docs/common/feedback.md';
-import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers'
+import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Link/Guide" />
+<Meta title="Components/Link/Guide" tags={['updated']} />
 
 # Link
 
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}><CustomBadge text="Updated" style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }} /><span class="small-text">for brand modernisation in Canopy{' '}<a href="https://github.com/Legal-and-General/canopy/releases/tag/v21.0.0" target="_blank" rel="noopener noreferrer">v21</a>.</span></span>
 <p class="standfirst">A Link is an interactive text element that enables users to navigate from one resource, page, or view to another—either within the application or to external destinations—in a way that is accessible to all users.</p>
 
 ![Link component example](docs/link/hero.png)

--- a/projects/canopy/src/styles/docs/link/link.stories.ts
+++ b/projects/canopy/src/styles/docs/link/link.stories.ts
@@ -6,6 +6,7 @@ import { LgMarginDirective } from '../../../lib/spacing';
 
 export default {
   title: 'Components/Link/Examples',
+  tags: [ 'updated' ],
   decorators: [
     moduleMetadata({
       imports: [ LgAlertComponent, LgIconComponent, LgMarginDirective ],


### PR DESCRIPTION
# Description

Canopy users want to know what version a brand modernised component will be available from

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
