### PR TITLE
feat(table): update for brand modernisation

### DIFF
--- a/projects/canopy/src/lib/table/docs/guide.mdx
+++ b/projects/canopy/src/lib/table/docs/guide.mdx
@@ -2,19 +2,20 @@ import { Meta, Markdown } from '@storybook/addon-docs/blocks';
 import Feedback from '../../docs/common/feedback.md?raw';
 import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
-<Meta title="Components/Table/Guide" tags={['pending']} />
+<Meta title="Components/Table/Guide" tags={['updated']}/>
 
 # Table
 
-<CustomBadge
-  text="Pending"
-  style={{ backgroundColor: '#005dba', borderColor: '#005dba', color: '#fff' }}
-/>
-<span class="small-text">Due for brand modernisation</span>
+<span style={{ display: 'inline-flex', alignItems: 'baseline', gap: '0.25rem' }}>
+  <CustomBadge
+    text="Updated"
+    style={{ backgroundColor: '#caeedd', borderColor: '#caeedd' }}
+  />
+  <span class="small-text">for brand modernisation in Canopy {' '} <a href="https://github.com/Legal-and-General/canopy/releases/tag/v40.0.0" target="_blank" rel="noopener noreferrer">v40</a>.</span>
+</span>
 
 <p class="standfirst">Tables display large amounts of structured information in a format that's easy to scan and read.</p>
-
-![example](docs/table/example.png)
+*Design guidance for this component is currently being rewritten. Please contact the Canopy team if you need more information on how to use this component.*
 
 ## Usage
 
@@ -23,10 +24,7 @@ Use a table to display tabular data. Tables are usually the best solution to all
 Import the table components into your application:
 
 ```js
-@NgModule({
-  ...
-  imports: [ ..., LgTableComponent, etc. ],
-});
+import { LgTableComponent } from '@legal-and-general/canopy';
 ```
 
 ### Simple example
@@ -52,6 +50,13 @@ Import the table components into your application:
       <td lg-table-cell>1947</td>
     </tr>
   </tbody>
+  <tfoot lg-table-foot>
+    <tr lg-table-row>
+      <td lg-table-cell></td>
+      <td lg-table-cell>Total books</td>
+      <td lg-table-cell>2</td>
+    </tr>
+  </tfoot>
 </table>
 ```
 
@@ -156,16 +161,12 @@ Also note the use of the [margin directive](./?path=/docs/helpers-directives-mar
 
 ### Do
 
-![do](docs/table/do.png)
-
 1. **Do** alternate row colours to aid table scanning.
 2. **Do** use table headers to establish an information hierarchy and communicate what the rows and columns represent.
 3. **Do** align numbers right in table cells when comparing columns of numbers and use the 1,000 separator for easy recognition.
 4. **Do** consider the responsive mobile view when you're designing your table layout.
 
 ### Don't
-
-![dont](docs/table/dont.png)
 
 1. **Don't** increase visual noise by using both horizontal and vertical lines to separate cells, use adequate padding instead.
 2. **Don't** centre align content vertically.
@@ -188,6 +189,10 @@ A component that acts as a standard table.
 ### LgTableBodyComponent
 
 A component that acts as a standard table body.
+
+### LgTableFootComponent
+
+A component that acts as a standard table footer.
 
 ### LgTableCellComponent
 
@@ -216,7 +221,7 @@ A component that acts as a standard table header cell.
 
 | Name        | Description                                                            | Type             | Default | Required |
 | ----------- | ---------------------------------------------------------------------- | ---------------- | ------- | -------- |
-| `align`     | Alignment option for the header and its respective column              | `start` or `end` | `start` | No       |
+| `align`     | Alignment option for the header and its respective column              | `start`, `centre` or `end` | `start` | No       |
 | `showLabel` | Whether to show label for this header in each row in non-column layout | `boolean`        | `true`  | No       |
 
 #### LgTableRowComponent

--- a/projects/canopy/src/lib/table/docs/table.stories.ts
+++ b/projects/canopy/src/lib/table/docs/table.stories.ts
@@ -516,6 +516,9 @@ export default {
       ],
     }),
   ],
+  parameters: {
+    backgrounds: { disable: true },
+  },
   argTypes,
 };
 

--- a/projects/canopy/src/lib/table/docs/table.stories.ts
+++ b/projects/canopy/src/lib/table/docs/table.stories.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, inject, Input } from '@angular/core';
 import { moduleMetadata } from '@storybook/angular';
 
-import type { TableVariant } from '../table.interface';
+import type { TableRowVariant, TableVariant } from '../table.interface';
 import { AlignmentOptions, TableColumnLayoutBreakpoints } from '../table.interface';
 import { LgTableComponent } from '../table/table.component';
 import { LgTableExpandedDetailComponent } from '../table-expanded-detail/table-expanded-detail.component';
@@ -10,6 +10,7 @@ import { LgTableRowComponent } from '../table-row/table-row.component';
 import { LgTableRowToggleComponent } from '../table-row-toggle/table-row-toggle.component';
 import { LgTableHeadCellComponent } from '../table-head-cell/table-head-cell.component';
 import { LgTableHeadComponent } from '../table-head/table-head.component';
+import { LgTableFootComponent } from '../table-foot/table-foot.component';
 import { LgTableBodyComponent } from '../table-body/table-body.component';
 import { LgInputDirective, LgInputFieldComponent } from '../../forms';
 import { LgMarginDirective } from '../../spacing';
@@ -21,12 +22,23 @@ import {
 } from '../../grid';
 import { LgButtonComponent } from '../../button';
 import { LgIconComponent } from '../../icon';
+import type { Colour, ColourTheme } from '../../colour';
+import { LgColourDirective } from '../../colour';
+import { LgCardComponent, LgCardContentComponent } from '../../card';
 
 interface TableStoryItem {
   author: string;
   title: string;
   published: string;
 }
+
+interface TableStoryModeArgs {
+  mode: Colour;
+  theme: ColourTheme;
+}
+
+const colours: Array<Colour> = [ 'blue', 'green', 'red', 'yellow' ];
+const themes: Array<ColourTheme> = [ 'neutral', 'neutral-inverse', 'subtle', 'bold' ];
 
 function getDefaultTableContent(): Array<TableStoryItem> {
   return [
@@ -141,12 +153,12 @@ export class StoryTableDetailComponent {
   private cd = inject(ChangeDetectorRef);
 
   @Input() books: Array<TableStoryItem> = [];
-  @Input() variant: TableVariant;
-  @Input() alignPublishColumn: AlignmentOptions;
-  @Input() showAuthorLabel: boolean;
-  @Input() columnBreakpoint: TableColumnLayoutBreakpoints;
+  @Input() variant!: TableVariant;
+  @Input() alignPublishColumn!: AlignmentOptions;
+  @Input() showAuthorLabel!: boolean;
+  @Input() columnBreakpoint!: TableColumnLayoutBreakpoints;
   @Input() expandedRows: Array<number> = [];
-  @Input() stack: boolean;
+  @Input() stack!: boolean;
 
   get colspan() {
     return Object.keys(this.books[0]).length + 1;
@@ -281,12 +293,48 @@ const withLongCopyTableTemplate = `
   ],
 })
 class StoryTableLongCopyComponent {
-  @Input() variant: TableVariant;
-  @Input() stack: boolean;
+  @Input() variant!: TableVariant;
+  @Input() stack!: boolean;
 }
 
 const responsiveCategory = 'Responsive options';
 const alignmentCategory = 'Alignment';
+const colourCategory = 'Colour';
+
+const colourArgTypes = {
+  mode: {
+    options: colours,
+    description: 'The colour mode to apply to the card containing the table.',
+    table: {
+      category: colourCategory,
+      type: {
+        summary: colours,
+      },
+      defaultValue: {
+        summary: 'blue',
+      },
+    },
+    control: {
+      type: 'select',
+    },
+  },
+  theme: {
+    options: themes,
+    description: 'The theme to apply to the card containing the table.',
+    table: {
+      category: colourCategory,
+      type: {
+        summary: themes,
+      },
+      defaultValue: {
+        summary: 'neutral',
+      },
+    },
+    control: {
+      type: 'select',
+    },
+  },
+};
 
 const argTypes = {
   variant: {
@@ -323,12 +371,12 @@ const argTypes = {
     },
   },
   alignTitleColumn: {
-    options: [ AlignmentOptions.End, AlignmentOptions.Start ],
+    options: [ AlignmentOptions.Start, AlignmentOptions.Centre, AlignmentOptions.End ],
     description: 'Align Title column.',
     table: {
       category: alignmentCategory,
       type: {
-        summary: [ AlignmentOptions.End, AlignmentOptions.Start ],
+        summary: [ AlignmentOptions.Start, AlignmentOptions.Centre, AlignmentOptions.End ],
       },
     },
     control: {
@@ -336,12 +384,28 @@ const argTypes = {
     },
   },
   alignPublishColumn: {
-    options: [ AlignmentOptions.End, AlignmentOptions.Start ],
+    options: [ AlignmentOptions.Start, AlignmentOptions.Centre, AlignmentOptions.End ],
     description: 'Align Publish column.',
     table: {
       category: alignmentCategory,
       type: {
-        summary: [ AlignmentOptions.End, AlignmentOptions.Start ],
+        summary: [ AlignmentOptions.Start, AlignmentOptions.Centre, AlignmentOptions.End ],
+      },
+    },
+    control: {
+      type: 'select',
+    },
+  },
+  rowVariant: {
+    options: [ null, 'error', 'selected' ],
+    description: 'Apply a visual variant to the row. Accepts `error`, or `selected`.',
+    table: {
+      category: 'Variant',
+      type: {
+        summary: [ 'error', 'selected' ],
+      },
+      defaultValue: {
+        summary: 'null',
       },
     },
     control: {
@@ -427,7 +491,7 @@ const argTypes = {
 
 export default {
   title: 'Components/Table/Examples',
-  tags: [ 'pending' ],
+  tags: [ 'updated' ],
   component: LgTableComponent,
   excludeStories: [ 'StoryTableDetailComponent' ],
   decorators: [
@@ -437,6 +501,7 @@ export default {
         StoryTableLongCopyComponent,
         LgTableComponent,
         LgTableHeadComponent,
+        LgTableFootComponent,
         LgTableRowComponent,
         LgTableHeadCellComponent,
         LgTableBodyComponent,
@@ -445,6 +510,9 @@ export default {
         LgInputDirective,
         LgMarginDirective,
         LgSuffixDirective,
+        LgColourDirective,
+        LgCardComponent,
+        LgCardContentComponent,
       ],
     }),
   ],
@@ -452,43 +520,136 @@ export default {
 };
 
 const standardTableTemplate = `
-<table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
-  <thead lg-table-head>
-    <tr lg-table-row>
-      <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
-      <th lg-table-head-cell [align]="alignTitleColumn">Title</th>
-      <th lg-table-head-cell [align]="alignPublishColumn">Published</th>
-    </tr>
-  </thead>
+<lg-card lgMarginHorizontal="none" [lgColour]="mode" [lgColourTheme]="theme">
+  <lg-card-content>
+    <table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
+      <thead lg-table-head>
+        <tr lg-table-row>
+          <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
+          <th lg-table-head-cell [align]="alignTitleColumn">Title</th>
+          <th lg-table-head-cell [align]="alignPublishColumn">Published</th>
+        </tr>
+      </thead>
 
-  <tbody lg-table-body>
-    @for (book of books; track book.title) {
-      <tr lg-table-row>
-        <td lg-table-cell [stack]="stack">{{ book.author }}</td>
-        <td lg-table-cell [stack]="stack">{{ book.title }}</td>
-        <td lg-table-cell [stack]="stack">{{ book.published }}</td>
-      </tr>
-    }
-  </tbody>
-</table>
+      <tbody lg-table-body>
+        @for (book of books; track book.title) {
+          <tr lg-table-row>
+            <td lg-table-cell [stack]="stack">{{ book.author }}</td>
+            <td lg-table-cell [stack]="stack">{{ book.title }}</td>
+            <td lg-table-cell [stack]="stack">{{ book.published }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </lg-card-content>
+</lg-card>
 `;
+
+const rowVariantsTableTemplate = `
+<table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
+    <thead lg-table-head>
+      <tr lg-table-row>
+        <th lg-table-head-cell>Author</th>
+        <th lg-table-head-cell [align]="alignTitleColumn">Title</th>
+        <th lg-table-head-cell [align]="alignPublishColumn">Published</th>
+      </tr>
+    </thead>
+
+    <tbody lg-table-body>
+      <tr lg-table-row>
+        <td lg-table-cell>Orhan Pamuk</td>
+        <td lg-table-cell>Strangeness In My Mind</td>
+        <td lg-table-cell>2016</td>
+      </tr>
+      <tr lg-table-row rowVariant="error">
+        <td lg-table-cell>George Orwell</td>
+        <td lg-table-cell>Animal Farm (error)</td>
+        <td lg-table-cell>1945</td>
+      </tr>
+      <tr lg-table-row rowVariant="selected">
+        <td lg-table-cell>Chinua Achebe</td>
+        <td lg-table-cell>Things Fall Apart (selected)</td>
+        <td lg-table-cell>1958</td>
+      </tr>
+      <tr lg-table-row>
+        <td lg-table-cell>Brian Greene</td>
+        <td lg-table-cell>The Elegant Universe</td>
+        <td lg-table-cell>1999</td>
+      </tr>
+    </tbody>
+
+    <tfoot lg-table-foot>
+      <tr lg-table-row>
+        <td lg-table-cell></td>
+        <td lg-table-cell [align]="alignTitleColumn">Total books</td>
+        <td lg-table-cell [align]="alignPublishColumn">5</td>
+      </tr>
+    </tfoot>
+  </table>
+`;
+
+export const RowVariantsTable = {
+  name: 'Row variants',
+  render: (args: LgTableComponent & { rowVariant: TableRowVariant }) => ({
+    props: args,
+    template: rowVariantsTableTemplate,
+  }),
+  args: {
+    variant: 'striped',
+    alignTitleColumn: AlignmentOptions.Start,
+    alignPublishColumn: AlignmentOptions.End,
+    columnBreakpoint: TableColumnLayoutBreakpoints.Medium,
+  },
+  argTypes: {
+    ...argTypes,
+    showAuthorLabel: {
+      table: {
+        disable: true,
+      },
+    },
+    stack: {
+      table: {
+        disable: true,
+      },
+    },
+    rowVariant: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: rowVariantsTableTemplate,
+      },
+    },
+  },
+};
 
 export const StandardTable = {
   name: 'Standard',
-  render: (args: LgTableComponent) => ({
+  render: (args: LgTableComponent & TableStoryModeArgs) => ({
     props: args,
     template: standardTableTemplate,
   }),
   args: {
     books: getDefaultTableContent(),
+    mode: 'blue',
+    theme: 'neutral',
     variant: 'striped',
     alignTitleColumn: AlignmentOptions.Start,
     alignPublishColumn: AlignmentOptions.End,
     columnBreakpoint: TableColumnLayoutBreakpoints.Medium,
-    showAuthorLabel: false,
+    showAuthorLabel: true,
     stack: false,
   },
+  argTypes: {
+    ...argTypes,
+    ...colourArgTypes,
+  },
   parameters: {
+    themes: { disable: true },
     docs: {
       source: {
         code: standardTableTemplate,
@@ -511,7 +672,7 @@ export const ExpandableTable = {
     alignTitleColumn: AlignmentOptions.Start,
     alignPublishColumn: AlignmentOptions.End,
     columnBreakpoint: TableColumnLayoutBreakpoints.Medium,
-    showAuthorLabel: false,
+    showAuthorLabel: true,
     stack: false,
   },
   argTypes: {
@@ -538,27 +699,27 @@ export const ExpandableTable = {
 
 const withInputTableTemplate = `
 <table lg-table [variant]="variant">
-  <thead lg-table-head>
-    <tr lg-table-row>
-      <th lg-table-head-cell>Author</th>
-      <th lg-table-head-cell>Rating</th>
-    </tr>
-  </thead>
-
-  <tbody lg-table-body>
-    @for (book of books; track book.author) {
+    <thead lg-table-head>
       <tr lg-table-row>
-        <td lg-table-cell>{{ book.author }}</td>
-        <td lg-table-cell>
-          <lg-input-field lgMarginBottom="none" showLabel="false">
-            <input lgInput size="2" />
-            <span lgSuffix>%</span>
-          </lg-input-field>
-        </td>
+        <th lg-table-head-cell>Author</th>
+        <th lg-table-head-cell>Rating</th>
       </tr>
-    }
-  </tbody>
-</table>
+    </thead>
+
+    <tbody lg-table-body>
+      @for (book of books; track book.author) {
+        <tr lg-table-row>
+          <td lg-table-cell>{{ book.author }}</td>
+          <td lg-table-cell>
+            <lg-input-field lgMarginBottom="none" showLabel="false">
+              <input lgInput size="2" />
+              <span lgSuffix>%</span>
+            </lg-input-field>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
 `;
 
 export const WithInputTable = {

--- a/projects/canopy/src/lib/table/docs/table.stories.ts
+++ b/projects/canopy/src/lib/table/docs/table.stories.ts
@@ -13,18 +13,13 @@ import { LgTableHeadComponent } from '../table-head/table-head.component';
 import { LgTableFootComponent } from '../table-foot/table-foot.component';
 import { LgTableBodyComponent } from '../table-body/table-body.component';
 import { LgInputDirective, LgInputFieldComponent } from '../../forms';
+import { LgToggleComponent } from '../../forms/toggle';
 import { LgMarginDirective } from '../../spacing';
 import { LgSuffixDirective } from '../../suffix';
-import {
-  LgGridColDirective,
-  LgGridContainerDirective,
-  LgGridRowDirective,
-} from '../../grid';
 import { LgButtonComponent } from '../../button';
 import { LgIconComponent } from '../../icon';
 import type { Colour, ColourTheme } from '../../colour';
 import { LgColourDirective } from '../../colour';
-import { LgCardComponent, LgCardContentComponent } from '../../card';
 
 interface TableStoryItem {
   author: string;
@@ -95,6 +90,14 @@ function getDefaultTableContent(): Array<TableStoryItem> {
   ];
 }
 
+function getFundTableContent(): Array<TableStoryItem> {
+  return Array.from({ length: 5 }, (_, index) => ({
+    author: `Fund ${index + 1}`,
+    title: '',
+    published: '',
+  }));
+}
+
 const expandableTableTemplate = `
 <table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
     <thead lg-table-head>
@@ -122,9 +125,13 @@ const expandableTableTemplate = `
         <td lg-table-cell>{{ book.title }}</td>
         <td lg-table-cell>{{ book.published }}</td>
       </tr>
-      <tr lg-table-row [isHidden]="expandedRows.indexOf(i) < 0">
+      <tr
+        lg-table-row
+        [isHidden]="expandedRows.indexOf(i) < 0 && closingRows.indexOf(i) < 0">
         <td lg-table-cell [colspan]="colspan">
-          <lg-table-expanded-detail>
+          <lg-table-expanded-detail
+            [class.lg-table-expanded-detail--active]="expandedRows.indexOf(i) > -1"
+            (transitionend)="hideCollapsedRow(i, $event)">
             {{ book.title }} was published in {{ book.published }} by
             {{ book.author }}
           </lg-table-expanded-detail>
@@ -159,6 +166,7 @@ export class StoryTableDetailComponent {
   @Input() columnBreakpoint!: TableColumnLayoutBreakpoints;
   @Input() expandedRows: Array<number> = [];
   @Input() stack!: boolean;
+  closingRows: Array<number> = [];
 
   get colspan() {
     return Object.keys(this.books[0]).length + 1;
@@ -168,110 +176,118 @@ export class StoryTableDetailComponent {
     const matchIndex = this.expandedRows.findIndex(i => i === index);
 
     if (matchIndex < 0) {
+      this.closingRows = this.closingRows.filter(rowIndex => rowIndex !== index);
       this.expandedRows.push(index);
     } else {
       this.expandedRows.splice(matchIndex, 1);
+      this.closingRows.push(index);
     }
 
     // Force story to respond to toggle events after data input changes
     // https://github.com/storybookjs/storybook/issues/7242
     this.cd.detectChanges();
   }
+
+  hideCollapsedRow(index: number, event: TransitionEvent) {
+    if (
+      event.propertyName !== 'grid-template-rows' ||
+      this.expandedRows.includes(index)
+    ) {
+      return;
+    }
+
+    this.closingRows = this.closingRows.filter(rowIndex => rowIndex !== index);
+    this.cd.detectChanges();
+  }
 }
 
 const withLongCopyTableTemplate = `
-<div lgContainer>
-  <div lgRow>
-    <div lgCol="12">
-      <table lg-table [variant]="variant">
-        <colgroup>
-          <col span="1" style="width: 65%;" />
-          <col span="1" style="width: 35%;" />
-        </colgroup>
-        <thead lg-table-head>
-          <tr lg-table-row>
-            <th lg-table-head-cell [showLabel]="false">Item</th>
-            <th lg-table-head-cell>More information</th>
-          </tr>
-        </thead>
+<table lg-table [variant]="variant">
+  <colgroup>
+    <col span="1" style="width: 65%;" />
+    <col span="1" style="width: 35%;" />
+  </colgroup>
+  <thead lg-table-head>
+    <tr lg-table-row>
+      <th lg-table-head-cell [showLabel]="false">Item</th>
+      <th lg-table-head-cell>More information</th>
+    </tr>
+  </thead>
 
-        <tbody lg-table-body>
-          <tr lg-table-row>
-            <td lg-table-cell [stack]="stack">
-              <h1 class="lg-font-size-1--700" lgMarginVertical="3">
-                Item one: Lorem ipsum dolor sit amet
-              </h1>
-              <p lgMarginBottom="3">
-                consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-                <a href="#">labore et dolore magna</a> aliqua. Ut enim ad minim
-                veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo consequat. Duis aute irure dolor in reprehenderit in
-                voluptate velit esse cillum dolore eu. Excepteur sint occaecat
-                cupidatat non proident.
-              </p>
-            </td>
-            <td lg-table-cell [stack]="stack">
-              <p>Sed ut perspiciatis</p>
-              <p>
-                emo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
-                fugit, sed quia consequuntur.
-              </p>
-              <button lg-button type="button" priority="link">
-                <lg-icon name="information-filled" />
-                More information
-              </button>
-            </td>
-          </tr>
-          <tr lg-table-row>
-            <td lg-table-cell [stack]="stack">
-              <h1 class="lg-font-size-1--700" lgMarginVertical="3">
-                Item two: At vero eos et accusamus
-              </h1>
-              <p>
-                Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil.
-              </p>
-              <p lgMarginBottom="3">
-                Temporibus autem quibusdam et aut officiis debitis aut rerum
-                necessitatibus saepe eveniet ut et voluptates repudiandae sint et
-                molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente
-                delectus, ut aut reiciendis voluptatibus maiores alias consequatur.
-              </p>
-            </td>
-            <td lg-table-cell [stack]="stack">
-              <p>
-                Et harum quidem rerum facilis est et expedita distinctio. Nam libero
-                tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo
-                minus id quod.
-              </p>
-              <button lg-button type="button" priority="link">
-                <lg-icon name="chevron-right-circle" />
-                Contact us
-              </button>
-            </td>
-          </tr>
-          <tr lg-table-row>
-            <td lg-table-cell [stack]="stack">
-              <h1 class="lg-font-size-1--700" lgMarginVertical="3">
-                Item three: Ut enim ad minima veniam
-              </h1>
-              <p>Proportionate final payment: Applies</p>
-              <p lgMarginBottom="3">
-                Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse
-                quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo
-                voluptas nulla pariatur. Tempora incidunt ut labore et dolore magnam
-                aliquam quaerat voluptatem.
-              </p>
-            </td>
-            <td lg-table-cell [stack]="stack">
-              Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis
-              voluptatibus maiores.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</div>
+  <tbody lg-table-body>
+    <tr lg-table-row>
+      <td lg-table-cell [stack]="stack">
+        <h1 class="lg-font-size-1--700" lgMarginVertical="3">
+          Item one: Lorem ipsum dolor sit amet
+        </h1>
+        <p lgMarginBottom="3">
+          consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+          <a href="#">labore et dolore magna</a> aliqua. Ut enim ad minim
+          veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+          ea commodo consequat. Duis aute irure dolor in reprehenderit in
+          voluptate velit esse cillum dolore eu. Excepteur sint occaecat
+          cupidatat non proident.
+        </p>
+      </td>
+      <td lg-table-cell [stack]="stack">
+        <p>Sed ut perspiciatis</p>
+        <p>
+          emo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
+          fugit, sed quia consequuntur.
+        </p>
+        <button lg-button type="button" priority="link">
+          <lg-icon name="information-filled" />
+          More information
+        </button>
+      </td>
+    </tr>
+    <tr lg-table-row>
+      <td lg-table-cell [stack]="stack">
+        <h1 class="lg-font-size-1--700" lgMarginVertical="3">
+          Item two: At vero eos et accusamus
+        </h1>
+        <p>
+          Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil.
+        </p>
+        <p lgMarginBottom="3">
+          Temporibus autem quibusdam et aut officiis debitis aut rerum
+          necessitatibus saepe eveniet ut et voluptates repudiandae sint et
+          molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente
+          delectus, ut aut reiciendis voluptatibus maiores alias consequatur.
+        </p>
+      </td>
+      <td lg-table-cell [stack]="stack">
+        <p>
+          Et harum quidem rerum facilis est et expedita distinctio. Nam libero
+          tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo
+          minus id quod.
+        </p>
+        <button lg-button type="button" priority="link">
+          <lg-icon name="chevron-right-circle" />
+          Contact us
+        </button>
+      </td>
+    </tr>
+    <tr lg-table-row>
+      <td lg-table-cell [stack]="stack">
+        <h1 class="lg-font-size-1--700" lgMarginVertical="3">
+          Item three: Ut enim ad minima veniam
+        </h1>
+        <p>Proportionate final payment: Applies</p>
+        <p lgMarginBottom="3">
+          Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse
+          quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo
+          voluptas nulla pariatur. Tempora incidunt ut labore et dolore magnam
+          aliquam quaerat voluptatem.
+        </p>
+      </td>
+      <td lg-table-cell [stack]="stack">
+        Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis
+        voluptatibus maiores.
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 @Component({
@@ -285,9 +301,6 @@ const withLongCopyTableTemplate = `
     LgTableRowComponent,
     LgTableCellComponent,
     LgMarginDirective,
-    LgGridContainerDirective,
-    LgGridRowDirective,
-    LgGridColDirective,
     LgButtonComponent,
     LgIconComponent,
   ],
@@ -295,6 +308,75 @@ const withLongCopyTableTemplate = `
 class StoryTableLongCopyComponent {
   @Input() variant!: TableVariant;
   @Input() stack!: boolean;
+}
+
+const withInputTableTemplate = `
+<table lg-table [variant]="variant">
+  <thead lg-table-head>
+    <tr lg-table-row>
+      <th lg-table-head-cell>Fund name</th>
+      <th lg-table-head-cell [align]="alignSplitColumn">Split of pension pot</th>
+    </tr>
+  </thead>
+
+  <tbody lg-table-body>
+    @for (book of books; track book.author; let i = $index) {
+      <tr lg-table-row>
+        <td lg-table-cell>{{ book.author }}</td>
+        <td lg-table-cell [align]="alignSplitColumn">
+          <lg-input-field [block]="false" lgMarginBottom="none" showLabel="false">
+            <input
+              lgInput
+              size="2"
+              type="number"
+              [value]="ratings[i]"
+              (input)="updateRating(i, $event)" />
+            <span lgSuffix>%</span>
+          </lg-input-field>
+        </td>
+      </tr>
+    }
+  </tbody>
+
+  <tfoot lg-table-foot>
+    <tr lg-table-row>
+      <td lg-table-cell>Total</td>
+      <td lg-table-cell [align]="alignSplitColumn">{{ total }}%</td>
+    </tr>
+  </tfoot>
+</table>
+`;
+
+@Component({
+  selector: 'lg-story-table-with-input',
+  template: withInputTableTemplate,
+  imports: [
+    LgTableComponent,
+    LgTableHeadComponent,
+    LgTableHeadCellComponent,
+    LgTableBodyComponent,
+    LgTableFootComponent,
+    LgTableRowComponent,
+    LgTableCellComponent,
+    LgInputFieldComponent,
+    LgInputDirective,
+    LgMarginDirective,
+    LgSuffixDirective,
+  ],
+})
+class StoryTableWithInputComponent {
+  @Input() books: Array<TableStoryItem> = [];
+  @Input() variant!: TableVariant;
+  alignSplitColumn = AlignmentOptions.End;
+  ratings = [ 20, 20, 20, 20, 20 ];
+
+  get total() {
+    return this.ratings.reduce((total, rating) => total + rating, 0);
+  }
+
+  updateRating(index: number, event: Event) {
+    this.ratings[index] = (event.target as HTMLInputElement).valueAsNumber || 0;
+  }
 }
 
 const responsiveCategory = 'Responsive options';
@@ -353,23 +435,6 @@ const argTypes = {
       type: 'select',
     },
   },
-  showColumnsAt: {
-    options: [ 'sm', 'md', 'lg' ],
-    description:
-      'Sets the minimum screen width from which the column layout is displayed..',
-    table: {
-      category: responsiveCategory,
-      type: {
-        summary: [ 'sm', 'md', 'lg' ],
-      },
-      defaultValue: {
-        summary: 'md',
-      },
-    },
-    control: {
-      type: 'select',
-    },
-  },
   alignTitleColumn: {
     options: [ AlignmentOptions.Start, AlignmentOptions.Centre, AlignmentOptions.End ],
     description: 'Align Title column.',
@@ -410,6 +475,11 @@ const argTypes = {
     },
     control: {
       type: 'select',
+    },
+  },
+  showColumnsAt: {
+    table: {
+      disable: true,
     },
   },
   columnBreakpoint: {
@@ -499,6 +569,7 @@ export default {
       imports: [
         StoryTableDetailComponent,
         StoryTableLongCopyComponent,
+        StoryTableWithInputComponent,
         LgTableComponent,
         LgTableHeadComponent,
         LgTableFootComponent,
@@ -508,11 +579,10 @@ export default {
         LgTableCellComponent,
         LgInputFieldComponent,
         LgInputDirective,
+        LgToggleComponent,
         LgMarginDirective,
         LgSuffixDirective,
         LgColourDirective,
-        LgCardComponent,
-        LgCardContentComponent,
       ],
     }),
   ],
@@ -523,9 +593,12 @@ export default {
 };
 
 const standardTableTemplate = `
-<lg-card lgMarginHorizontal="none" [lgColour]="mode" [lgColourTheme]="theme">
-  <lg-card-content>
-    <table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
+<table
+  lg-table
+  [lgColour]="mode"
+  [lgColourTheme]="theme"
+  [showColumnsAt]="columnBreakpoint"
+  [variant]="variant">
       <thead lg-table-head>
         <tr lg-table-row>
           <th lg-table-head-cell [showLabel]="showAuthorLabel">Author</th>
@@ -544,8 +617,6 @@ const standardTableTemplate = `
         }
       </tbody>
     </table>
-  </lg-card-content>
-</lg-card>
 `;
 
 const rowVariantsTableTemplate = `
@@ -564,13 +635,27 @@ const rowVariantsTableTemplate = `
         <td lg-table-cell>Strangeness In My Mind</td>
         <td lg-table-cell>2016</td>
       </tr>
-      <tr lg-table-row rowVariant="error">
-        <td lg-table-cell>George Orwell</td>
+      <tr lg-table-row [rowVariant]="errorRowSelected ? 'error' : null">
+        <td lg-table-cell>
+          <lg-checkbox
+            size="sm"
+            [checked]="errorRowSelected"
+            (change)="errorRowSelected = !errorRowSelected">
+            George Orwell
+          </lg-checkbox>
+        </td>
         <td lg-table-cell>Animal Farm (error)</td>
         <td lg-table-cell>1945</td>
       </tr>
-      <tr lg-table-row rowVariant="selected">
-        <td lg-table-cell>Chinua Achebe</td>
+      <tr lg-table-row [rowVariant]="selectedRowSelected ? 'selected' : null">
+        <td lg-table-cell>
+          <lg-checkbox
+            size="sm"
+            [checked]="selectedRowSelected"
+            (change)="selectedRowSelected = !selectedRowSelected">
+            Chinua Achebe
+          </lg-checkbox>
+        </td>
         <td lg-table-cell>Things Fall Apart (selected)</td>
         <td lg-table-cell>1958</td>
       </tr>
@@ -581,19 +666,54 @@ const rowVariantsTableTemplate = `
       </tr>
     </tbody>
 
-    <tfoot lg-table-foot>
-      <tr lg-table-row>
-        <td lg-table-cell></td>
-        <td lg-table-cell [align]="alignTitleColumn">Total books</td>
-        <td lg-table-cell [align]="alignPublishColumn">5</td>
-      </tr>
-    </tfoot>
   </table>
 `;
 
+export const StandardTable = {
+  name: 'Standard',
+  render: (args: LgTableComponent & TableStoryModeArgs) => ({
+    props: args,
+    template: standardTableTemplate,
+  }),
+  args: {
+    books: getDefaultTableContent(),
+    mode: 'blue',
+    theme: 'neutral',
+    variant: 'striped',
+    alignTitleColumn: AlignmentOptions.Start,
+    alignPublishColumn: AlignmentOptions.End,
+    columnBreakpoint: TableColumnLayoutBreakpoints.Medium,
+    showAuthorLabel: true,
+    stack: false,
+  },
+  argTypes: {
+    ...argTypes,
+    ...colourArgTypes,
+    rowVariant: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  parameters: {
+    themes: { disable: true },
+    docs: {
+      source: {
+        code: standardTableTemplate,
+      },
+    },
+  },
+};
+
 export const RowVariantsTable = {
   name: 'Row variants',
-  render: (args: LgTableComponent & { rowVariant: TableRowVariant }) => ({
+  render: (
+    args: LgTableComponent & {
+      rowVariant: TableRowVariant;
+      errorRowSelected: boolean;
+      selectedRowSelected: boolean;
+    },
+  ) => ({
     props: args,
     template: rowVariantsTableTemplate,
   }),
@@ -602,6 +722,8 @@ export const RowVariantsTable = {
     alignTitleColumn: AlignmentOptions.Start,
     alignPublishColumn: AlignmentOptions.End,
     columnBreakpoint: TableColumnLayoutBreakpoints.Medium,
+    errorRowSelected: true,
+    selectedRowSelected: true,
   },
   argTypes: {
     ...argTypes,
@@ -630,37 +752,6 @@ export const RowVariantsTable = {
   },
 };
 
-export const StandardTable = {
-  name: 'Standard',
-  render: (args: LgTableComponent & TableStoryModeArgs) => ({
-    props: args,
-    template: standardTableTemplate,
-  }),
-  args: {
-    books: getDefaultTableContent(),
-    mode: 'blue',
-    theme: 'neutral',
-    variant: 'striped',
-    alignTitleColumn: AlignmentOptions.Start,
-    alignPublishColumn: AlignmentOptions.End,
-    columnBreakpoint: TableColumnLayoutBreakpoints.Medium,
-    showAuthorLabel: true,
-    stack: false,
-  },
-  argTypes: {
-    ...argTypes,
-    ...colourArgTypes,
-  },
-  parameters: {
-    themes: { disable: true },
-    docs: {
-      source: {
-        code: standardTableTemplate,
-      },
-    },
-  },
-};
-
 export const ExpandableTable = {
   name: 'Expandable details',
   render: (args: LgTableComponent) => ({
@@ -680,11 +771,6 @@ export const ExpandableTable = {
   },
   argTypes: {
     ...argTypes,
-    showColumnsAt: {
-      table: {
-        disable: true,
-      },
-    },
     alignTitleColumn: {
       table: {
         disable: true,
@@ -700,48 +786,23 @@ export const ExpandableTable = {
   },
 };
 
-const withInputTableTemplate = `
-<table lg-table [variant]="variant">
-    <thead lg-table-head>
-      <tr lg-table-row>
-        <th lg-table-head-cell>Author</th>
-        <th lg-table-head-cell>Rating</th>
-      </tr>
-    </thead>
-
-    <tbody lg-table-body>
-      @for (book of books; track book.author) {
-        <tr lg-table-row>
-          <td lg-table-cell>{{ book.author }}</td>
-          <td lg-table-cell>
-            <lg-input-field lgMarginBottom="none" showLabel="false">
-              <input lgInput size="2" />
-              <span lgSuffix>%</span>
-            </lg-input-field>
-          </td>
-        </tr>
-      }
-    </tbody>
-  </table>
-`;
-
 export const WithInputTable = {
   name: 'With input',
   render: (args: LgTableComponent) => ({
     props: args,
-    template: withInputTableTemplate,
+    template: `
+      <lg-story-table-with-input
+        [books]="books"
+        [variant]="variant">
+      </lg-story-table-with-input>
+    `,
   }),
   args: {
-    books: getDefaultTableContent(),
+    books: getFundTableContent(),
     variant: 'striped',
   },
   argTypes: {
     ...argTypes,
-    showColumnsAt: {
-      table: {
-        disable: true,
-      },
-    },
     alignTitleColumn: {
       table: {
         disable: true,
@@ -794,11 +855,6 @@ export const WithLongCopyTable = {
   },
   argTypes: {
     ...argTypes,
-    showColumnsAt: {
-      table: {
-        disable: true,
-      },
-    },
     alignTitleColumn: {
       table: {
         disable: true,

--- a/projects/canopy/src/lib/table/docs/table.stories.ts
+++ b/projects/canopy/src/lib/table/docs/table.stories.ts
@@ -18,22 +18,12 @@ import { LgMarginDirective } from '../../spacing';
 import { LgSuffixDirective } from '../../suffix';
 import { LgButtonComponent } from '../../button';
 import { LgIconComponent } from '../../icon';
-import type { Colour, ColourTheme } from '../../colour';
-import { LgColourDirective } from '../../colour';
 
 interface TableStoryItem {
   author: string;
   title: string;
   published: string;
 }
-
-interface TableStoryModeArgs {
-  mode: Colour;
-  theme: ColourTheme;
-}
-
-const colours: Array<Colour> = [ 'blue', 'green', 'red', 'yellow' ];
-const themes: Array<ColourTheme> = [ 'neutral', 'neutral-inverse', 'subtle', 'bold' ];
 
 function getDefaultTableContent(): Array<TableStoryItem> {
   return [
@@ -381,42 +371,6 @@ class StoryTableWithInputComponent {
 
 const responsiveCategory = 'Responsive options';
 const alignmentCategory = 'Alignment';
-const colourCategory = 'Colour';
-
-const colourArgTypes = {
-  mode: {
-    options: colours,
-    description: 'The colour mode to apply to the card containing the table.',
-    table: {
-      category: colourCategory,
-      type: {
-        summary: colours,
-      },
-      defaultValue: {
-        summary: 'blue',
-      },
-    },
-    control: {
-      type: 'select',
-    },
-  },
-  theme: {
-    options: themes,
-    description: 'The theme to apply to the card containing the table.',
-    table: {
-      category: colourCategory,
-      type: {
-        summary: themes,
-      },
-      defaultValue: {
-        summary: 'neutral',
-      },
-    },
-    control: {
-      type: 'select',
-    },
-  },
-};
 
 const argTypes = {
   variant: {
@@ -582,7 +536,6 @@ export default {
         LgToggleComponent,
         LgMarginDirective,
         LgSuffixDirective,
-        LgColourDirective,
       ],
     }),
   ],
@@ -595,8 +548,6 @@ export default {
 const standardTableTemplate = `
 <table
   lg-table
-  [lgColour]="mode"
-  [lgColourTheme]="theme"
   [showColumnsAt]="columnBreakpoint"
   [variant]="variant">
       <thead lg-table-head>
@@ -621,8 +572,15 @@ const standardTableTemplate = `
 
 const rowVariantsTableTemplate = `
 <table lg-table [showColumnsAt]="columnBreakpoint" [variant]="variant">
+    <colgroup>
+      <col span="1" style="width: 1%;" />
+      <col span="3" />
+    </colgroup>
     <thead lg-table-head>
       <tr lg-table-row>
+        <th lg-table-head-cell [showLabel]="false">
+          <span class="lg-visually-hidden">Select</span>
+        </th>
         <th lg-table-head-cell>Author</th>
         <th lg-table-head-cell [align]="alignTitleColumn">Title</th>
         <th lg-table-head-cell [align]="alignPublishColumn">Published</th>
@@ -631,6 +589,7 @@ const rowVariantsTableTemplate = `
 
     <tbody lg-table-body>
       <tr lg-table-row>
+        <td lg-table-cell></td>
         <td lg-table-cell>Orhan Pamuk</td>
         <td lg-table-cell>Strangeness In My Mind</td>
         <td lg-table-cell>2016</td>
@@ -638,28 +597,30 @@ const rowVariantsTableTemplate = `
       <tr lg-table-row [rowVariant]="errorRowSelected ? 'error' : null">
         <td lg-table-cell>
           <lg-checkbox
-            size="sm"
+            [class.lg-toggle--error]="errorRowSelected"
             [checked]="errorRowSelected"
             (change)="errorRowSelected = !errorRowSelected">
-            George Orwell
+            <span class="lg-visually-hidden">Select George Orwell</span>
           </lg-checkbox>
         </td>
+        <td lg-table-cell>George Orwell</td>
         <td lg-table-cell>Animal Farm (error)</td>
         <td lg-table-cell>1945</td>
       </tr>
       <tr lg-table-row [rowVariant]="selectedRowSelected ? 'selected' : null">
         <td lg-table-cell>
           <lg-checkbox
-            size="sm"
             [checked]="selectedRowSelected"
             (change)="selectedRowSelected = !selectedRowSelected">
-            Chinua Achebe
+            <span class="lg-visually-hidden">Select Chinua Achebe</span>
           </lg-checkbox>
         </td>
+        <td lg-table-cell>Chinua Achebe</td>
         <td lg-table-cell>Things Fall Apart (selected)</td>
         <td lg-table-cell>1958</td>
       </tr>
       <tr lg-table-row>
+        <td lg-table-cell></td>
         <td lg-table-cell>Brian Greene</td>
         <td lg-table-cell>The Elegant Universe</td>
         <td lg-table-cell>1999</td>
@@ -671,14 +632,12 @@ const rowVariantsTableTemplate = `
 
 export const StandardTable = {
   name: 'Standard',
-  render: (args: LgTableComponent & TableStoryModeArgs) => ({
+  render: (args: LgTableComponent) => ({
     props: args,
     template: standardTableTemplate,
   }),
   args: {
     books: getDefaultTableContent(),
-    mode: 'blue',
-    theme: 'neutral',
     variant: 'striped',
     alignTitleColumn: AlignmentOptions.Start,
     alignPublishColumn: AlignmentOptions.End,
@@ -688,7 +647,6 @@ export const StandardTable = {
   },
   argTypes: {
     ...argTypes,
-    ...colourArgTypes,
     rowVariant: {
       table: {
         disable: true,

--- a/projects/canopy/src/lib/table/index.ts
+++ b/projects/canopy/src/lib/table/index.ts
@@ -1,4 +1,5 @@
 export * from './table-cell/table-cell.component';
+export * from './table-foot/table-foot.component';
 export * from './table-head/table-head.component';
 export * from './table-head-cell/table-head-cell.component';
 export * from './table-row/table-row.component';

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.html
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.html
@@ -12,6 +12,7 @@
   class="lg-table-cell__content"
   [ngClass]="{
     'lg-table-cell__content--align-end': align === alignOptions.End,
+    'lg-table-cell__content--align-centre': align === alignOptions.Centre,
     'lg-table-cell__content--hidden-label': !showLabel
   }"
 >

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -4,6 +4,7 @@
 .lg-table-cell {
   display: flex;
   align-items: center;
+  padding: var(--table-cell-common-padding-y-sm) var(--table-cell-common-padding-x);
 
   &--stacked {
     flex-direction: column;
@@ -28,7 +29,6 @@
 
   &--toggle-cell {
     order: 1;
-    padding: 0;
 
     .lg-table-cell__label {
       display: none;
@@ -41,7 +41,7 @@
 }
 
 .lg-table-cell__content {
-  text-align: end;
+  // text-align: end;
   margin-left: auto;
 
   .lg-label {
@@ -65,7 +65,7 @@
 }
 
 .lg-table-cell__label {
-  font-weight: var(--font-weight-500);
+  font-weight: var(--font-weight-700);
   padding-right: var(--space-5);
 }
 
@@ -74,14 +74,7 @@
     .lg-table-cell {
       @include mixins.lg-breakpoint($columns-breakpoint) {
         display: table-cell;
-        padding: var(--space-4);
-      }
-
-      &--toggle-cell {
-        @include mixins.lg-breakpoint($columns-breakpoint) {
-          min-width: var(--table-toggle-width);
-          padding: 0;
-        }
+        padding: var(--table-cell-common-padding-y-lg) var(--table-cell-common-padding-x);
       }
 
       &__content {
@@ -93,6 +86,14 @@
         &--align-end {
           @include mixins.lg-breakpoint($columns-breakpoint) {
             text-align: right;
+          }
+        }
+
+        &--align-centre {
+          @include mixins.lg-breakpoint($columns-breakpoint) {
+            text-align: center;
+            margin-left: auto;
+            margin-right: auto;
           }
         }
       }

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -73,6 +73,12 @@
   display: none;
 }
 
+.lg-table-cell:has(.lg-toggle .lg-visually-hidden) {
+  .lg-toggle__label > .lg-toggle__checkbox {
+    margin: 0;
+  }
+}
+
 .lg-table-cell__label {
   font-weight: var(--font-weight-700);
   padding-right: var(--space-5);
@@ -84,9 +90,10 @@
       @include mixins.lg-breakpoint($columns-breakpoint) {
         display: table-cell;
         padding: var(--table-cell-common-padding-y-lg) var(--table-cell-common-padding-x);
+        vertical-align: middle;
       }
 
-      &:has(input) {
+      &:has(.lg-input-field) {
         @include mixins.lg-breakpoint($columns-breakpoint) {
           padding: var(--table-cell-common-padding-y-sm)
             var(--table-cell-common-padding-x);

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.scss
@@ -64,6 +64,15 @@
   }
 }
 
+.lg-table-row--footer .lg-table-cell:first-child .lg-table-cell__content {
+  margin-left: 0;
+  text-align: start;
+}
+
+.lg-table-row--footer .lg-table-cell__label {
+  display: none;
+}
+
 .lg-table-cell__label {
   font-weight: var(--font-weight-700);
   padding-right: var(--space-5);
@@ -75,6 +84,24 @@
       @include mixins.lg-breakpoint($columns-breakpoint) {
         display: table-cell;
         padding: var(--table-cell-common-padding-y-lg) var(--table-cell-common-padding-x);
+      }
+
+      &:has(input) {
+        @include mixins.lg-breakpoint($columns-breakpoint) {
+          padding: var(--table-cell-common-padding-y-sm)
+            var(--table-cell-common-padding-x);
+        }
+
+        .lg-label {
+          margin-bottom: 0;
+        }
+      }
+
+      &--toggle-cell {
+        @include mixins.lg-breakpoint($columns-breakpoint) {
+          width: 1%;
+          white-space: nowrap;
+        }
       }
 
       &__content {

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.spec.ts
@@ -72,6 +72,29 @@ describe('LgTableCellComponent', () => {
     });
   });
 
+  describe('when align is set to centre', () => {
+    beforeEach(() => {
+      component.align = AlignmentOptions.Centre;
+      fixture.detectChanges();
+    });
+
+    it('should set the centre alignment class', () => {
+      const contentElement = debugElement.query(By.css('.lg-table-cell__content'));
+
+      expect(contentElement.nativeElement.getAttribute('class')).toContain(
+        'lg-table-cell__content--align-centre',
+      );
+    });
+
+    it('should not set the end alignment class', () => {
+      const contentElement = debugElement.query(By.css('.lg-table-cell__content'));
+
+      expect(contentElement.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-cell__content--align-end',
+      );
+    });
+  });
+
   describe('when stack is set to true', () => {
     beforeEach(() => {
       component.stack = true;

--- a/projects/canopy/src/lib/table/table-cell/table-cell.component.ts
+++ b/projects/canopy/src/lib/table/table-cell/table-cell.component.ts
@@ -98,6 +98,7 @@ export class LgTableCellComponent {
     return this._columnLabel;
   }
 
+  @Input()
   set align(align: AlignmentOptions) {
     this._align = align;
 

--- a/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.html
+++ b/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.html
@@ -1,1 +1,3 @@
-<ng-content />
+<div class="lg-table-expanded-detail__content">
+	<ng-content />
+</div>

--- a/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.scss
+++ b/projects/canopy/src/lib/table/table-expanded-detail/table-expanded-detail.component.scss
@@ -1,3 +1,23 @@
 .lg-table-expanded-detail {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  transition:
+    grid-template-rows var(--animation-duration) ease-in-out,
+    opacity var(--animation-duration) ease-in-out,
+    padding var(--animation-duration) ease-in-out;
   white-space: normal;
+
+  &--active {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    padding: var(--space-4) 0;
+  }
+
+  &__content {
+    min-height: 0;
+    overflow: hidden;
+  }
 }

--- a/projects/canopy/src/lib/table/table-foot/table-foot.component.html
+++ b/projects/canopy/src/lib/table/table-foot/table-foot.component.html
@@ -1,0 +1,1 @@
+<ng-content />

--- a/projects/canopy/src/lib/table/table-foot/table-foot.component.scss
+++ b/projects/canopy/src/lib/table/table-foot/table-foot.component.scss
@@ -1,0 +1,16 @@
+@use '../../../styles/mixins.scss';
+@use '../table.breakpoints';
+
+.lg-table-foot {
+  font-weight: var(--font-weight-700);
+}
+
+@each $columns-breakpoint in table.$columns-breakpoints {
+  .lg-table--columns-#{$columns-breakpoint} {
+    .lg-table-foot {
+      @include mixins.lg-breakpoint($columns-breakpoint) {
+        display: table-footer-group;
+      }
+    }
+  }
+}

--- a/projects/canopy/src/lib/table/table-foot/table-foot.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-foot/table-foot.component.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
+
+import { LgTableRowComponent } from '../table-row/table-row.component';
+
+import { LgTableFootComponent } from './table-foot.component';
+
+describe('LgTableFootComponent', () => {
+  let component: LgTableFootComponent;
+  let fixture: ComponentFixture<LgTableFootComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ LgTableFootComponent, MockComponent(LgTableRowComponent) ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LgTableFootComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have the table foot class', () => {
+    expect(fixture.nativeElement.getAttribute('class')).toContain('lg-table-foot');
+  });
+
+  describe('when a foot row is present', () => {
+    it('should mark the row as a foot row', () => {
+      const row = { isFootRow: false } as Partial<LgTableRowComponent>;
+
+      component.footRow = row as LgTableRowComponent;
+      component.ngAfterContentChecked();
+
+      expect(component.footRow.isFootRow).toBe(true);
+    });
+  });
+});

--- a/projects/canopy/src/lib/table/table-foot/table-foot.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-foot/table-foot.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { QueryList } from '@angular/core';
 import { MockComponent } from 'ng-mocks';
 
 import { LgTableRowComponent } from '../table-row/table-row.component';
@@ -29,14 +30,18 @@ describe('LgTableFootComponent', () => {
     expect(fixture.nativeElement.getAttribute('class')).toContain('lg-table-foot');
   });
 
-  describe('when a foot row is present', () => {
-    it('should mark the row as a foot row', () => {
-      const row = { isFootRow: false } as Partial<LgTableRowComponent>;
+  describe('when foot rows are present', () => {
+    it('should mark all rows as foot rows', () => {
+      const firstRow = { isFootRow: false } as Partial<LgTableRowComponent>;
+      const secondRow = { isFootRow: false } as Partial<LgTableRowComponent>;
+      const rows = new QueryList<LgTableRowComponent>();
 
-      component.footRow = row as LgTableRowComponent;
+      rows.reset([ firstRow, secondRow ] as Array<LgTableRowComponent>);
+      component.footRows = rows;
       component.ngAfterContentChecked();
 
-      expect(component.footRow.isFootRow).toBe(true);
+      expect(firstRow.isFootRow).toBe(true);
+      expect(secondRow.isFootRow).toBe(true);
     });
   });
 });

--- a/projects/canopy/src/lib/table/table-foot/table-foot.component.ts
+++ b/projects/canopy/src/lib/table/table-foot/table-foot.component.ts
@@ -2,8 +2,9 @@ import {
   AfterContentChecked,
   ChangeDetectionStrategy,
   Component,
-  ContentChild,
+  ContentChildren,
   HostBinding,
+  QueryList,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -20,11 +21,11 @@ import { LgTableRowComponent } from '../table-row/table-row.component';
 export class LgTableFootComponent implements AfterContentChecked {
   @HostBinding('class') class = 'lg-table-foot';
 
-  @ContentChild(LgTableRowComponent, { static: false }) footRow: LgTableRowComponent;
+  @ContentChildren(LgTableRowComponent) footRows!: QueryList<LgTableRowComponent>;
 
   ngAfterContentChecked() {
-    if (this.footRow) {
-      this.footRow.isFootRow = true;
-    }
+    this.footRows?.forEach(row => {
+      row.isFootRow = true;
+    });
   }
 }

--- a/projects/canopy/src/lib/table/table-foot/table-foot.component.ts
+++ b/projects/canopy/src/lib/table/table-foot/table-foot.component.ts
@@ -1,0 +1,30 @@
+import {
+  AfterContentChecked,
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+  HostBinding,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { LgTableRowComponent } from '../table-row/table-row.component';
+
+@Component({
+  selector: '[lg-table-foot]',
+  templateUrl: './table-foot.component.html',
+  styleUrls: [ './table-foot.component.scss' ],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+})
+export class LgTableFootComponent implements AfterContentChecked {
+  @HostBinding('class') class = 'lg-table-foot';
+
+  @ContentChild(LgTableRowComponent, { static: false }) footRow: LgTableRowComponent;
+
+  ngAfterContentChecked() {
+    if (this.footRow) {
+      this.footRow.isFootRow = true;
+    }
+  }
+}

--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.scss
@@ -3,10 +3,11 @@
 
 .lg-table-head-cell {
   display: block;
-  font-weight: var(--font-weight-500);
-  background-color: transparent;
-  border-bottom: solid var(--table-header-border-width) var(--table-header-border-color);
-  padding: var(--space-3) 0;
+  // font-weight: var(--font-weight-500);
+  background: var(--table-cell-common-background-colour);
+  border-bottom: var(--table-cell-header-border-width) solid
+    var(--table-cell-header-border-colour);
+  padding: var(--table-cell-common-padding-y-sm) var(--table-cell-common-padding-x);
   vertical-align: bottom;
 
   &--align-end {
@@ -18,7 +19,7 @@
   .lg-table--columns-#{$columns-breakpoint} {
     .lg-table-head-cell {
       @include mixins.lg-breakpoint($columns-breakpoint) {
-        padding: var(--space-4);
+        padding: var(--table-cell-common-padding-y-lg) var(--table-cell-common-padding-x);
         display: table-cell;
       }
     }

--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.scss
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.scss
@@ -3,7 +3,6 @@
 
 .lg-table-head-cell {
   display: block;
-  // font-weight: var(--font-weight-500);
   background: var(--table-cell-common-background-colour);
   border-bottom: var(--table-cell-header-border-width) solid
     var(--table-cell-header-border-colour);

--- a/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.ts
+++ b/projects/canopy/src/lib/table/table-head-cell/table-head-cell.component.ts
@@ -25,9 +25,15 @@ export class LgTableHeadCellComponent {
 
   @HostBinding('style.text-align')
   get alignment() {
-    return this.align === AlignmentOptions.End
-      ? 'right'
-      : 'left';
+    if (this.align === AlignmentOptions.End) {
+      return 'right';
+    }
+
+    if (this.align === AlignmentOptions.Centre) {
+      return 'center';
+    }
+
+    return 'left';
   }
 
   @Input() align: AlignmentOptions = AlignmentOptions.Start;

--- a/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
+++ b/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
@@ -10,8 +10,6 @@
     appearance: none;
     cursor: pointer;
     padding: 0 var(--space-2) 0 0;
-    min-width: var(--table-toggle-width);
-    min-height: var(--table-toggle-width);
 
     &:focus-visible {
       @include mixins.lg-focus-outline;

--- a/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
+++ b/projects/canopy/src/lib/table/table-row-toggle/table-row-toggle.component.scss
@@ -19,6 +19,12 @@
   &__heading-icon {
     transition: transform var(--animation-duration) var(--animation-fn);
     margin-right: var(--space-2);
+    vertical-align: middle;
+
+    &.lg-icon {
+      width: var(--content-icon-size-sm);
+      height: var(--content-icon-size-sm);
+    }
 
     &--active {
       transform: rotateX(180deg);

--- a/projects/canopy/src/lib/table/table-row/table-row.component.scss
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.scss
@@ -4,7 +4,6 @@
 .lg-table-row {
   display: flex;
   flex-direction: column;
-  padding: var(--space-3);
 
   &__detail {
     padding: 0;
@@ -13,6 +12,23 @@
   &--hidden {
     @include mixins.lg-visually-hidden;
   }
+
+  &--error {
+    background-color: var(
+      --table-status-cell-error-background-colour
+    ) !important; // this should be updated with new package, without the status in name
+  }
+
+  &--selected {
+    background-color: var(
+      --table-cell-common-background-colour
+    ) !important; // check this background
+  }
+
+  &--footer {
+    border-top: solid var(--table-cell-header-border-width)
+      var(--table-cell-header-border-colour);
+  }
 }
 
 @each $columns-breakpoint in table.$columns-breakpoints {
@@ -20,6 +36,15 @@
     .lg-table-row {
       @include mixins.lg-breakpoint($columns-breakpoint) {
         display: table-row;
+      }
+
+      &--footer {
+        @include mixins.lg-breakpoint($columns-breakpoint) {
+          .lg-table-cell {
+            border-top: solid var(--table-cell-header-border-width)
+              var(--table-cell-header-border-colour);
+          }
+        }
       }
     }
   }

--- a/projects/canopy/src/lib/table/table-row/table-row.component.scss
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.scss
@@ -14,15 +14,11 @@
   }
 
   &--error {
-    background-color: var(
-      --table-status-cell-error-background-colour
-    ) !important; // this should be updated with new package, without the status in name
+    background-color: var(--table-status-cell-error-background-colour) !important;
   }
 
   &--selected {
-    background-color: var(
-      --table-cell-common-background-colour
-    ) !important; // check this background
+    background-color: var(--table-cell-common-background-colour) !important;
   }
 
   &--footer {

--- a/projects/canopy/src/lib/table/table-row/table-row.component.scss
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.scss
@@ -5,6 +5,10 @@
   display: flex;
   flex-direction: column;
 
+  .lg-toggle {
+    margin-bottom: 0;
+  }
+
   &__detail {
     padding: 0;
   }
@@ -24,6 +28,11 @@
   &--footer {
     border-top: solid var(--table-cell-header-border-width)
       var(--table-cell-header-border-colour);
+    flex-direction: row;
+
+    .lg-table-cell:first-child {
+      flex: 1;
+    }
   }
 }
 

--- a/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
@@ -154,7 +154,8 @@ describe('LgTableRowComponent', () => {
       const classes = fixture.nativeElement.getAttribute('class');
 
       expect(classes).toContain('lg-status-error');
-      expect(classes).toContain('lg-theme-neutral-inverse');
+      expect(classes).toContain('lg-theme-neutral');
+      expect(classes).not.toContain('lg-theme-neutral-inverse');
       expect(classes).not.toContain('lg-mode-blue');
     });
 
@@ -167,6 +168,18 @@ describe('LgTableRowComponent', () => {
       expect(classes).toContain('lg-table-row--selected');
       expect(classes).toContain('lg-mode-blue');
       expect(classes).toContain('lg-theme-subtle');
+    });
+
+    it('should add the selected colour classes when a striped row is selected', () => {
+      component.isStripedEvenRow = true;
+      component.rowVariant = 'selected';
+      fixture.detectChanges();
+
+      const classes = fixture.nativeElement.getAttribute('class');
+
+      expect(classes).toContain('lg-mode-blue');
+      expect(classes).toContain('lg-theme-subtle');
+      expect(classes).not.toContain('lg-theme-neutral-inverse');
     });
 
     it('should not apply multiple variant classes simultaneously', () => {

--- a/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.spec.ts
@@ -125,4 +125,85 @@ describe('LgTableRowComponent', () => {
       expect(debugElement.nativeElement.getAttribute('aria-labelledby')).toBe('test');
     });
   });
+
+  describe('rowVariant', () => {
+    it('should not add any variant class by default', () => {
+      expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-row--error',
+      );
+
+      expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-row--selected',
+      );
+    });
+
+    it('should add the error class when rowVariant is error', () => {
+      component.rowVariant = 'error';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('class')).toContain(
+        'lg-table-row--error',
+      );
+    });
+
+    it('should add the error status classes when rowVariant is error', () => {
+      component.rowVariant = 'error';
+      component.isStripedEvenRow = true;
+      fixture.detectChanges();
+
+      const classes = fixture.nativeElement.getAttribute('class');
+
+      expect(classes).toContain('lg-status-error');
+      expect(classes).toContain('lg-theme-neutral-inverse');
+      expect(classes).not.toContain('lg-mode-blue');
+    });
+
+    it('should add the selected class when rowVariant is selected', () => {
+      component.rowVariant = 'selected';
+      fixture.detectChanges();
+
+      const classes = fixture.nativeElement.getAttribute('class');
+
+      expect(classes).toContain('lg-table-row--selected');
+      expect(classes).toContain('lg-mode-blue');
+      expect(classes).toContain('lg-theme-subtle');
+    });
+
+    it('should not apply multiple variant classes simultaneously', () => {
+      component.rowVariant = 'error';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-row--selected',
+      );
+    });
+  });
+
+  describe('isFootRow', () => {
+    it('should not add the footer class by default', () => {
+      expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-row--footer',
+      );
+    });
+
+    it('should add the footer class when isFootRow is true', () => {
+      component.isFootRow = true;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('class')).toContain(
+        'lg-table-row--footer',
+      );
+    });
+
+    it('should remove the footer class when isFootRow is false', () => {
+      component.isFootRow = true;
+      fixture.detectChanges();
+      component.isFootRow = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('class')).not.toContain(
+        'lg-table-row--footer',
+      );
+    });
+  });
 });

--- a/projects/canopy/src/lib/table/table-row/table-row.component.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.ts
@@ -4,15 +4,18 @@ import {
   Component,
   ContentChild,
   ContentChildren,
+  ElementRef,
   HostBinding,
   Input,
   QueryList,
+  Renderer2,
   ViewEncapsulation,
   inject,
 } from '@angular/core';
 
 import { LgTableCellComponent } from '../table-cell/table-cell.component';
 import { LgTableHeadCellComponent } from '../table-head-cell/table-head-cell.component';
+import { TableRowVariant } from '../table.interface';
 
 @Component({
   selector: '[lg-table-row]',
@@ -24,6 +27,8 @@ import { LgTableHeadCellComponent } from '../table-head-cell/table-head-cell.com
 })
 export class LgTableRowComponent {
   private cd = inject(ChangeDetectorRef);
+  private hostElement = inject(ElementRef);
+  private renderer = inject(Renderer2);
 
   private _isHeadRow = false;
   set isHeadRow(isHeadRow: boolean) {
@@ -35,9 +40,39 @@ export class LgTableRowComponent {
     return this._isHeadRow;
   }
 
+  private _isFootRow = false;
+  set isFootRow(isFootRow: boolean) {
+    this._isFootRow = isFootRow;
+    this.cd.detectChanges();
+  }
+  get isFootRow() {
+    return this._isFootRow;
+  }
+
+  private _isStripedEvenRow = false;
+  set isStripedEvenRow(isStripedEvenRow: boolean) {
+    this._isStripedEvenRow = isStripedEvenRow;
+
+    this.setStripedEvenRowClasses();
+  }
+  get isStripedEvenRow() {
+    return this._isStripedEvenRow;
+  }
+
+  private _rowVariant: TableRowVariant | null = null;
+  @Input()
+  set rowVariant(rowVariant: TableRowVariant | null) {
+    this._rowVariant = rowVariant;
+
+    this.setStripedEvenRowClasses();
+  }
+  get rowVariant() {
+    return this._rowVariant;
+  }
+
   isDetailRow = false;
-  ariaLabelledBy: string = null;
-  ariaId: string = null;
+  ariaLabelledBy: string | null = null;
+  ariaId: string | null = null;
   @Input() isHidden = false;
 
   @HostBinding('class') class = 'lg-table-row';
@@ -45,6 +80,41 @@ export class LgTableRowComponent {
   @HostBinding('class.lg-table-row--hidden')
   get hideActiveClass() {
     return this.isHidden;
+  }
+
+  @HostBinding('class.lg-table-row--error')
+  get isError() {
+    return this.rowVariant === 'error';
+  }
+
+  @HostBinding('class.lg-status-error')
+  get hasErrorStatus() {
+    return this.isError;
+  }
+
+  @HostBinding('class.lg-theme-neutral-inverse')
+  get hasErrorTheme() {
+    return this.isError;
+  }
+
+  @HostBinding('class.lg-theme-subtle')
+  get hasSelectedTheme() {
+    return this.isSelected;
+  }
+
+  @HostBinding('class.lg-table-row--selected')
+  get isSelected() {
+    return this.rowVariant === 'selected';
+  }
+
+  @HostBinding('class.lg-table-row--footer')
+  get isFooter() {
+    return this.isFootRow;
+  }
+
+  @HostBinding('class.lg-mode-blue')
+  get isBlueMode() {
+    return this.isSelected;
   }
 
   @HostBinding('attr.id')
@@ -64,13 +134,14 @@ export class LgTableRowComponent {
     return this.ariaLabelledBy;
   }
 
-  @ContentChildren(LgTableCellComponent) bodyCells: QueryList<LgTableCellComponent>;
+  @ContentChildren(LgTableCellComponent) bodyCells: QueryList<LgTableCellComponent> =
+    new QueryList();
 
   @ContentChildren(LgTableHeadCellComponent)
-  headCells: QueryList<LgTableHeadCellComponent>;
+  headCells: QueryList<LgTableHeadCellComponent> = new QueryList();
 
   @ContentChild(LgTableCellComponent, { static: true })
-  tableCellComponent: LgTableCellComponent;
+  tableCellComponent: LgTableCellComponent | undefined;
 
   @HostBinding('class.lg-table-row__toggle--active')
   get isToggledActive(): boolean {
@@ -80,5 +151,24 @@ export class LgTableRowComponent {
   @HostBinding('class.lg-table-row__toggle')
   get hasToggle(): boolean {
     return !!this.tableCellComponent?.toggleClass;
+  }
+
+  private setStripedEvenRowClasses() {
+    const shouldUseBlueMode = this.isStripedEvenRow && !this.isError;
+
+    if (this.isStripedEvenRow) {
+      this.renderer.addClass(this.hostElement.nativeElement, 'lg-theme-neutral-inverse');
+    } else {
+      this.renderer.removeClass(
+        this.hostElement.nativeElement,
+        'lg-theme-neutral-inverse',
+      );
+    }
+
+    if (shouldUseBlueMode) {
+      this.renderer.addClass(this.hostElement.nativeElement, 'lg-mode-blue');
+    } else {
+      this.renderer.removeClass(this.hostElement.nativeElement, 'lg-mode-blue');
+    }
   }
 }

--- a/projects/canopy/src/lib/table/table-row/table-row.component.ts
+++ b/projects/canopy/src/lib/table/table-row/table-row.component.ts
@@ -92,7 +92,7 @@ export class LgTableRowComponent {
     return this.isError;
   }
 
-  @HostBinding('class.lg-theme-neutral-inverse')
+  @HostBinding('class.lg-theme-neutral')
   get hasErrorTheme() {
     return this.isError;
   }
@@ -154,9 +154,11 @@ export class LgTableRowComponent {
   }
 
   private setStripedEvenRowClasses() {
-    const shouldUseBlueMode = this.isStripedEvenRow && !this.isError;
+    const shouldUseStripedTheme =
+      this.isStripedEvenRow && !this.isError && !this.isSelected;
+    const shouldUseBlueMode = this.isSelected || (this.isStripedEvenRow && !this.isError);
 
-    if (this.isStripedEvenRow) {
+    if (shouldUseStripedTheme) {
       this.renderer.addClass(this.hostElement.nativeElement, 'lg-theme-neutral-inverse');
     } else {
       this.renderer.removeClass(

--- a/projects/canopy/src/lib/table/table.interface.ts
+++ b/projects/canopy/src/lib/table/table.interface.ts
@@ -1,7 +1,10 @@
 export type TableVariant = 'striped' | 'bordered';
 
+export type TableRowVariant = 'error' | 'selected';
+
 export enum AlignmentOptions {
   Start = 'start',
+  Centre = 'centre',
   End = 'end',
 }
 

--- a/projects/canopy/src/lib/table/table/table.component.scss
+++ b/projects/canopy/src/lib/table/table/table.component.scss
@@ -6,17 +6,23 @@
   flex-direction: column;
   margin-bottom: var(--component-margin);
   border-spacing: 0;
-  border-top: solid var(--table-header-border-width) var(--table-header-border-color);
+  border-radius: var(--table-border-radius);
+  overflow: hidden;
+  border: var(--container-common-border-width-xs) solid var(--table-border-colour);
+  background: var(--table-background-colour);
+  color: var(--table-cell-common-colour);
 
-  &--striped:not(&--expandable) tbody tr:nth-child(odd) {
-    background-color: var(--table-stripe-color);
+  &--striped:not(&--expandable) tbody tr:nth-child(even):not(.lg-table-row--error) {
+    background-color: var(--table-cell-common-background-colour) !important;
   }
 
   &--bordered {
-    border-collapse: collapse;
+    border-collapse: separate; // or should this be collapse
 
-    tr {
-      border-bottom: solid var(--border-width) var(--table-row-border-color);
+    tr:not(:last-child):not(.lg-table-row--error):not(.lg-table-row--selected):not(
+        .lg-table-row__toggle--active
+      ) {
+      border-bottom: solid var(--border-width) var(--table-cell-common-border-colour);
     }
   }
 
@@ -24,11 +30,11 @@
     &.lg-table--striped {
       tbody tr {
         &:nth-child(4n + 1) {
-          background-color: var(--table-stripe-color);
+          background-color: var(--table-cell-common-background-colour);
         }
 
         &:nth-child(4n + 2) {
-          background-color: var(--table-stripe-color);
+          background-color: var(--table-cell-common-background-colour);
         }
       }
     }
@@ -42,10 +48,23 @@
 @each $columns-breakpoint in table.$columns-breakpoints {
   .lg-table--columns-#{$columns-breakpoint} {
     @include mixins.lg-breakpoint($columns-breakpoint) {
-      border-top: 0;
+      // border-top: 0;
       display: table;
       table-layout: auto;
       width: 100%;
+
+      &.lg-table--bordered {
+        .lg-table-row:not(:last-child):not(.lg-table-row--error):not(
+            .lg-table-row--selected
+          ):not(.lg-table-row__toggle--active) {
+          border-bottom: 0;
+
+          td {
+            border-bottom: solid var(--border-width)
+              var(--table-cell-common-border-colour);
+          }
+        }
+      }
     }
   }
 }

--- a/projects/canopy/src/lib/table/table/table.component.scss
+++ b/projects/canopy/src/lib/table/table/table.component.scss
@@ -17,12 +17,13 @@
   }
 
   &--bordered {
-    border-collapse: separate; // or should this be collapse
+    border-collapse: separate;
 
     tr:not(:last-child):not(.lg-table-row--error):not(.lg-table-row--selected):not(
         .lg-table-row__toggle--active
       ) {
-      border-bottom: solid var(--border-width) var(--table-cell-common-border-colour);
+      box-shadow: inset 0 calc(-1 * var(--border-width)) 0
+        var(--table-cell-common-border-colour);
     }
   }
 
@@ -48,7 +49,6 @@
 @each $columns-breakpoint in table.$columns-breakpoints {
   .lg-table--columns-#{$columns-breakpoint} {
     @include mixins.lg-breakpoint($columns-breakpoint) {
-      // border-top: 0;
       display: table;
       table-layout: auto;
       width: 100%;
@@ -60,7 +60,7 @@
           border-bottom: 0;
 
           td {
-            border-bottom: solid var(--border-width)
+            box-shadow: inset 0 calc(-1 * var(--border-width)) 0
               var(--table-cell-common-border-colour);
           }
         }

--- a/projects/canopy/src/lib/table/table/table.component.ts
+++ b/projects/canopy/src/lib/table/table/table.component.ts
@@ -129,6 +129,16 @@ export class LgTableComponent implements AfterContentChecked {
   }
 
   private handleBodyRows() {
+    let rowIndex = -1;
+
+    this.tableBody.rows.forEach(row => {
+      if (!row.isDetailRow) {
+        rowIndex++;
+      }
+
+      row.isStripedEvenRow = this.variant === 'striped' && rowIndex % 2 === 1;
+    });
+
     this.tableBody.rows
       .filter(row => !row.isDetailRow)
       .forEach((row, index) => {

--- a/projects/canopy/src/styles/variables.scss
+++ b/projects/canopy/src/styles/variables.scss
@@ -13,7 +13,6 @@
 @use 'variables/components/separator';
 @use 'variables/components/spinner';
 @use 'variables/components/tabs';
-@use 'variables/components/table';
 @use 'variables/components/toggle';
 @use 'variables/typography';
 

--- a/projects/canopy/src/styles/variables/components/_table.scss
+++ b/projects/canopy/src/styles/variables/components/_table.scss
@@ -1,7 +1,0 @@
-:root {
-  --table-stripe-color: var(--colour-greyscale-100);
-  --table-header-border-width: 0.125rem;
-  --table-header-border-color: var(--colour-greyscale-900);
-  --table-row-border-color: var(--colour-greyscale-200);
-  --table-toggle-width: var(--space-8);
-}

--- a/skills/best-practice/table/SKILL.md
+++ b/skills/best-practice/table/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: canopy-table
+name: table
 description: Best practices for the Canopy Table component. Trigger when displaying tabular data, comparison tables, expandable detail rows, or structured data grids in an Angular project using Canopy.
 license: MIT
 metadata:
@@ -21,6 +21,7 @@ import {
   LgTableComponent,
   LgTableHeadComponent,
   LgTableBodyComponent,
+  LgTableFootComponent,
   LgTableRowComponent,
   LgTableHeadCellComponent,
   LgTableCellComponent,
@@ -48,9 +49,23 @@ import {
       <td lg-table-cell>Strangeness in my Mind</td>
       <td lg-table-cell>2016</td>
     </tr>
+    <tr lg-table-row>
+      <td lg-table-cell>Albert Camus</td>
+      <td lg-table-cell>The Plague</td>
+      <td lg-table-cell>1947</td>
+    </tr>
   </tbody>
+  <tfoot lg-table-foot>
+    <tr lg-table-row>
+      <td lg-table-cell></td>
+      <td lg-table-cell>Total books</td>
+      <td lg-table-cell>2</td>
+    </tr>
+  </tfoot>
 </table>
 ```
+
+Use `lg-table-foot` on a `tfoot` when the table needs a summary or total row.
 
 ---
 
@@ -102,6 +117,17 @@ When using tables with long copy, place contextual actions inside the cell using
 | `stack` | `boolean` | `false` | On small screens, stacks label and content vertically instead of side by side. |
 | `colspan` | `number` | `undefined` | Sets the `colspan` attribute. |
 
+## LgTableHeadCellComponent Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `align` | `'start' \| 'centre' \| 'end'` | `'start'` | Alignment option for the header and its respective column. |
+| `showLabel` | `boolean` | `true` | Whether to show the label for this header in each row in non-column layout. |
+
+## LgTableFootComponent
+
+Use `LgTableFootComponent` through the `lg-table-foot` attribute on `tfoot` to mark footer rows for table footer styling.
+
 ---
 
 ## Dos and Don'ts
@@ -127,4 +153,5 @@ When using tables with long copy, place contextual actions inside the cell using
 - Numeric comparison columns must be right-aligned.
 - Column headers align to match their column data.
 - At mobile breakpoints the table switches to a 2-column layout (header | value) per row.
+- Storybook may wrap the Standard table example in a card so mode and theme controls can demonstrate colour rendering; that wrapper is for the example presentation and is not required for table usage.
 


### PR DESCRIPTION
# Description

This PR updates the Canopy Table component to support brand modernisation styling, including new table/footer capabilities, additional alignment options, and row-level variants for stateful styling.

### Changes:

- Introduces `LgTableFootComponent` (`lg-table-foot`) and updates docs/stories to demonstrate footer usage.
- Adds centre alignment support and introduces row variants (error, selected) with accompanying styles/tests.
- Reworks table SCSS and removes legacy table CSS variable imports.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
