### PR TITLE
ci(npm): security hardening fixed versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       interval: 'daily'
       time: '18:00'
       timezone: 'Europe/London'
+    cooldown:
+      default-days: 5
     pull-request-branch-name:
       separator: '-'
     groups:
@@ -41,6 +43,8 @@ updates:
       interval: 'daily'
       time: '18:00'
       timezone: 'Europe/London'
+    cooldown:
+      default-days: 5
     pull-request-branch-name:
       separator: '-'
     groups:
@@ -100,6 +104,8 @@ updates:
       interval: 'daily'
       time: '18:00'
       timezone: 'Europe/London'
+    cooldown:
+      default-days: 5
     pull-request-branch-name:
       separator: '-'
     groups:

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 registry=https://registry.npmjs.org/
 legacy-peer-deps=true
 save-exact=true
-min-release-age=2
+min-release-age=5

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "svg-to-ts": "12.0.0",
         "svgo": "4.0.1",
         "ts-node": "10.9.2",
-        "typescript": "~5.9.3",
+        "typescript": "5.9.3",
         "webpack": "5.106.1",
         "webpack-cli": "7.0.2",
         "webpack-remove-empty-scripts": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "svg-to-ts": "12.0.0",
     "svgo": "4.0.1",
     "ts-node": "10.9.2",
-    "typescript": "~5.9.3",
+    "typescript": "5.9.3",
     "webpack": "5.106.1",
     "webpack-cli": "7.0.2",
     "webpack-remove-empty-scripts": "1.1.1"

--- a/projects/canopy/package.json
+++ b/projects/canopy/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/Legal-and-General/canopy",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "date-fns": "^2.29.2"
+    "date-fns": "2.29.2"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
@@ -21,6 +21,6 @@
   "metadata": "canopy.metadata.json",
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^2.4.0"
+    "tslib": "2.4.0"
   }
 }


### PR DESCRIPTION
# Description
- Set Dependabot to have the cooldown property set to 5
- Set .npmrc to have min-release-age set to 5
- Set all packages in package.json are fixed versions (no ~ or ^)

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [ ] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [ ] I have provided a story in storybook to document the changes
- [ ] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
