### PR TITLE
fix(lg-validation): projection issue

### DIFF
--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.html
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.html
@@ -11,6 +11,6 @@
   </legend>
   <ng-content select=".lg-label--optional" />
   <ng-content select="lg-hint" />
-  <ng-content select="lg-validation" />
+  <ng-content select="lg-validation, [lgValidationWrapper]" />
   <ng-content select="lg-toggle, lg-checkbox, lg-filter-checkbox" />
 </fieldset>

--- a/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts
+++ b/projects/canopy/src/lib/forms/checkbox-group/checkbox-group.component.ts
@@ -16,7 +16,7 @@ import { ControlValueAccessor, FormGroupDirective, NgControl } from '@angular/fo
 import { LgDomService, randomUniqueId } from '../../utils';
 import { LgHintComponent } from '../hint';
 import { LgErrorStateMatcher } from '../validation';
-import { LgValidationComponent } from '../validation';
+import { LgValidationComponent, LgValidationWrapperDirective } from '../validation';
 import { LgToggleComponent } from '../toggle';
 import { LgMarginDirective } from '../../spacing';
 import { LgLabelComponent } from '../label';
@@ -46,10 +46,12 @@ export class LgCheckboxGroupComponent implements ControlValueAccessor {
   private uniqueId = randomUniqueId();
   private _name = `lg-checkbox-group-${this.uniqueId}`;
   private _value: Array<string> = [];
+  private _describedByValidation: { id: string };
   _variant: CheckboxGroupVariant;
   _checkboxes: QueryList<LgToggleComponent>;
   _hintElement: LgHintComponent;
   _validationElement: LgValidationComponent;
+  _validationWrapperElement: LgValidationWrapperDirective;
   hintText = '';
 
   @Input() id = `lg-checkbox-group-id-${this.uniqueId}`;
@@ -135,15 +137,16 @@ export class LgCheckboxGroupComponent implements ControlValueAccessor {
     this.hintText = element?.nativeElement.textContent?.trim() ?? '';
   }
 
-  @ContentChild(LgValidationComponent)
+  @ContentChild(LgValidationComponent, { descendants: true })
   set errorElement(element: LgValidationComponent) {
-    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
-      this.ariaDescribedBy,
-      this._validationElement,
-      element,
-    );
-
     this._validationElement = element;
+    this.updateValidationDescription();
+  }
+
+  @ContentChild(LgValidationWrapperDirective)
+  set errorWrapperElement(element: LgValidationWrapperDirective) {
+    this._validationWrapperElement = element;
+    this.updateValidationDescription();
   }
 
   constructor() {
@@ -184,5 +187,17 @@ export class LgCheckboxGroupComponent implements ControlValueAccessor {
         checkbox.name = this.name;
       });
     }
+  }
+
+  private updateValidationDescription(): void {
+    const element = this._validationElement ?? this._validationWrapperElement ?? null;
+
+    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
+      this.ariaDescribedBy,
+      this._describedByValidation,
+      element,
+    );
+
+    this._describedByValidation = element;
   }
 }

--- a/projects/canopy/src/lib/forms/date/date-field.component.html
+++ b/projects/canopy/src/lib/forms/date/date-field.component.html
@@ -7,7 +7,7 @@
     <ng-content />
   </legend>
   <lg-hint>For example, 27 12 1977</lg-hint>
-  <ng-content select="lg-validation" />
+  <ng-content select="lg-validation, [lgValidationWrapper]" />
   <div
     class="lg-date-field__fields"
     [formGroup]="dateFormGroup"

--- a/projects/canopy/src/lib/forms/date/date-field.component.ts
+++ b/projects/canopy/src/lib/forms/date/date-field.component.ts
@@ -27,7 +27,7 @@ import { isValid, parseISO } from 'date-fns';
 
 import { LgHintComponent } from '../hint';
 import { LgErrorStateMatcher } from '../validation';
-import { LgValidationComponent } from '../validation';
+import { LgValidationComponent, LgValidationWrapperDirective } from '../validation';
 import omit from '../../utils/omit';
 import { randomUniqueId } from '../../utils';
 import { LgInputDirective } from '../input';
@@ -76,6 +76,7 @@ implements OnInit, AfterViewInit, ControlValueAccessor, OnDestroy {
   subscriptions: Array<Subscription> = [];
   _hintElement: LgHintComponent;
   _validationElement: LgValidationComponent;
+  _validationWrapperElement: LgValidationWrapperDirective;
 
   @Input() value: string;
   @Input() disabled = false;
@@ -92,9 +93,14 @@ implements OnInit, AfterViewInit, ControlValueAccessor, OnDestroy {
     this._hintElement = element;
   }
 
-  @ContentChild(LgValidationComponent)
+  @ContentChild(LgValidationComponent, { descendants: true })
   set errorContentElement(element: LgValidationComponent) {
     this._validationElement = element;
+  }
+
+  @ContentChild(LgValidationWrapperDirective)
+  set errorWrapperContentElement(element: LgValidationWrapperDirective) {
+    this._validationWrapperElement = element;
   }
 
   @ViewChild('dateFormDirective')
@@ -190,8 +196,11 @@ implements OnInit, AfterViewInit, ControlValueAccessor, OnDestroy {
       ids.push(this._hintElement.id);
     }
 
-    if (this._validationElement?.id) {
-      ids.push(this._validationElement.id);
+    const validationId =
+      this._validationElement?.id ?? this._validationWrapperElement?.id;
+
+    if (validationId) {
+      ids.push(validationId);
     }
 
     this.ariaDescribedBy = ids.length

--- a/projects/canopy/src/lib/forms/input/input-field.component.html
+++ b/projects/canopy/src/lib/forms/input/input-field.component.html
@@ -3,7 +3,7 @@
 </label>
 <ng-content select=".lg-label--optional" />
 <ng-content select="lg-hint" />
-<ng-content select="lg-validation" />
+<ng-content select="lg-validation, [lgValidationWrapper]" />
 <div
   class="lg-input-field__inputs"
   (focusin)="onFocusIn($event)"

--- a/projects/canopy/src/lib/forms/input/input-field.component.ts
+++ b/projects/canopy/src/lib/forms/input/input-field.component.ts
@@ -15,7 +15,7 @@ import { Subscription } from 'rxjs';
 import { randomUniqueId } from '../../utils';
 import { LgHintComponent } from '../hint';
 import { LgLabelComponent } from '../label';
-import { LgValidationComponent } from '../validation';
+import { LgValidationComponent, LgValidationWrapperDirective } from '../validation';
 import { LgButtonComponent } from '../../button';
 import { LgSuffixDirective } from '../../suffix';
 import { LgPrefixDirective } from '../../prefix';
@@ -50,6 +50,7 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
   private _inputElement: LgInputDirective;
   private _hintElement: LgHintComponent;
   private _validationElement: LgValidationComponent;
+  private _validationWrapperElement: LgValidationWrapperDirective;
   private _suffixChildren: QueryList<LgSuffixDirective>;
   private _prefixChildren: QueryList<LgPrefixDirective>;
   private _externalButtonChildren: QueryList<LgInputFieldExternalButtonDirective>;
@@ -122,9 +123,15 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
     this.updateAriaDescribedBy();
   }
 
-  @ContentChild(LgValidationComponent)
+  @ContentChild(LgValidationComponent, { descendants: true })
   set errorElement(element: LgValidationComponent) {
     this._validationElement = element;
+    this.updateAriaDescribedBy();
+  }
+
+  @ContentChild(LgValidationWrapperDirective)
+  set errorWrapperElement(element: LgValidationWrapperDirective) {
+    this._validationWrapperElement = element;
     this.updateAriaDescribedBy();
   }
 
@@ -207,7 +214,7 @@ export class LgInputFieldComponent implements AfterContentInit, OnDestroy {
 
     const ids = [
       this._hintElement?.id,
-      this._validationElement?.id,
+      this._validationElement?.id ?? this._validationWrapperElement?.id,
       ...this.getDescriptiveAffixIds(this._prefixChildren),
       ...this.getDescriptiveAffixIds(this._suffixChildren),
     ].filter((id, index, values) => Boolean(id) && values.indexOf(id) === index);

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.html
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.html
@@ -9,7 +9,7 @@
   <ng-content select=".lg-label--optional" />
   <ng-content select="lg-hint" />
 
-  <ng-content select="lg-validation" />
+  <ng-content select="lg-validation, [lgValidationWrapper]" />
 
   @if (variant === 'segment') {
     <div class="lg-radio-group__segment">

--- a/projects/canopy/src/lib/forms/radio/radio-group.component.ts
+++ b/projects/canopy/src/lib/forms/radio/radio-group.component.ts
@@ -17,7 +17,7 @@ import { ControlValueAccessor, FormGroupDirective, NgControl } from '@angular/fo
 import { LgDomService, randomUniqueId } from '../../utils';
 import { LgHintComponent } from '../hint';
 import { LgErrorStateMatcher } from '../validation';
-import { LgValidationComponent } from '../validation';
+import { LgValidationComponent, LgValidationWrapperDirective } from '../validation';
 import { LgLabelComponent } from '../label';
 import { LgFocusDirective } from '../../focus';
 
@@ -45,11 +45,13 @@ export class LgRadioGroupComponent implements ControlValueAccessor, AfterContent
 
   private uniqueId = randomUniqueId();
   private _name = `lg-radio-group-${this.uniqueId}`;
+  private _describedByValidation: { id: string };
   variant: RadioVariant;
   _stack: RadioStackBreakpoint;
   _radios: QueryList<LgRadioButtonComponent>;
   _hintElement: LgHintComponent;
   _validationElement: LgValidationComponent;
+  _validationWrapperElement: LgValidationWrapperDirective;
   _value: boolean | string = null;
 
   @Input() id = `lg-radio-group-id-${this.uniqueId}`;
@@ -112,15 +114,16 @@ export class LgRadioGroupComponent implements ControlValueAccessor, AfterContent
     this._hintElement = element;
   }
 
-  @ContentChild(LgValidationComponent)
+  @ContentChild(LgValidationComponent, { descendants: true })
   set errorElement(element: LgValidationComponent) {
-    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
-      this.ariaDescribedBy,
-      this._validationElement,
-      element,
-    );
-
     this._validationElement = element;
+    this.updateValidationDescription();
+  }
+
+  @ContentChild(LgValidationWrapperDirective)
+  set errorWrapperElement(element: LgValidationWrapperDirective) {
+    this._validationWrapperElement = element;
+    this.updateValidationDescription();
   }
 
   @Input()
@@ -206,5 +209,17 @@ export class LgRadioGroupComponent implements ControlValueAccessor, AfterContent
         radio.name = this.name;
       });
     }
+  }
+
+  private updateValidationDescription(): void {
+    const element = this._validationElement ?? this._validationWrapperElement ?? null;
+
+    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
+      this.ariaDescribedBy,
+      this._describedByValidation,
+      element,
+    );
+
+    this._describedByValidation = element;
   }
 }

--- a/projects/canopy/src/lib/forms/select/select-field.component.html
+++ b/projects/canopy/src/lib/forms/select/select-field.component.html
@@ -3,7 +3,7 @@
 </label>
 <ng-content select=".lg-label--optional" />
 <ng-content select="lg-hint" />
-<ng-content select="lg-validation" />
+<ng-content select="lg-validation, [lgValidationWrapper]" />
 <div class="lg-select-field__outer">
   <div class="lg-select-field__inner" [class.lg-select-field__inner--block]="block">
     <ng-content select="[lgSelect]" />

--- a/projects/canopy/src/lib/forms/select/select-field.component.ts
+++ b/projects/canopy/src/lib/forms/select/select-field.component.ts
@@ -13,7 +13,7 @@ import { randomUniqueId } from '../../utils/unique-id';
 import { LgHintComponent } from '../hint';
 import { LgLabelComponent } from '../label';
 import { LgErrorStateMatcher } from '../validation';
-import { LgValidationComponent } from '../validation';
+import { LgValidationComponent, LgValidationWrapperDirective } from '../validation';
 import { LgIconComponent } from '../../icon';
 
 import { LgSelectDirective } from './select.directive';
@@ -84,9 +84,16 @@ export class LgSelectFieldComponent {
   }
 
   _validationElement?: LgValidationComponent;
-  @ContentChild(LgValidationComponent)
+  @ContentChild(LgValidationComponent, { descendants: true })
   set errorElement(element: LgValidationComponent) {
     this._validationElement = element;
+    this.updateAriaDescribedBy();
+  }
+
+  _validationWrapperElement?: LgValidationWrapperDirective;
+  @ContentChild(LgValidationWrapperDirective)
+  set errorWrapperElement(element: LgValidationWrapperDirective) {
+    this._validationWrapperElement = element;
     this.updateAriaDescribedBy();
   }
 
@@ -95,9 +102,10 @@ export class LgSelectFieldComponent {
       return;
     }
 
-    const ids = [ this._hintElement?.id, this._validationElement?.id ].filter(
-      (id, index, values) => Boolean(id) && values.indexOf(id) === index,
-    );
+    const ids = [
+      this._hintElement?.id,
+      this._validationElement?.id ?? this._validationWrapperElement?.id,
+    ].filter((id, index, values) => Boolean(id) && values.indexOf(id) === index);
 
     this._selectElement.ariaDescribedBy = ids.length > 0
       ? ids.join(' ')

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.html
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.html
@@ -1,4 +1,4 @@
-<ng-content select="lg-validation" />
+<ng-content select="lg-validation, [lgValidationWrapper]" />
 <input
   (click)="onCheck()"
   (blur)="onBlur($event)"

--- a/projects/canopy/src/lib/forms/toggle/toggle.component.ts
+++ b/projects/canopy/src/lib/forms/toggle/toggle.component.ts
@@ -16,7 +16,7 @@ import { NgClass } from '@angular/common';
 
 import { LgDomService, randomUniqueId } from '../../utils';
 import { LgErrorStateMatcher } from '../validation';
-import { LgValidationComponent } from '../validation';
+import { LgValidationComponent, LgValidationWrapperDirective } from '../validation';
 import { LgCheckboxGroupComponent } from '../checkbox-group';
 import { LgIconComponent } from '../../icon';
 import { LgFocusDirective } from '../../focus';
@@ -41,6 +41,7 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     skipSelf: true,
   });
   private hostElement = inject(ElementRef);
+  private _describedByValidation: { id: string };
   control = inject(NgControl, { self: true, optional: true });
 
   uniqueId = randomUniqueId();
@@ -79,15 +80,17 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
   @ViewChild('input', { static: true }) inputRef: ElementRef;
 
   _validationElement: LgValidationComponent;
-  @ContentChild(LgValidationComponent)
+  @ContentChild(LgValidationComponent, { descendants: true })
   set errorElement(element: LgValidationComponent) {
-    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
-      this.ariaDescribedBy,
-      this._validationElement,
-      element,
-    );
-
     this._validationElement = element;
+    this.updateValidationDescription();
+  }
+
+  _validationWrapperElement: LgValidationWrapperDirective;
+  @ContentChild(LgValidationWrapperDirective)
+  set errorWrapperElement(element: LgValidationWrapperDirective) {
+    this._validationWrapperElement = element;
+    this.updateValidationDescription();
   }
 
   constructor() {
@@ -169,5 +172,17 @@ export class LgToggleComponent implements ControlValueAccessor, OnInit {
     if (this.selectorVariant !== 'toggle' && !this.checkboxGroup) {
       this.variant = this.selectorVariant as ToggleVariant;
     }
+  }
+
+  private updateValidationDescription(): void {
+    const element = this._validationElement ?? this._validationWrapperElement ?? null;
+
+    this.ariaDescribedBy = this.domService.toggleIdInStringProperty(
+      this.ariaDescribedBy,
+      this._describedByValidation,
+      element,
+    );
+
+    this._describedByValidation = element;
   }
 }

--- a/projects/canopy/src/lib/forms/validation/docs/guide.mdx
+++ b/projects/canopy/src/lib/forms/validation/docs/guide.mdx
@@ -11,7 +11,6 @@ import { CustomBadge } from 'storybook-addon-tag-badges/manager-helpers';
 
 ![Form Validation Hero](docs/forms/validation/form-validation-hero.png)
 
-
 ## Usage
 
 Use form validation to guide users through data entry and ensure submitted information is accurate. Validation must be clear, timely, and accessible.
@@ -20,45 +19,45 @@ Use form validation to guide users through data entry and ensure submitted infor
 
 ![Form Validation Examples](docs/forms/validation/form-validation-examples.png)
 
-1. **Use an error summary for long forms**  
-  For forms with multiple errors or those that span beyond the viewport, you must include an inline message at the top of the form. This summary must:
+1. **Use an error summary for long forms**
+   For forms with multiple errors or those that span beyond the viewport, you must include an inline message at the top of the form. This summary must:
    - Summarise all errors on the page.
    - Provide anchor links to each field requiring attention.
    - Receive focus automatically so it is announced to screen readers.
-2. **Highlight all fields with errors**  
+2. **Highlight all fields with errors**
    Use error state tokens to provide a clear visual cue.
-3. **Display inline messages between the label and hint, and the field**  
+3. **Display inline messages between the label and hint, and the field**
    Messages must be placed directly above the input they relate to so they are not missed.
-4. **Focus the first error**  
+4. **Focus the first error**
    If an error summary is not used, the first field with an error must automatically receive focus.
-5. **Keep the submit button active**  
+5. **Keep the submit button active**
    Do not disable the submit button. Users must be able to click it to trigger validation and receive feedback on what needs fixing.
 
 **Writing error messages**
 
 Error messages must be clear, concise, and tell the user how to fix the problem. Follow these L&G microcopy standards:
 
-  - **State the problem and the fix** – explain what is wrong and what to do next (e.g., "Enter a valid email address").
+- **State the problem and the fix** – explain what is wrong and what to do next (e.g., "Enter a valid email address").
 
-  - **Use imperatives** – start with a verb like "Enter", "Select", or "Use" to keep messages actionable and consistent with buttons.
+- **Use imperatives** – start with a verb like "Enter", "Select", or "Use" to keep messages actionable and consistent with buttons.
 
-  - **Keep it short** – aim for under 10 words. Use one concise sentence that is easy to scan.
+- **Keep it short** – aim for under 10 words. Use one concise sentence that is easy to scan.
 
-  - **No end punctuation** – do not use full stops or exclamation marks for single-sentence inline errors. This keeps the UI visually light.
+- **No end punctuation** – do not use full stops or exclamation marks for single-sentence inline errors. This keeps the UI visually light.
 
-  - **Use plain English** – write for low digital and financial literacy. Avoid technical terms, system language, or internal jargon.
+- **Use plain English** – write for low digital and financial literacy. Avoid technical terms, system language, or internal jargon.
 
-  - **Be neutral and supportive** – use a factual, calm tone. Do not blame the user, apologise, or use filler words like "Please" or "Sorry."
+- **Be neutral and supportive** – use a factual, calm tone. Do not blame the user, apologise, or use filler words like "Please" or "Sorry."
 
-  - **Stay consistent** – use the same wording for the same rule across the entire journey.
+- **Stay consistent** – use the same wording for the same rule across the entire journey.
 
 **When to validate**
 
-  - **On submit**: Validate the entire form when the user attempts to proceed. This is the primary method for catching errors.
+- **On submit**: Validate the entire form when the user attempts to proceed. This is the primary method for catching errors.
 
-  - **On blur**: Validate individual fields only after a user has finished interacting with them and moved away. Do not validate a field before a user has touched it.
+- **On blur**: Validate individual fields only after a user has finished interacting with them and moved away. Do not validate a field before a user has touched it.
 
-  - **Dynamically**: Only use real-time validation (as the user types) for specific cases like password strength or character counts. Use a debounce of 500 – 1000ms to avoid flickering.
+- **Dynamically**: Only use real-time validation (as the user types) for specific cases like password strength or character counts. Use a debounce of 500 – 1000ms to avoid flickering.
 
 The rules to display the error states are incorporated into the individual Canopy form components. When used in conjunction with standard Angular form validation the error styles will be displayed automatically.
 
@@ -93,59 +92,108 @@ isControlInvalid(control: AbstractControl, form: FormGroupDirective) {
 In your HTML, add the validation components with the appropriate structural directives to determine if they should be visible. The error state matcher will determine whether the form field is in an error state.
 
 ```html
-<form
-  [formGroup]="form"
-  (ngSubmit)="onSubmit(form)"
-  #userForm="ngForm">
-    <lg-input-field>
-      Text
-      <lg-hint>This is a standard input field</lg-hint>
-    @if (isControlInvalid(text, userForm) && text.hasError('required')) {
-      <lg-validation>
-        Username is a required field
-      </lg-validation>
+<form [formGroup]="form" (ngSubmit)="onSubmit(form)" #userForm="ngForm">
+  <lg-input-field>
+    Text
+    <lg-hint>This is a standard input field</lg-hint>
+    @if ( isControlInvalid(form.get('text')!, userForm) &&
+    form.get('text')?.hasError('required') ) {
+    <lg-validation>Enter a value</lg-validation>
+    } @if ( isControlInvalid(form.get('text')!, userForm) &&
+    form.get('text')?.hasError('minlength') ) {
+    <lg-validation>Enter at least 4 characters</lg-validation>
     }
-    @if (isControlInvalid(text, validationForm) && text.hasError('minlength')) {
-      <lg-validation>
-        Username needs to be at least 4 characters
-      </lg-validation>
-    }
-      <input lgInput formControlName="username" />
+    <input lgInput formControlName="text" />
   </lg-input-field>
 </form>
 ```
 
+## Wrapping the validation component
+
+Form fields project `lg-validation` into a dedicated slot between the label and hint and the field itself. Angular content projection only matches the projected element itself, so if you wrap `lg-validation` in your own component, the field cannot recognise it and the wrapper falls back into the label. Add the `lgValidationWrapper` attribute to your wrapper so that it is projected into the validation slot.
+
+```js
+import { LgValidationWrapperDirective } from '@legal-and-general/canopy';
+```
+
+If your wrapper projects `lg-validation` through with `ng-content`, the field finds the inner `lg-validation` and links it to the input automatically:
+
+```html
+<lg-input-field>
+  Username
+  <app-my-error lgValidationWrapper>
+    <lg-validation>Enter a username</lg-validation>
+  </app-my-error>
+  <input lgInput formControlName="username" />
+</lg-input-field>
+```
+
+If your wrapper renders `lg-validation` inside its own template, the field cannot reach it. In that case the field describes the input using the wrapper's own ID, which the directive generates for you. Use a static `id` or bind `lgValidationWrapperId` when you need a predictable value, for example to anchor an error summary link:
+
+```html
+<lg-input-field>
+  Username
+  <app-my-error
+    lgValidationWrapper
+    [lgValidationWrapperId]="'username-error'"
+    [message]="errorMessage"
+  />
+  <input lgInput formControlName="username" />
+</lg-input-field>
+```
+
+Import `LgValidationWrapperDirective` in the component that uses the
+`lgValidationWrapper` attribute. The directive supplies the wrapper ID used by the
+fallback when the wrapper renders `lg-validation` in its own template.
+
+For a wrapper that only projects `lg-validation` with `ng-content`, you can use
+`ngProjectAs="lg-validation"` instead. The field can still find the inner
+`lg-validation` and use its ID for `aria-describedby`:
+
+```html
+<app-my-error ngProjectAs="lg-validation">
+  <lg-validation>Enter a username</lg-validation>
+</app-my-error>
+```
+
 ## Dos and don’ts
+
 **Do**
 
-  - **Do** be specific and actionable – explain exactly what is wrong and how to fix it (e.g., "Enter a date in the format DD/MM/YYYY").
+- **Do** be specific and actionable – explain exactly what is wrong and how to fix it (e.g., "Enter a date in the format DD/MM/YYYY").
 
-  - **Do** use plain English – maintain a helpful, professional tone and avoid technical jargon or error codes.
+- **Do** use plain English – maintain a helpful, professional tone and avoid technical jargon or error codes.
 
-  - **Do** keep the submit button enabled – allow users to click submit so they can receive feedback on what needs fixing.
+- **Do** keep the submit button enabled – allow users to click submit so they can receive feedback on what needs fixing.
 
-  - **Do** use anchor links in summaries – for long forms, provide links in the error summary that jump the user directly to the erroneous field.
+- **Do** use anchor links in summaries – for long forms, provide links in the error summary that jump the user directly to the erroneous field.
 
-  - **Do** ensure visual clarity – always use the error icon alongside red text to support users with colour vision deficiencies.
+- **Do** ensure visual clarity – always use the error icon alongside red text to support users with colour vision deficiencies.
 
 **Don’t**
 
-  - **Don’t** blame the user – avoid accusatory language like "You entered the wrong date."
+- **Don’t** blame the user – avoid accusatory language like "You entered the wrong date."
 
-  - **Don’t** validate on focus – do not show an error message before a user has had a chance to enter any information.
+- **Don’t** validate on focus – do not show an error message before a user has had a chance to enter any information.
 
-  - **Don’t** rely on colour alone – never use colour as the only indicator of an error state.
+- **Don’t** rely on colour alone – never use colour as the only indicator of an error state.
 
-  - **Don’t** hide the solution – don't just say "Invalid input"; always provide the requirement or an example of the correct format.
+- **Don’t** hide the solution – don't just say "Invalid input"; always provide the requirement or an example of the correct format.
 
 ## Developer reference
- 
+
 **LgValidationComponent inputs**
 
-| Name       | Description                                                        | Type      | Default | Required |
-|------------|----------------------------------------------------------------------|-----------|---------|----------|
-| `status`  | The status of the validation: `generic`, `info`, `warning`, `error`, `success` | `string`  | `error` | No       |
-| `showIcon` | Whether the icon should display | `boolean` | `true` | No |
+| Name       | Description                                                                    | Type      | Default | Required |
+| ---------- | ------------------------------------------------------------------------------ | --------- | ------- | -------- |
+| `status`   | The status of the validation: `generic`, `info`, `warning`, `error`, `success` | `string`  | `error` | No       |
+| `showIcon` | Whether the icon should display                                                | `boolean` | `true`  | No       |
+
+**LgValidationWrapperDirective inputs**
+
+| Name                    | Description                                                                                        | Type     | Default                          | Required |
+| ----------------------- | -------------------------------------------------------------------------------------------------- | -------- | -------------------------------- | -------- |
+| `lgValidationWrapperId` | Dynamic ID used to describe the field when the wrapper renders `lg-validation` in its own template | `string` | `lg-validation-wrapper-<unique>` | No       |
 
 ## Accessibility – other considerations
 
@@ -153,18 +201,16 @@ Style error messages in red and use a warning icon to provide a <a href="https:/
 
 ## References
 
-   - **GOV.UK Design System** – <a href="https://design-system.service.gov.uk/components/error-message/" target="_blank">Error message guidance</a> and <a href="https://design-system.service.gov.uk/components/error-summary/" target="_blank">Error summary pattern</a>.
+- **GOV.UK Design System** – <a href="https://design-system.service.gov.uk/components/error-message/" target="_blank">Error message guidance</a> and <a href="https://design-system.service.gov.uk/components/error-summary/" target="_blank">Error summary pattern</a>.
 
-   - **Nielsen Norman Group (NN/g)** – <a href="https://www.nngroup.com/articles/slips/" target="_blank">Preventing User Errors: Avoid Unnecessary Constraints</a> and <a href="https://www.nngroup.com/articles/web-form-design/" target="_blank">Form Design Best Practices</a>.
+- **Nielsen Norman Group (NN/g)** – <a href="https://www.nngroup.com/articles/slips/" target="_blank">Preventing User Errors: Avoid Unnecessary Constraints</a> and <a href="https://www.nngroup.com/articles/web-form-design/" target="_blank">Form Design Best Practices</a>.
 
-   - **Adam Silver** – <a href="https://formdesignpatterns.com/" target="_blank">Form Design Patterns</a>.
+- **Adam Silver** – <a href="https://formdesignpatterns.com/" target="_blank">Form Design Patterns</a>.
 
-   - **W3C WAI** –  <a href="https://www.w3.org/WAI/tutorials/forms/" target="_blank">Forms Concepts</a> and WCAG 3.3.1:  <a href="https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html" target="_blank">Error Identification</a>.
+- **W3C WAI** – <a href="https://www.w3.org/WAI/tutorials/forms/" target="_blank">Forms Concepts</a> and WCAG 3.3.1: <a href="https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html" target="_blank">Error Identification</a>.
 
-   - **Inclusive Design Principles** – <a href="https://vispero.com/resources/inclusive-design-principle-provide-a-comparable-experience/" target="_blank">Provide a comparable experience</a> (for colour-blind users).
+- **Inclusive Design Principles** – <a href="https://vispero.com/resources/inclusive-design-principle-provide-a-comparable-experience/" target="_blank">Provide a comparable experience</a> (for colour-blind users).
 
-***
+---
 
-<Markdown>
-  {Feedback}
-</Markdown>
+<Markdown>{Feedback}</Markdown>

--- a/projects/canopy/src/lib/forms/validation/docs/validation.stories.ts
+++ b/projects/canopy/src/lib/forms/validation/docs/validation.stories.ts
@@ -2,6 +2,8 @@ import { Meta, moduleMetadata } from '@storybook/angular';
 import { Component, Input } from '@angular/core';
 
 import { LgValidationComponent } from '../validation.component';
+import { LgValidationWrapperDirective } from '../validation-wrapper.directive';
+import { LgInputDirective, LgInputFieldComponent } from '../../input';
 
 const statusTypes = [ 'generic', 'info', 'success', 'warning', 'error' ];
 
@@ -26,13 +28,42 @@ class LgValidationExampleComponent {
   @Input() showIcon: boolean;
 }
 
+const wrapperTemplate = `
+<lg-input-field>
+  Username
+  <lg-my-error lgValidationWrapper>
+    <lg-validation>Enter a username</lg-validation>
+  </lg-my-error>
+  <input lgInput />
+</lg-input-field>
+`;
+
+@Component({
+  selector: 'lg-my-error',
+  template: '<ng-content />',
+})
+class MyErrorComponent {}
+
+@Component({
+  selector: 'lg-validation-wrapper-example',
+  template: wrapperTemplate,
+  imports: [
+    LgInputFieldComponent,
+    LgInputDirective,
+    LgValidationComponent,
+    LgValidationWrapperDirective,
+    MyErrorComponent,
+  ],
+})
+class LgValidationWrapperExampleComponent {}
+
 export default {
   title: 'Components/Forms/Form validation/Examples',
   tags: [ 'updated' ],
   component: LgValidationComponent,
   decorators: [
     moduleMetadata({
-      imports: [ LgValidationExampleComponent ],
+      imports: [ LgValidationExampleComponent, LgValidationWrapperExampleComponent ],
     }),
   ],
   argTypes: {
@@ -109,6 +140,23 @@ export const Validation = {
     docs: {
       source: {
         code: template,
+      },
+    },
+  },
+};
+
+export const ValidationWrapper = {
+  name: 'Validation wrapper',
+  render: () => ({
+    template: '<lg-validation-wrapper-example />',
+  }),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: wrapperTemplate,
       },
     },
   },

--- a/projects/canopy/src/lib/forms/validation/index.ts
+++ b/projects/canopy/src/lib/forms/validation/index.ts
@@ -1,2 +1,3 @@
 export * from './validation.component';
+export * from './validation-wrapper.directive';
 export * from './error-state-matcher';

--- a/projects/canopy/src/lib/forms/validation/validation-wrapper.directive.spec.ts
+++ b/projects/canopy/src/lib/forms/validation/validation-wrapper.directive.spec.ts
@@ -1,0 +1,395 @@
+import { Component, DebugElement, inject, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  FormGroupDirective,
+  FormsModule,
+  ReactiveFormsModule,
+  UntypedFormBuilder,
+  UntypedFormGroup,
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { MockComponents } from 'ng-mocks';
+
+import { LgIconComponent } from '../../icon';
+import { LgCheckboxGroupComponent } from '../checkbox-group';
+import { LgDateFieldComponent } from '../date';
+import { LgInputDirective, LgInputFieldComponent } from '../input';
+import { LgRadioButtonComponent, LgRadioGroupComponent } from '../radio';
+import { LgSelectDirective, LgSelectFieldComponent } from '../select';
+import { LgToggleComponent } from '../toggle';
+
+import { LgValidationComponent } from './validation.component';
+import { LgValidationWrapperDirective } from './validation-wrapper.directive';
+
+const validationId = 'test-validation-id';
+const wrapperId = 'test-wrapper-id';
+
+function isInsideLabelOrLegend(element: HTMLElement): boolean {
+  return Boolean(element.closest('label, legend'));
+}
+
+describe('LgValidationWrapperDirective', () => {
+  @Component({
+    template: '<div lgValidationWrapper></div>',
+    imports: [ LgValidationWrapperDirective ],
+  })
+  class DefaultIdHostComponent {}
+
+  @Component({
+    template: '<div lgValidationWrapper id="static-wrapper-id"></div>',
+    imports: [ LgValidationWrapperDirective ],
+  })
+  class StaticIdHostComponent {}
+
+  @Component({
+    template: '<div lgValidationWrapper [lgValidationWrapperId]="wrapperId"></div>',
+    imports: [ LgValidationWrapperDirective ],
+  })
+  class DynamicIdHostComponent {
+    wrapperId = 'dynamic-wrapper-id';
+  }
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        DefaultIdHostComponent,
+        StaticIdHostComponent,
+        DynamicIdHostComponent,
+        LgValidationWrapperDirective,
+      ],
+    }).compileComponents();
+  }));
+
+  it('generates a unique id when no id is provided', () => {
+    const fixture = TestBed.createComponent(DefaultIdHostComponent);
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('div').id).toMatch(
+      /^lg-validation-wrapper-[a-z0-9]{7}$/,
+    );
+  });
+
+  it('uses a static host id', () => {
+    const fixture = TestBed.createComponent(StaticIdHostComponent);
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('div').id).toBe('static-wrapper-id');
+  });
+
+  it('uses lgValidationWrapperId for a dynamic id', () => {
+    const fixture = TestBed.createComponent(DynamicIdHostComponent);
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('div').id).toBe('dynamic-wrapper-id');
+  });
+});
+
+describe('validation wrapper projection', () => {
+  describe('lg-input-field', () => {
+    @Component({
+      template: `
+        <lg-input-field>
+          Label
+          <div lgValidationWrapper id="${wrapperId}">
+            <lg-validation id="${validationId}">Error</lg-validation>
+          </div>
+          <input lgInput />
+        </lg-input-field>
+      `,
+      imports: [
+        LgInputFieldComponent,
+        LgInputDirective,
+        LgValidationComponent,
+        LgValidationWrapperDirective,
+      ],
+    })
+    class TransparentHostComponent {}
+
+    @Component({
+      template: `
+        <lg-input-field>
+          Label
+          <div lgValidationWrapper id="${wrapperId}"></div>
+          <input lgInput />
+        </lg-input-field>
+      `,
+      imports: [ LgInputFieldComponent, LgInputDirective, LgValidationWrapperDirective ],
+    })
+    class OpaqueHostComponent {}
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          TransparentHostComponent,
+          OpaqueHostComponent,
+          FormsModule,
+          ReactiveFormsModule,
+          MockComponents(LgIconComponent),
+        ],
+      }).compileComponents();
+    }));
+
+    it('projects a wrapper with validation outside the label and uses the validation id', () => {
+      const fixture = TestBed.createComponent(TransparentHostComponent);
+
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(
+        fixture.nativeElement.querySelector('input').getAttribute('aria-describedby'),
+      ).toBe(validationId);
+    });
+
+    it('projects an empty wrapper outside the label and falls back to the wrapper id', () => {
+      const fixture = TestBed.createComponent(OpaqueHostComponent);
+
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(
+        fixture.nativeElement.querySelector('input').getAttribute('aria-describedby'),
+      ).toBe(wrapperId);
+    });
+  });
+
+  describe('lg-select-field', () => {
+    @Component({
+      template: `
+        <lg-select-field>
+          Label
+          <div lgValidationWrapper id="${wrapperId}"></div>
+          <select lgSelect>
+            <option value="1">One</option>
+          </select>
+        </lg-select-field>
+      `,
+      imports: [ LgSelectFieldComponent, LgSelectDirective, LgValidationWrapperDirective ],
+    })
+    class HostComponent {}
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          HostComponent,
+          FormsModule,
+          ReactiveFormsModule,
+          MockComponents(LgIconComponent),
+        ],
+      }).compileComponents();
+    }));
+
+    it('projects the wrapper outside the label and describes the select', () => {
+      const fixture = TestBed.createComponent(HostComponent);
+
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(
+        fixture.nativeElement.querySelector('select').getAttribute('aria-describedby'),
+      ).toBe(wrapperId);
+    });
+  });
+
+  describe('lg-radio-group', () => {
+    @Component({
+      template: `
+        <lg-radio-group>
+          Label
+          <div lgValidationWrapper id="${wrapperId}"></div>
+          <lg-radio-button value="1">One</lg-radio-button>
+        </lg-radio-group>
+      `,
+      imports: [
+        LgRadioGroupComponent,
+        LgRadioButtonComponent,
+        LgValidationWrapperDirective,
+      ],
+    })
+    class HostComponent {}
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          HostComponent,
+          FormsModule,
+          ReactiveFormsModule,
+          MockComponents(LgIconComponent),
+        ],
+      }).compileComponents();
+    }));
+
+    it('projects the wrapper outside the legend and describes the fieldset', () => {
+      const fixture = TestBed.createComponent(HostComponent);
+
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(
+        fixture.nativeElement.querySelector('fieldset').getAttribute('aria-describedby'),
+      ).toBe(wrapperId);
+    });
+  });
+
+  describe('lg-checkbox-group', () => {
+    @Component({
+      template: `
+        <lg-checkbox-group>
+          Label
+          <div lgValidationWrapper id="${wrapperId}"></div>
+          <lg-checkbox value="1">One</lg-checkbox>
+        </lg-checkbox-group>
+      `,
+      imports: [
+        LgCheckboxGroupComponent,
+        LgToggleComponent,
+        LgValidationWrapperDirective,
+      ],
+    })
+    class HostComponent {}
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          HostComponent,
+          FormsModule,
+          ReactiveFormsModule,
+          MockComponents(LgIconComponent),
+        ],
+      }).compileComponents();
+    }));
+
+    it('projects the wrapper outside the legend and describes the fieldset', () => {
+      const fixture = TestBed.createComponent(HostComponent);
+
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(
+        fixture.nativeElement.querySelector('fieldset').getAttribute('aria-describedby'),
+      ).toBe(wrapperId);
+    });
+  });
+
+  describe('lg-toggle', () => {
+    @Component({
+      template: `
+        <lg-toggle>
+          Label
+          <div lgValidationWrapper id="${wrapperId}"></div>
+        </lg-toggle>
+      `,
+      imports: [ LgToggleComponent, LgValidationWrapperDirective ],
+    })
+    class HostComponent {}
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          HostComponent,
+          FormsModule,
+          ReactiveFormsModule,
+          MockComponents(LgIconComponent),
+        ],
+      }).compileComponents();
+    }));
+
+    it('projects the wrapper outside the label and describes the checkbox', () => {
+      const fixture = TestBed.createComponent(HostComponent);
+
+      fixture.detectChanges();
+
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(
+        fixture.nativeElement.querySelector('input').getAttribute('aria-describedby'),
+      ).toBe(wrapperId);
+    });
+  });
+
+  describe('lg-date-field', () => {
+    @Component({
+      template: `
+        <form [formGroup]="form" #testForm="ngForm">
+          <lg-date-field formControlName="dateOfBirth">
+            Date of birth
+            <div lgValidationWrapper id="${wrapperId}"></div>
+          </lg-date-field>
+        </form>
+      `,
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        LgDateFieldComponent,
+        LgValidationWrapperDirective,
+      ],
+    })
+    class HostComponent {
+      private fb = inject(UntypedFormBuilder);
+      form: UntypedFormGroup = this.fb.group({ dateOfBirth: [ '' ] });
+
+      @ViewChild('testForm') testFormDirective: FormGroupDirective;
+    }
+
+    let fixture: ComponentFixture<HostComponent>;
+    let fieldset: DebugElement;
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          HostComponent,
+          FormsModule,
+          ReactiveFormsModule,
+          MockComponents(LgIconComponent),
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(HostComponent);
+      fixture.detectChanges();
+      fieldset = fixture.debugElement.query(By.css('fieldset'));
+    }));
+
+    it('projects the wrapper outside the legend and describes the fieldset', () => {
+      const wrapper: HTMLElement = fixture.nativeElement.querySelector(
+        '[lgValidationWrapper]',
+      );
+
+      expect(isInsideLabelOrLegend(wrapper)).toBe(false);
+
+      expect(fieldset.nativeElement.getAttribute('aria-describedby')).toContain(
+        wrapperId,
+      );
+    });
+  });
+});

--- a/projects/canopy/src/lib/forms/validation/validation-wrapper.directive.ts
+++ b/projects/canopy/src/lib/forms/validation/validation-wrapper.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, HostAttributeToken, HostBinding, inject, Input } from '@angular/core';
+
+import { randomUniqueId } from '../../utils';
+
+/**
+ * Marks a custom component as a validation wrapper so a form field projects it into the
+ * validation slot and can describe its control with the wrapper's id.
+ */
+@Directive({
+  selector: '[lgValidationWrapper]',
+  standalone: true,
+})
+export class LgValidationWrapperDirective {
+  private readonly staticId = inject(new HostAttributeToken('id'), { optional: true });
+
+  @HostBinding('id')
+  id = this.staticId || `lg-validation-wrapper-${randomUniqueId()}`;
+
+  @Input()
+  set lgValidationWrapperId(id: string | null | undefined) {
+    if (id) {
+      this.id = id;
+    }
+  }
+}

--- a/skills/best-practice/forms-validation/SKILL.md
+++ b/skills/best-practice/forms-validation/SKILL.md
@@ -8,7 +8,9 @@ metadata:
 
 # Canopy Form Validation — Best Practices
 
-This skill provides usage guidance for form validation with `LgValidationComponent` and `LgErrorStateMatcher` from `@legal-and-general/canopy`.
+This skill provides usage guidance for form validation with `LgValidationComponent`,
+`LgValidationWrapperDirective`, and `LgErrorStateMatcher` from
+`@legal-and-general/canopy`.
 
 Apply this skill whenever you display inline form errors in a Canopy form.
 
@@ -19,6 +21,7 @@ Apply this skill whenever you display inline form errors in a Canopy form.
 ```ts
 import {
   LgValidationComponent,
+  LgValidationWrapperDirective,
   LgErrorStateMatcher,
 } from '@legal-and-general/canopy';
 ```
@@ -53,12 +56,12 @@ Always add `#userForm="ngForm"` to the `<form>` element and ensure the submit bu
 ```html
 <form [formGroup]="form" (ngSubmit)="onSubmit(form)" #userForm="ngForm">
   <lg-input-field>
-    Username
-    @if (isControlInvalid(form.get('username'), userForm) && form.get('username').hasError('required')) {
-      <lg-validation>Username is required</lg-validation>
-    }
-    @if (isControlInvalid(form.get('username'), userForm) && form.get('username').hasError('minlength')) {
-      <lg-validation>Username must be at least 4 characters</lg-validation>
+    Username @if (isControlInvalid(form.get('username'), userForm) &&
+    form.get('username').hasError('required')) {
+    <lg-validation>Username is required</lg-validation>
+    } @if (isControlInvalid(form.get('username'), userForm) &&
+    form.get('username').hasError('minlength')) {
+    <lg-validation>Username must be at least 4 characters</lg-validation>
     }
     <input lgInput formControlName="username" />
   </lg-input-field>
@@ -68,12 +71,70 @@ Always add `#userForm="ngForm"` to the `<form>` element and ensure the submit bu
 
 ---
 
+## Wrapped Validation
+
+Form fields project `<lg-validation>` between the label and hint and the field. When a
+custom component wraps validation, add `lgValidationWrapper` to that component so the
+form field projects it into the validation slot and connects the field with
+`aria-describedby`.
+
+When the custom component projects `<lg-validation>` through `<ng-content>`, Canopy
+finds the inner validation element and uses its ID automatically:
+
+```html
+<lg-input-field>
+  Username
+  <app-error-message lgValidationWrapper>
+    <lg-validation>Enter a username</lg-validation>
+  </app-error-message>
+  <input lgInput formControlName="username" />
+</lg-input-field>
+```
+
+When the custom component renders `<lg-validation>` in its own template, Canopy cannot
+reach the inner element. It describes the field with the wrapper ID instead. Use a static
+`id` or bind `lgValidationWrapperId` when an error summary needs a stable anchor target:
+
+```html
+<lg-input-field>
+  Username
+  <app-error-message
+    lgValidationWrapper
+    [lgValidationWrapperId]="'username-error'"
+    [message]="errorMessage"
+  />
+  <input lgInput formControlName="username" />
+</lg-input-field>
+```
+
+### Do
+
+1. **Do** import `LgValidationWrapperDirective` in every standalone component that uses
+   `lgValidationWrapper`; it supplies the wrapper ID for component-rendered validation.
+2. **Do** assign a static `id` or bind `lgValidationWrapperId` when an error summary links
+   to a message rendered by the wrapper.
+
+### Don't
+
+1. **Don't** bind `[id]` on a component that also has an `id` input. Use
+   `[lgValidationWrapperId]` to avoid an input-name collision.
+
+---
+
 ## LgValidationComponent Inputs
 
-| Input | Type | Default | Description |
-|-------|------|---------|-------------|
-| `status` | `'generic' \| 'info' \| 'warning' \| 'error' \| 'success'` | `'error'` | Visual and semantic status. |
-| `showIcon` | `boolean` | `true` | Whether to show the status icon. |
+| Input      | Type                                                       | Default   | Description                      |
+| ---------- | ---------------------------------------------------------- | --------- | -------------------------------- |
+| `status`   | `'generic' \| 'info' \| 'warning' \| 'error' \| 'success'` | `'error'` | Visual and semantic status.      |
+| `showIcon` | `boolean`                                                  | `true`    | Whether to show the status icon. |
+
+---
+
+## LgValidationWrapperDirective Inputs
+
+| Input                   | Type     | Default                          | Description                                                                                    |
+| ----------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `lgValidationWrapperId` | `string` | `lg-validation-wrapper-<unique>` | Dynamic ID used to describe the field when the wrapper renders validation in its own template. |
 
 ---
 


### PR DESCRIPTION
# Description

When `lg-validation` is wrapped inside a custom component, the input field component no longer recognises it as a validation component. As a result, the validation content is projected into the wrong location instead of the dedicated validation area.

### Fix

- Support a marker attribute on wrapper components so they can be recognised as validation wrappers.
- Update the projection logic to handle wrapped `lg-validation` components correctly.
- Update documentation to explain how wrapper components should pass the validation ID through to the underlying input.

# Checklist:

- [x] The commit messages follow the [convention for this project](./blob/master/docs/CONTRIBUTING.md#conventional-commits)
- [x] I have provided an adequate amount of test coverage
- [ ] I have added the functionality to the [test app](./blob/master/docs/CONTRIBUTING.md#build-test-application)
- [x] I have provided a story in storybook to document the changes
- [x] I have added the documentation
- [ ] I have added any new public feature modules to public-api.ts
