### PR TITLE
fix(segment): amend margin on stacked

### DIFF
--- a/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
+++ b/projects/canopy/src/lib/forms/radio/radio-button--segment.component.scss
@@ -76,7 +76,6 @@
       @include mixins.lg-breakpoint($stack-breakpoint, 'max-width') {
         display: flex;
         flex-flow: column wrap;
-        margin: 0;
       }
 
       .lg-radio-button__label {

--- a/projects/canopy/src/lib/forms/select/select-field.component.scss
+++ b/projects/canopy/src/lib/forms/select/select-field.component.scss
@@ -36,11 +36,12 @@
     color: var(--form-error-border-color);
   }
 
-  .lg-select-field--error *:focus-visible + & {
-    color: inherit;
+  // Keep error icon colour when the select is focused.
+  .lg-select-field--error .lg-select:focus-visible + & {
+    color: var(--form-error-border-color);
   }
 
-  .lg-select-field:disabled & {
+  .lg-select:disabled + & {
     color: var(--disabled-color);
   }
 }

--- a/projects/canopy/src/lib/forms/select/select.scss
+++ b/projects/canopy/src/lib/forms/select/select.scss
@@ -43,7 +43,6 @@
 
   &--error,
   &--error:hover {
-    color: var(--select-error-colour);
     background: var(--select-error-background-colour);
     box-shadow: 0 0 0 var(--select-error-border-width)
       var(--select-error-background-colour);
@@ -51,11 +50,10 @@
   }
 
   &.lg-select--error:focus-visible {
-    color: var(--select-error-colour);
     background: var(--select-error-background-colour);
     box-shadow: 0 0 0 var(--select-error-border-width)
       var(--select-error-background-colour);
-    border: var(--text-input-rest-border-width) solid var(--select-error-border-colour);
+    border: var(--text-input-error-border-width) solid var(--select-error-border-colour);
     outline: 0;
   }
 

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.scss
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.scss
@@ -27,6 +27,7 @@
 }
 
 .lg-toggle__label > .lg-toggle__checkbox {
+  flex-shrink: 0;
   color: transparent;
   font-size: var(--_toggle-icon-font-size);
   margin: var(--_toggle-icon-margin-top) var(--checkbox-common-gap) auto 0;


### PR DESCRIPTION
Fixes # (issue)

Remove margin:0 on segments as this was breaking layout on segment when stacked

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
